### PR TITLE
Fixed base64_decode for php 7.1

### DIFF
--- a/Relay/Node/GlobalId.php
+++ b/Relay/Node/GlobalId.php
@@ -22,7 +22,7 @@ class GlobalId
 
     public static function fromGlobalId($globalId)
     {
-        $unBasedGlobalId = base64_decode($globalId, true);
+        $unBasedGlobalId = base64_decode($globalId, false);
 
         $decodeGlobalId = [
             'type' => null,


### PR DESCRIPTION
While running the tests in PHP 7.1 I found this issue:

```
PHP 7.1.0RC1 (cli) (built: Sep  1 2016 13:52:06) ( NTS )
Copyright (c) 1997-2016 The PHP Group
Zend Engine v3.1.0-dev, Copyright (c) 1998-2016 Zend Technologies
    with Xdebug v2.5.0-dev, Copyright (c) 2002-2016, by Derick Rethans

PHPUnit 5.5.4 by Sebastian Bergmann and contributors.

...............................................................  63 / 154 ( 40%)
.............................................F................. 126 / 154 ( 81%)
............................                                    154 / 154 (100%)

Time: 2.4 seconds, Memory: 30.00MB

There was 1 failure:

1) Overblog\GraphQLBundle\Tests\Relay\Node\GlobalIdTest::testFromGlobalIdWithTypeEmpty
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
     'type' => null
-    'id' => 15
+    'id' => null
 )

/home/renatomefi/Workspace/php/GraphQLBundle/Tests/Relay/Node/GlobalIdTest.php:57

FAILURES!
Tests: 154, Assertions: 209, Failures: 1.
```

This is due to this code:
```
$unBasedGlobalId = base64_decode($globalId, true);
```

The problem is:
Since the separator `const SEPARATOR = ':'` is `:` its not in the base64 alphabet, which in you can check here: http://www.faqs.org/rfcs/rfc2045.html Section 6.8 Table 1
Which means you can't use strict base64_decode.

Since the code change is small I took sometime to explain the reason! :)

I hope you can accept it, thanks!

