### PR TITLE
Added php7 errors compatibility

### DIFF
--- a/Error/ErrorHandler.php
+++ b/Error/ErrorHandler.php
@@ -164,9 +164,9 @@ class ErrorHandler
      *
      * @param \Exception $rawException
      *
-     * @return \Exception
+     * @return \Exception|\Error
      */
-    protected function convertException(\Exception $rawException = null)
+    protected function convertException($rawException = null)
     {
         if (null === $rawException) {
             return;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| License       | MIT

This PRs adds compatibility for php7 by also handling the `\Error` class.