### PR TITLE
Update the whole Sf toolbar when using GraphiQL

### DIFF
--- a/Resources/views/GraphiQL/index.html.twig
+++ b/Resources/views/GraphiQL/index.html.twig
@@ -43,6 +43,11 @@
         body: JSON.stringify(params),
         credentials: 'include',
       }).then((res) => {
+        var xdebugToken = res.headers.get('X-Debug-Token')
+        if (typeof Sfjs !== "undefined") {
+          var toolbarElement = document.querySelector('.sf-toolbar')
+          Sfjs.load(toolbarElement.id, '/_wdt/' + xdebugToken)
+        }
         return res.text()
       }).then((body) => {
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | no
| License       | MIT

This PR is a small improvement which will update the Symfony toolbar when using GraphiQL in dev mode.