### PR TITLE
Avoid creating services before compiler passes are all done

### DIFF
--- a/DependencyInjection/Compiler/TaggedServiceMappingPass.php
+++ b/DependencyInjection/Compiler/TaggedServiceMappingPass.php
@@ -12,7 +12,6 @@
 namespace Overblog\GraphQLBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 

--- a/DependencyInjection/Compiler/TaggedServiceMappingPass.php
+++ b/DependencyInjection/Compiler/TaggedServiceMappingPass.php
@@ -43,9 +43,9 @@ abstract class TaggedServiceMappingPass implements CompilerPassInterface
         foreach ($mapping as $name => $options) {
             $cleanOptions = $options;
             $solutionID = $options['id'];
-            $solution = $container->get($solutionID);
 
-            if ($solution instanceof ContainerAwareInterface) {
+            $definition = $container->findDefinition($solutionID);
+            if (is_subclass_of($definition->getClass(), 'Symfony\Component\DependencyInjection\ContainerAwareInterface')) {
                 $solutionDefinition = $container->findDefinition($options['id']);
                 $solutionDefinition->addMethodCall('setContainer', [new Reference('service_container')]);
             }

--- a/Tests/DependencyInjection/Compiler/FakeCompilerPass.php
+++ b/Tests/DependencyInjection/Compiler/FakeCompilerPass.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Overblog\GraphQLBundle\Tests\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Class FakeCompilerPass
+ * @package DependencyInjection\Compiler
+ */
+class FakeCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $container
+            ->getDefinition('test_resolver')
+            ->addArgument(new Reference('injected_service'))
+        ;
+    }
+}

--- a/Tests/DependencyInjection/Compiler/FakeInjectedService.php
+++ b/Tests/DependencyInjection/Compiler/FakeInjectedService.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Overblog\GraphQLBundle\Tests\DependencyInjection\Compiler;
+
+/**
+ * Class FakeInjectedService
+ */
+class FakeInjectedService
+{
+    public function doSomething()
+    {
+        return true;
+    }
+}

--- a/Tests/DependencyInjection/Compiler/ResolverTaggedServiceMappingPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ResolverTaggedServiceMappingPassTest.php
@@ -3,12 +3,8 @@
 namespace Overblog\GraphQLBundle\Tests\DependencyInjection\Compiler;
 
 use Overblog\GraphQLBundle\DependencyInjection\Compiler\ResolverTaggedServiceMappingPass;
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
-use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * Class ResolverTaggedServiceMappingPassTest
@@ -34,13 +30,13 @@ class ResolverTaggedServiceMappingPassTest extends \PHPUnit_Framework_TestCase
             "Overblog\\GraphQLBundle\\Resolver\\ResolverResolver"
         );
 
-        $fakeResolver = new Definition('Overblog\GraphQLBundle\Tests\DependencyInjection\Compiler\FakeResolverService');
-        $fakeResolver
+        $testResolver = new Definition('Overblog\GraphQLBundle\Tests\DependencyInjection\Compiler\ResolverTestService');
+        $testResolver
             ->addTag( 'overblog_graphql.resolver', [
-                'alias' => 'fake_resolver', 'method' => 'doSomethingWithContainer'
+                'alias' => 'test_resolver', 'method' => 'doSomethingWithContainer'
             ]);
 
-        $container->setDefinition('fake_resolver', $fakeResolver);
+        $container->setDefinition('test_resolver', $testResolver);
 
         $this->container = $container;
     }
@@ -48,7 +44,6 @@ class ResolverTaggedServiceMappingPassTest extends \PHPUnit_Framework_TestCase
     private function addCompilerPassesAndCompile()
     {
             $this->container->addCompilerPass(new ResolverTaggedServiceMappingPass());
-            // Manipulate container after ResolverTaggedServiceMappingPass
             $this->container->addCompilerPass(new FakeCompilerPass());
             $this->container->compile();
     }
@@ -57,40 +52,6 @@ class ResolverTaggedServiceMappingPassTest extends \PHPUnit_Framework_TestCase
     {
         $this->addCompilerPassesAndCompile();
 
-        $this->assertTrue($this->container->has('fake_resolver'));
-    }
-}
-
-class FakeCompilerPass implements CompilerPassInterface
-{
-    public function process(ContainerBuilder $container)
-    {
-        $container
-            ->getDefinition('fake_resolver')
-            ->addArgument(new Reference('injected_service'))
-        ;
-    }
-}
-
-// Instantiate ContainerAwareInterface to trigger the problem in ResolverTaggedServiceMappingPass
-class FakeResolverService implements ContainerAwareInterface
-{
-    use ContainerAwareTrait;
-
-    public function __construct($service)
-    {
-    }
-
-    public function doSomethingWithContainer()
-    {
-        return $this->container->get('injected_service')->doSomething();
-    }
-}
-
-class FakeInjectedService
-{
-    public function doSomething()
-    {
-        return true;
+        $this->assertTrue($this->container->has('test_resolver'));
     }
 }

--- a/Tests/DependencyInjection/Compiler/ResolverTaggedServiceMappingPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ResolverTaggedServiceMappingPassTest.php
@@ -4,7 +4,6 @@ namespace Overblog\GraphQLBundle\Tests\DependencyInjection\Compiler;
 
 use Overblog\GraphQLBundle\DependencyInjection\Compiler\ResolverTaggedServiceMappingPass;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -25,13 +24,17 @@ class ResolverTaggedServiceMappingPassTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $container = new ContainerBuilder();
-        $container->setDefinition('injected_service', new Definition(FakeInjectedService::class));
+        $container->setDefinition(
+            'injected_service',
+            new Definition('Overblog\GraphQLBundle\Tests\DependencyInjection\Compiler\FakeInjectedService')
+        );
+
         $container->register(
             'overblog_graphql.resolver_resolver',
             "Overblog\\GraphQLBundle\\Resolver\\ResolverResolver"
         );
 
-        $fakeResolver = new Definition(FakeResolverService::class);
+        $fakeResolver = new Definition('Overblog\GraphQLBundle\Tests\DependencyInjection\Compiler\FakeResolverService');
         $fakeResolver
             ->addTag( 'overblog_graphql.resolver', [
                 'alias' => 'fake_resolver', 'method' => 'doSomethingWithContainer'

--- a/Tests/DependencyInjection/Compiler/ResolverTaggedServiceMappingPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ResolverTaggedServiceMappingPassTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Overblog\GraphQLBundle\Tests\DependencyInjection\Compiler;
+
+use Overblog\GraphQLBundle\DependencyInjection\Compiler\ResolverTaggedServiceMappingPass;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Class ResolverTaggedServiceMappingPassTest
+ * @package DependencyInjection
+ */
+class ResolverTaggedServiceMappingPassTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ContainerBuilder
+     */
+    private $container;
+
+    public function setUp()
+    {
+        $container = new ContainerBuilder();
+        $container->setDefinition('injected_service', new Definition(FakeInjectedService::class));
+        $container->register(
+            'overblog_graphql.resolver_resolver',
+            "Overblog\\GraphQLBundle\\Resolver\\ResolverResolver"
+        );
+
+        $fakeResolver = new Definition(FakeResolverService::class);
+        $fakeResolver
+            ->addTag( 'overblog_graphql.resolver', [
+                'alias' => 'fake_resolver', 'method' => 'doSomethingWithContainer'
+            ]);
+
+        $container->setDefinition('fake_resolver', $fakeResolver);
+
+        $this->container = $container;
+    }
+
+    private function addCompilerPassesAndCompile()
+    {
+            $this->container->addCompilerPass(new ResolverTaggedServiceMappingPass());
+            // Manipulate container after ResolverTaggedServiceMappingPass
+            $this->container->addCompilerPass(new FakeCompilerPass());
+            $this->container->compile();
+    }
+
+    public function testCompilationWorksPassConfigDirective()
+    {
+        $this->addCompilerPassesAndCompile();
+
+        $this->assertTrue($this->container->has('fake_resolver'));
+    }
+}
+
+class FakeCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $container
+            ->getDefinition('fake_resolver')
+            ->addArgument(new Reference('injected_service'))
+        ;
+    }
+}
+
+// Instantiate ContainerAwareInterface to trigger the problem in ResolverTaggedServiceMappingPass
+class FakeResolverService implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    public function __construct($service)
+    {
+    }
+
+    public function doSomethingWithContainer()
+    {
+        return $this->container->get('injected_service')->doSomething();
+    }
+}
+
+class FakeInjectedService
+{
+    public function doSomething()
+    {
+        return true;
+    }
+}

--- a/Tests/DependencyInjection/Compiler/ResolverTestService.php
+++ b/Tests/DependencyInjection/Compiler/ResolverTestService.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+/**
+ * Class ResolverTestService
+ * @package DependencyInjection\Compiler
+ */
+class ResolverTestService implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    public function __construct($service)
+    {
+    }
+
+    public function doSomethingWithContainer()
+    {
+        return $this->container->get('injected_service')->doSomething();
+    }
+}


### PR DESCRIPTION
Issue `$container->get()` should not be called during compiler passes to avoid issues where a resolver service (for instance), implements ContainerAwareInterface and for which a service is not fully yet created.

This fix uses `$container->findDefinition()` instead and checks if the class (string) is a sub class of the interface.