### PR TITLE
fix(README): StarWarsData namespace doc was wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ require_once __DIR__ . '/../../../../vendor/webonyx/graphql-php/tests/StarWarsDa
 
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
-use GraphQL\StarWarsData;
+use GraphQL\Tests\StarWarsData;
 
 class CharacterResolver implements ContainerAwareInterface
 {


### PR DESCRIPTION
Fix namespace for StarWarsData in README example