### PR TITLE
Enable multiple schema

### DIFF
--- a/Controller/GraphController.php
+++ b/Controller/GraphController.php
@@ -17,40 +17,44 @@ use Symfony\Component\HttpFoundation\Request;
 
 class GraphController extends Controller
 {
-    public function endpointAction(Request $request)
+    public function endpointAction(Request $request, $schemaName = null)
     {
-        $payload = $this->processNormalQuery($request);
+        $payload = $this->processNormalQuery($request, $schemaName);
 
         return new JsonResponse($payload, 200);
     }
 
-    public function batchEndpointAction(Request $request)
+    public function batchEndpointAction(Request $request, $schemaName = null)
     {
-        $payloads = $this->processBatchQuery($request);
+        $payloads = $this->processBatchQuery($request, $schemaName);
 
         return new JsonResponse($payloads, 200);
     }
 
-    private function processBatchQuery(Request $request)
+    private function processBatchQuery(Request $request, $schemaName = null)
     {
         $queries = $this->get('overblog_graphql.request_batch_parser')->parse($request);
         $payloads = [];
 
         foreach ($queries as $query) {
-            $payloadResult = $this->get('overblog_graphql.request_executor')->execute([
-                'query' => $query['query'],
-                'variables' => $query['variables'],
-            ]);
+            $payloadResult = $this->get('overblog_graphql.request_executor')->execute(
+                [
+                    'query' => $query['query'],
+                    'variables' => $query['variables'],
+                ],
+                [],
+                $schemaName
+            );
             $payloads[] = ['id' => $query['id'], 'payload' => $payloadResult->toArray()];
         }
 
         return $payloads;
     }
 
-    private function processNormalQuery(Request $request)
+    private function processNormalQuery(Request $request, $schemaName = null)
     {
         $params = $this->get('overblog_graphql.request_parser')->parse($request);
-        $data = $this->get('overblog_graphql.request_executor')->execute($params)->toArray();
+        $data = $this->get('overblog_graphql.request_executor')->execute($params, [], $schemaName)->toArray();
 
         return $data;
     }

--- a/Controller/GraphiQLController.php
+++ b/Controller/GraphiQLController.php
@@ -15,12 +15,18 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
 class GraphiQLController extends Controller
 {
-    public function indexAction()
+    public function indexAction($schemaName = null)
     {
+        if (null === $schemaName) {
+            $endpoint = $this->generateUrl('overblog_graphql_endpoint');
+        } else {
+            $endpoint = $this->generateUrl('overblog_graphql_multiple_endpoint', ['schemaName' => $schemaName]);
+        }
+
         return $this->render(
             $this->getParameter('overblog_graphql.graphiql_template'),
             [
-                'endpoint' => $this->generateUrl('overblog_graphql_endpoint'),
+                'endpoint' => $endpoint,
                 'versions' => [
                     'graphiql' => $this->getParameter('overblog_graphql.versions.graphiql'),
                     'react' => $this->getParameter('overblog_graphql.versions.react'),

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -46,11 +46,26 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('internal_error_message')->defaultNull()->end()
                         ->booleanNode('config_validation')->defaultValue($this->debug)->end()
                         ->arrayNode('schema')
-                            ->addDefaultsIfNotSet()
-                            ->children()
-                                ->scalarNode('query')->defaultNull()->end()
-                                ->scalarNode('mutation')->defaultNull()->end()
-                                ->scalarNode('subscription')->defaultNull()->end()
+                            ->beforeNormalization()
+                                ->ifTrue(function ($v) {
+                                    $needNormalization = isset($v['query']) && is_string($v['query']) ||
+                                        isset($v['mutation']) && is_string($v['mutation']) ||
+                                        isset($v['subscription']) && is_string($v['subscription']);
+
+                                    return $needNormalization;
+                                })
+                                ->then(function ($v) {
+                                    return ['default' => $v];
+                                })
+                            ->end()
+                            ->useAttributeAsKey('name')
+                            ->prototype('array')
+                                ->addDefaultsIfNotSet()
+                                ->children()
+                                    ->scalarNode('query')->defaultNull()->end()
+                                    ->scalarNode('mutation')->defaultNull()->end()
+                                    ->scalarNode('subscription')->defaultNull()->end()
+                                ->end()
                             ->end()
                         ->end()
                         ->arrayNode('mappings')
@@ -142,8 +157,8 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('versions')
                     ->addDefaultsIfNotSet()
                     ->children()
-                        ->scalarNode('graphiql')->defaultValue('0.7.1')->end()
-                        ->scalarNode('react')->defaultValue('15.0.2')->end()
+                        ->scalarNode('graphiql')->defaultValue('0.7.8')->end()
+                        ->scalarNode('react')->defaultValue('15.3.2')->end()
                     ->end()
                 ->end()
             ->end();

--- a/README.md
+++ b/README.md
@@ -903,6 +903,38 @@ Batching
 Batching can help decrease io between server and client.
 The default route of batching is `/batch`.
 
+Multiple schema endpoint
+------------------------
+
+```yaml
+#app/config/config.yml
+
+overblog_graphql:
+    definitions:
+        schema:
+            foo:
+                query: fooQuery
+            bar:
+                query: barQuery
+                mutation: barMutation
+```
+
+**foo** schema endpoint can be access:
+
+type | Path
+-----| -----
+simple request | `/graphql/foo`
+batch request | `/graphql/foo/batch`
+graphiQL | `/graphiql/foo`
+
+**bar** schema endpoint can be access:
+
+type | Path
+-----| -----
+simple request | `/graphql/bar`
+batch request | `/graphql/bar/batch`
+graphiQL | `/graphiql/bar`
+
 Contribute
 ----------
 

--- a/Resources/config/routing/graphiql.yml
+++ b/Resources/config/routing/graphiql.yml
@@ -2,3 +2,8 @@ overblog_graphql_graphiql:
     path: /graphiql
     defaults:
         _controller: OverblogGraphQLBundle:GraphiQL:index
+
+overblog_graphql_graphiql_multiple:
+    path: /graphiql/{schemaName}
+    defaults:
+        _controller: OverblogGraphQLBundle:GraphiQL:index

--- a/Resources/config/routing/graphql.yml
+++ b/Resources/config/routing/graphql.yml
@@ -9,3 +9,15 @@ overblog_graphql_batch_endpoint:
     defaults:
         _controller: OverblogGraphQLBundle:Graph:batchEndpoint
         _format: "json"
+
+overblog_graphql_multiple_endpoint:
+    path: /graphql/{schemaName}
+    defaults:
+        _controller: OverblogGraphQLBundle:Graph:endpoint
+        _format: "json"
+
+overblog_graphql_batch_multiple_endpoint:
+    path: /graphql/{schemaName}/batch
+    defaults:
+        _controller: OverblogGraphQLBundle:Graph:batchEndpoint
+        _format: "json"

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -14,7 +14,6 @@ services:
     overblog_graphql.request_executor:
         class: Overblog\GraphQLBundle\Request\Executor
         arguments:
-            - "@overblog_graphql.schema"
             - "@event_dispatcher"
             - "%kernel.debug%"
             - "@overblog_graphql.error_handler"
@@ -27,15 +26,6 @@ services:
 
     overblog_graphql.request_batch_parser:
         class: Overblog\GraphQLBundle\Request\BatchParser
-
-    overblog_graphql.schema:
-        class: GraphQL\Schema
-        public: false
-        factory: ["@overblog_graphql.schema_builder", create]
-        arguments:
-            - ~
-            - ~
-            - ~
 
     overblog_graphql.schema_builder:
         class: Overblog\GraphQLBundle\Definition\Builder\SchemaBuilder

--- a/Tests/Functional/Controller/GraphiQLControllerTest.php
+++ b/Tests/Functional/Controller/GraphiQLControllerTest.php
@@ -15,11 +15,22 @@ use Overblog\GraphQLBundle\Tests\Functional\TestCase;
 
 class GraphiQLControllerTest extends TestCase
 {
-    public function testIndexAction()
+    /**
+     * @dataProvider graphiQLUriProvider
+     */
+    public function testIndexAction($uri)
     {
         $client = static::createClient();
 
-        $client->request('GET', '/graphiql');
+        $client->request('GET', $uri);
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
+    }
+
+    public function graphiQLUriProvider()
+    {
+        return [
+            ['/graphiql'],
+            ['/graphiql/default']
+        ];
     }
 }

--- a/Tests/Request/ExecutorTest.php
+++ b/Tests/Request/ExecutorTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the OverblogGraphQLBundle package.
+ *
+ * (c) Overblog <http://github.com/overblog/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Overblog\GraphQLBundle\Tests\Resolver;
+
+use Overblog\GraphQLBundle\Request\Executor;
+
+class ExecutorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage At least one schema should be declare.
+     */
+    public function testGetSchemaNoSchemaFound()
+    {
+        (new Executor())->getSchema('default');
+    }
+}


### PR DESCRIPTION
Multiple schema endpoint
----------------------------------

```yaml
#app/config/config.yml

overblog_graphql:
    definitions:
        schema:
            foo:
                query: fooQuery
            bar:
                query: barQuery
                mutation: barMutation
```

**foo** schema endpoint can be access:

type | Path
-----| -----
simple request | `/graphql/foo`
batch request | `/graphql/foo/batch`
graphiQL | `/graphiql/foo`

**bar** schema endpoint can be access:

type | Path
-----| -----
simple request | `/graphql/bar`
batch request | `/graphql/bar/batch`
graphiQL | `/graphiql/bar`
