### PR TITLE
Paginator backward method now accepts arguments for its callback

### DIFF
--- a/Relay/Connection/Paginator.php
+++ b/Relay/Connection/Paginator.php
@@ -33,11 +33,14 @@ class Paginator
     /**
      * @param Argument|array $args
      * @param int|callable   $total
+     * @param array          $callableArgs
      *
      * @return Connection
      */
-    public function backward($args, $total)
+    public function backward($args, $total, array $callableArgs = [])
     {
+        $total = is_callable($total) ? call_user_func_array($total, $callableArgs) : $total;
+
         $args = $this->protectArgs($args);
         $limit = $args['last'];
         $offset = max(0, ConnectionBuilder::getOffsetWithDefault($args['before'], $total) - $limit);
@@ -79,15 +82,16 @@ class Paginator
     /**
      * @param Argument|array $args
      * @param int|callable   $total
+     * @param array          $callableArgs
      *
      * @return Connection
      */
-    public function auto($args, $total)
+    public function auto($args, $total, $callableArgs = [])
     {
         $args = $this->protectArgs($args);
 
         if ($args['last']) {
-            return $this->backward($args, is_callable($total) ? call_user_func($total) : $total);
+            return $this->backward($args, $total, $callableArgs);
         } else {
             return $this->forward($args);
         }

--- a/Resources/doc/helpers/relay-paginator.md
+++ b/Resources/doc/helpers/relay-paginator.md
@@ -152,3 +152,45 @@ The callback function will receive:
 - `$limit = 3`
 
 And it must return at least `['C','D','E']`
+
+#### With a `last` relay parameter
+
+```php
+<?php
+
+use Overblog\GraphQLBundle\Definition\Argument;
+use Overblog\GraphQLBundle\Relay\Connection\Paginator;
+
+class DataBackend
+{
+    public $data = ['A', 'B', 'C', 'D', 'E'];
+
+    public function getData($offset = 0)
+    {
+        return array_slice($this->data, $offset);
+    }
+
+    public function count($array)
+    {
+        return count($array);
+    }
+}
+
+$backend = new DataBackend();
+
+$paginator = new Paginator(function ($offset, $limit) use ($backend) {
+    return $backend->getData($offset);
+});
+
+$result = $paginator->backward(
+    new Argument(
+        [
+            'last' => 4,
+        ]
+    ),
+    [$backend, 'count'],
+    ['array' => $backend->getData]
+);
+```
+
+You should get the 4 last items of the _data set_.

--- a/Tests/Relay/Connection/PaginatorBackend.php
+++ b/Tests/Relay/Connection/PaginatorBackend.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the OverblogGraphQLBundle package.
+ *
+ * (c) Overblog <http://github.com/overblog/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Overblog\GraphQLBundle\Tests\Relay\Connection;
+
+/**
+ * Class PaginatorBackend.
+ */
+class PaginatorBackend
+{
+    public function count($array)
+    {
+        return count($array);
+    }
+}

--- a/Tests/Relay/Connection/PaginatorTest.php
+++ b/Tests/Relay/Connection/PaginatorTest.php
@@ -253,4 +253,33 @@ class PaginatorTest extends \PHPUnit_Framework_TestCase
         $this->assertSameEdgeNodeValue(['B', 'C', 'D', 'E'], $result);
         $this->assertTrue($result->pageInfo->hasPreviousPage);
     }
+
+    public function testTotalCallableWithArguments()
+    {
+        $paginatorBackend = new PaginatorBackend();
+
+        $callable = [
+            $paginatorBackend,
+            'count',
+        ];
+
+        $this->assertSame(5, call_user_func_array($callable, ['array' => $this->data]));
+
+        $paginator = new Paginator(function ($offset, $limit) {
+            $this->assertSame(1, $offset);
+            $this->assertSame(4, $limit);
+
+            return $this->getData($offset);
+        });
+
+        $result = $paginator->auto(
+            new Argument(['last' => 4]),
+            $callable,
+            ['array' => $this->data]
+        );
+
+        $this->assertCount(4, $result->edges);
+        $this->assertSameEdgeNodeValue(['B', 'C', 'D', 'E'], $result);
+        $this->assertTrue($result->pageInfo->hasPreviousPage);
+    }
 }


### PR DESCRIPTION
Make it possible to pass arguments for the callable used in the `auto` and `backward` function of the `Paginator`.