### PR TITLE
Fixed round for execution time

### DIFF
--- a/Request/Executor.php
+++ b/Request/Executor.php
@@ -158,7 +158,7 @@ class Executor
 
         if ($this->hasDebugInfo()) {
             $executionResult->extensions['debug'] = [
-                'executionTime' => sprintf('%d ms', round(microtime(true) - $startTime, 1) * 1000),
+                'executionTime' => sprintf('%d ms', round(microtime(true) - $startTime, 3) * 1000),
                 'memoryUsage' => sprintf('%.2F MiB', (memory_get_usage(true) - $startMemoryUsage) / 1024 / 1024),
             ];
         }


### PR DESCRIPTION
This changes the rounding of the execution time provided when debug mode is enabled. Now the precision should be of 1ms instead of 100ms.