### PR TITLE
Added paginator helper to convert first/after and before/last to offset/limit

### DIFF
--- a/Relay/Connection/Paginator.php
+++ b/Relay/Connection/Paginator.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Overblog\GraphQLBundle\Relay\Connection;
+
+use Overblog\GraphQLBundle\Definition\Argument;
+use Overblog\GraphQLBundle\Relay\Connection\Output\Connection;
+use Overblog\GraphQLBundle\Relay\Connection\Output\ConnectionBuilder;
+
+class Paginator
+{
+    /**
+     * @var callable
+     */
+    private $fetcher;
+
+    /**
+     * @param callable $fetcher
+     */
+    public function __construct(callable $fetcher)
+    {
+        $this->fetcher = $fetcher;
+    }
+
+    /**
+     * @param Argument|array $args
+     * @param int|callable   $total
+     *
+     * @return Connection
+     */
+    public function backward($args, $total)
+    {
+        $args = $this->protectArgs($args);
+        $limit = $args['last'];
+        $offset = max(0, ConnectionBuilder::getOffsetWithDefault($args['before'], $total) - $limit);
+
+        $entities = call_user_func($this->fetcher, $offset, $limit);
+
+        return ConnectionBuilder::connectionFromArraySlice($entities, $args, [
+            'sliceStart' => $offset,
+            'arrayLength' => $total,
+        ]);
+    }
+
+    /**
+     * @param Argument|array $args
+     *
+     * @return Connection
+     */
+    public function forward($args)
+    {
+        $args = $this->protectArgs($args);
+        $limit = $args['first'];
+        $offset = ConnectionBuilder::getOffsetWithDefault($args['after'], 0);
+
+        // The extra fetched element is here to determine if there is a next page.
+        $entities = call_user_func($this->fetcher, $offset, $limit + 1);
+
+        return ConnectionBuilder::connectionFromArraySlice($entities, $args, [
+            'sliceStart' => $offset,
+            'arrayLength' => $offset + count($entities),
+        ]);
+    }
+
+    /**
+     * @param Argument|array $args
+     * @param int|callable   $total
+     *
+     * @return Connection
+     */
+    public function auto($args, $total)
+    {
+        $args = $this->protectArgs($args);
+
+        if ($args['last']) {
+            return $this->backward($args, is_callable($total) ? call_user_func($total) : $total);
+        } else {
+            return $this->forward($args);
+        }
+    }
+
+    /**
+     * @param Argument|array $args
+     *
+     * @return Argument
+     */
+    private function protectArgs($args)
+    {
+        return $args instanceof Argument ? $args : new Argument($args);
+    }
+}

--- a/Tests/Relay/Connection/PaginatorTest.php
+++ b/Tests/Relay/Connection/PaginatorTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Overblog\GraphQLBundle\Tests\Relay\Connection;
+
+use Overblog\GraphQLBundle\Definition\Argument;
+use Overblog\GraphQLBundle\Relay\Connection\Paginator;
+
+class PaginatorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testForward()
+    {
+        $paginator = new Paginator(function ($offset, $limit) {
+            $this->assertSame(0, $offset);
+            $this->assertSame(6, $limit); // Includes the extra element to check if next page is available
+
+            return array_fill(0, 6, 'item');
+        });
+
+        $this->assertCount(5, $paginator->forward(new Argument(['first' => 5]))->edges);
+    }
+
+    public function testForwardAfter()
+    {
+        $paginator = new Paginator(function ($offset, $limit) {
+            $this->assertSame(5, $offset);
+            $this->assertSame(6, $limit); // Includes the extra element to check if next page is available
+
+            return array_fill(0, 6, 'item');
+        });
+
+        $this->assertCount(5, $paginator->forward(new Argument(['first' => 5, 'after' => base64_encode('arrayconnection:5') ]))->edges);
+    }
+
+    public function testBackward()
+    {
+        $paginator = new Paginator(function ($offset, $limit) {
+            $this->assertSame(5, $offset);
+            $this->assertSame(5, $limit);
+
+            return array_fill(0, 5, 'item');
+        });
+
+        $this->assertCount(5, $paginator->backward(new Argument(['last' => 5]), 10)->edges);
+    }
+
+    public function testBackwardBefore()
+    {
+        $paginator = new Paginator(function ($offset, $limit) {
+            $this->assertSame(0, $offset);
+            $this->assertSame(5, $limit);
+
+            return array_fill(0, 5, 'item');
+        });
+
+        $this->assertCount(5, $paginator->backward(new Argument(['last' => 5, 'before' => base64_encode('arrayconnection:5')]), 10)->edges);
+    }
+
+    public function testAuto()
+    {
+        // Backward
+        $paginator = new Paginator(function ($offset, $limit) {
+            $this->assertSame(5, $offset);
+            $this->assertSame(5, $limit);
+
+            return array_fill(0, 5, 'item');
+        });
+
+        $this->assertCount(5, $paginator->auto(new Argument(['last' => 5]), 10)->edges);
+
+        // Forward
+        $paginator = new Paginator(function ($offset, $limit) {
+            $this->assertSame(0, $offset);
+            $this->assertSame(6, $limit); // Includes the extra element to check if next page is available
+
+            return array_fill(0, 5, 'item');
+        });
+
+        $this->assertCount(5, $paginator->auto(new Argument(['first' => 5]), 10)->edges);
+
+        // Backward + callable
+        $paginator = new Paginator(function ($offset, $limit) {
+            $this->assertSame(5, $offset);
+            $this->assertSame(5, $limit);
+
+            return array_fill(0, 5, 'item');
+        });
+
+        $countCalled = false;
+        $result = $paginator->auto(new Argument(['last' => 5]), function () use (&$countCalled) {
+            $countCalled = true;
+            return 10;
+        });
+
+        $this->assertTrue($countCalled);
+        $this->assertCount(5, $result->edges);
+    }
+}


### PR DESCRIPTION
This adds a standalone object to help on pagination. Its role is to convert GraphQL arguments from the ConnectionArgs to an offset/limit pair. For instance : 

```php
    public function resolveList($args)
    {
        $pagination = new EntityPaginator(function ($offset, $limit) {
            return $this->myRepository->getAll($offset, $limit); // Or Doctrine or whatever
        });
        
        // Make use of the 'first' and 'after' arguments
        return $pagination->forward($args);
    }
```

All you have to do is provide a callable that fetch the items you need to paginate.

For backward pagination, you have to provide an item count : 

```php
return $pagination->backward($args, $this->myRepository->count());
```

You can also have an automatic mode that detects if you go backward or forward : 

```php
return $pagination->auto($args, $this->myRepository->count());
```

To avoid computing a total that is uneeded for forward pagination, you can provide a callable that will only be resolved when going backward : 

```php
return $pagination->auto($args, [$this->myRepository, 'count']);
```