### PR TITLE
Fix mutation access control

### DIFF
--- a/README.md
+++ b/README.md
@@ -761,7 +761,7 @@ Expression | Description | Scope
 **request** | Refers to the current request. | Request
 **token** | Refers to the token which is currently in the security token storage. | Token 
 **user** | Refers to the user which is currently in the security token storage. | Valid Token
-**object** | Refers to the value of the field for which access is being requested. For array `object` will be each item of the array. For Relay connection `object` will be the node of each connection edges. | only available for `config.fields.*.access`
+**object** | Refers to the value of the field for which access is being requested. For array `object` will be each item of the array. For Relay connection `object` will be the node of each connection edges. | only available for `config.fields.*.access` with query operation type.
 **value** | Resolver value | only available in resolve context 
 **args** | Resolver args array | only available in resolve context 
 **info** | Resolver GraphQL\Type\Definition\ResolveInfo Object | only available in resolve context

--- a/Resolver/Config/AbstractConfigSolution.php
+++ b/Resolver/Config/AbstractConfigSolution.php
@@ -108,11 +108,16 @@ abstract class AbstractConfigSolution implements ConfigSolutionInterface
 
     protected function solveUsingExpressionLanguageIfNeeded($expression, array $values = [])
     {
-        if (is_string($expression) &&  0 === strpos($expression, '@=')) {
+        if ($this->isExpression($expression)) {
             return $this->expressionLanguage->evaluate(substr($expression, 2), $values);
         }
 
         return $expression;
+    }
+
+    protected function isExpression($expression)
+    {
+        return is_string($expression) &&  0 === strpos($expression, '@=');
     }
 
     protected function solveResolveCallbackArgs()


### PR DESCRIPTION
Resolver result is retrieve only if access return true for mutation operation type. This mean that `object` expression language can't no more be use on access field for mutation operation.