### PR TITLE
Use the whatwg-fetch polyfill for GraphiQL

### DIFF
--- a/Controller/GraphiQLController.php
+++ b/Controller/GraphiQLController.php
@@ -30,6 +30,7 @@ class GraphiQLController extends Controller
                 'versions' => [
                     'graphiql' => $this->getParameter('overblog_graphql.versions.graphiql'),
                     'react' => $this->getParameter('overblog_graphql.versions.react'),
+                    'fetch' => $this->getParameter('overblog_graphql.versions.fetch'),
                 ],
             ]
         );

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -162,6 +162,7 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->scalarNode('graphiql')->defaultValue('0.7.8')->end()
                         ->scalarNode('react')->defaultValue('15.3.2')->end()
+                        ->scalarNode('fetch')->defaultValue('2.0.1')->end()
                     ->end()
                 ->end()
             ->end();

--- a/DependencyInjection/OverblogGraphQLExtension.php
+++ b/DependencyInjection/OverblogGraphQLExtension.php
@@ -59,6 +59,7 @@ class OverblogGraphQLExtension extends Extension implements PrependExtensionInte
     {
         $container->setParameter($this->getAlias().'.versions.graphiql', $config['versions']['graphiql']);
         $container->setParameter($this->getAlias().'.versions.react', $config['versions']['react']);
+        $container->setParameter($this->getAlias().'.versions.fetch', $config['versions']['fetch']);
     }
 
     private function setConfigBuilders(array $config)

--- a/Resources/views/GraphiQL/index.html.twig
+++ b/Resources/views/GraphiQL/index.html.twig
@@ -13,6 +13,7 @@
   </style>
   <link href="https://unpkg.com/graphiql@{{ versions.graphiql }}/graphiql.css" rel="stylesheet">
   {% endblock style %}
+  <script src="https://unpkg.com/whatwg-fetch@{{ versions.fetch }}/fetch.js"></script>
   <script src="https://unpkg.com/react@{{ versions.react }}/dist/react.min.js"></script>
   <script src="https://unpkg.com/react-dom@{{ versions.react }}/dist/react-dom.min.js"></script>
   <script src="https://unpkg.com/graphiql@{{ versions.graphiql }}/graphiql.min.js"></script>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | N/A
| Fixed tickets | none
| License       | MIT

When using GraphiQL with browsers that do not natively support `window.fetch` (such as Safari in my case, but also older versions of Chrome, Firefox and IE), javascript errors pop up and GraphiQL becomes unusable.

![screenshot 2017-01-12 11 13 58](https://cloud.githubusercontent.com/assets/106844/21885483/3c94e11a-d8b8-11e6-9b37-aeff785b858c.png)


The example HTML that GraphiQL themselves provide uses the whatwg-fetch polyfill as a workaround.

See https://github.com/graphql/graphiql/blob/master/example/index.html#L31 and https://www.npmjs.com/package/whatwg-fetch for more information.