### PR TITLE
Allow GraphQL schema shorthand configuration

### DIFF
--- a/Definition/Builder/SchemaBuilder.php
+++ b/Definition/Builder/SchemaBuilder.php
@@ -13,6 +13,7 @@ namespace Overblog\GraphQLBundle\Definition\Builder;
 
 use GraphQL\Schema;
 use GraphQL\Type\Definition\Config;
+use GraphQL\Type\LazyResolution;
 use Overblog\GraphQLBundle\Resolver\ResolverInterface;
 
 class SchemaBuilder
@@ -22,12 +23,29 @@ class SchemaBuilder
      */
     private $typeResolver;
 
+    /**
+     * @var array
+     */
+    private $schemaDescriptor;
+
     /** @var bool */
     private $enableValidation;
 
-    public function __construct(ResolverInterface $typeResolver, $enableValidation = false)
+    /**
+     * SchemaBuilder constructor.
+     *
+     * @param ResolverInterface $typeResolver
+     * @param array             $schemaDescriptor
+     * @param bool              $enableValidation
+     */
+    public function __construct(
+        ResolverInterface $typeResolver,
+        array $schemaDescriptor,
+        $enableValidation = false
+    )
     {
         $this->typeResolver = $typeResolver;
+        $this->schemaDescriptor = $schemaDescriptor;
         $this->enableValidation = $enableValidation;
     }
 
@@ -50,7 +68,7 @@ class SchemaBuilder
             'query' => $query,
             'mutation' => $mutation,
             'subscription' => $subscription,
-            'types' => $this->typeResolver->getSolutions(),
+            'typeResolution' => new LazyResolution($this->schemaDescriptor, [$this->typeResolver, 'resolve'])
         ]);
     }
 }

--- a/DependencyInjection/Compiler/TaggedServiceMappingPass.php
+++ b/DependencyInjection/Compiler/TaggedServiceMappingPass.php
@@ -40,15 +40,7 @@ abstract class TaggedServiceMappingPass implements CompilerPassInterface
         $resolverDefinition = $container->findDefinition($this->getResolverServiceID());
 
         foreach ($mapping as $name => $options) {
-            $cleanOptions = $options;
-            $solutionID = $options['id'];
-
-            $definition = $container->findDefinition($solutionID);
-            if (is_subclass_of($definition->getClass(), 'Symfony\Component\DependencyInjection\ContainerAwareInterface')) {
-                $solutionDefinition = $container->findDefinition($options['id']);
-                $solutionDefinition->addMethodCall('setContainer', [new Reference('service_container')]);
-            }
-            $resolverDefinition->addMethodCall('addSolution', [$name, new Reference($solutionID), $cleanOptions]);
+            $resolverDefinition->addMethodCall('addSolution', [$name, null, $options]);
         }
     }
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -76,7 +76,7 @@ class Configuration implements ConfigurationInterface
                                     ->prototype('array')
                                         ->addDefaultsIfNotSet()
                                         ->children()
-                                            ->enumNode('type')->isRequired()->values(['yml', 'xml'])->end()
+                                            ->enumNode('type')->isRequired()->values(['yml', 'xml', 'graphqls'])->end()
                                             ->scalarNode('dir')->defaultNull()->end()
                                         ->end()
                                     ->end()

--- a/DependencyInjection/OverblogGraphQLTypesExtension.php
+++ b/DependencyInjection/OverblogGraphQLTypesExtension.php
@@ -11,6 +11,36 @@
 
 namespace Overblog\GraphQLBundle\DependencyInjection;
 
+use GraphQL\Error\SyntaxError;
+use GraphQL\Language\AST\BooleanValueNode;
+use GraphQL\Language\AST\DirectiveDefinitionNode;
+use GraphQL\Language\AST\EnumTypeDefinitionNode;
+use GraphQL\Language\AST\DocumentNode;
+use GraphQL\Language\AST\EnumValueDefinitionNode;
+use GraphQL\Language\AST\FieldDefinitionNode;
+use GraphQL\Language\AST\EnumValueNode;
+use GraphQL\Language\AST\FloatValueNode;
+use GraphQL\Language\AST\InputObjectTypeDefinitionNode;
+use GraphQL\Language\AST\InputValueDefinitionNode;
+use GraphQL\Language\AST\InterfaceTypeDefinitionNode;
+use GraphQL\Language\AST\FragmentDefinitionNode;
+use GraphQL\Language\AST\IntValueNode;
+use GraphQL\Language\AST\ListTypeNode;
+use GraphQL\Language\AST\ListValueNode;
+use GraphQL\Language\AST\NamedTypeNode;
+use GraphQL\Language\AST\NodeKind;
+use GraphQL\Language\AST\ObjectTypeDefinitionNode;
+use GraphQL\Language\AST\NonNullTypeNode;
+use GraphQL\Language\AST\ObjectValueNode;
+use GraphQL\Language\AST\ScalarTypeDefinitionNode;
+use GraphQL\Language\AST\OperationDefinitionNode;
+use GraphQL\Language\AST\StringValueNode;
+use GraphQL\Language\AST\UnionTypeDefinitionNode;
+use GraphQL\Language\AST\TypeExtensionDefinitionNode;
+use GraphQL\Language\Parser;
+use GraphQL\Language\AST\VariableDefinitionNode;
+use GraphQL\Language\Visitor;
+
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Config\Util\XmlUtils;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -23,6 +53,8 @@ use Symfony\Component\Yaml\Parser as YamlParser;
 
 class OverblogGraphQLTypesExtension extends Extension
 {
+    const NAME_TO_KEY = '__key';
+
     private $yamlParser;
 
     public function load(array $configs, ContainerBuilder $container)
@@ -55,7 +87,18 @@ class OverblogGraphQLTypesExtension extends Extension
     {
         /** @var SplFileInfo $file */
         foreach ($files as $file) {
-            $typeConfig = 'yml' === $type ? $this->typesConfigFromYml($file, $container) : $this->typesConfigFromXml($file, $container);
+            switch ($type) {
+                case 'yml':
+                    $typeConfig = $this->typesConfigFromYml($file, $container);
+                    break;
+                case 'xml':
+                    $typeConfig = $this->typesConfigFromXml($file, $container);
+                    break;
+                default:
+                    $typeConfig = $this->typesConfigFromGraphqls($file, $container);
+                    break;
+            }
+
             $container->prependExtensionConfig($this->getAlias(), $typeConfig);
         }
     }
@@ -77,6 +120,18 @@ class OverblogGraphQLTypesExtension extends Extension
             $container->addResource(new FileResource($file->getRealPath()));
         } catch (\InvalidArgumentException $e) {
             throw new InvalidArgumentException(sprintf('Unable to parse file "%s".', $file), $e->getCode(), $e);
+        }
+
+        return $typesConfig;
+    }
+
+    private function typesConfigFromGraphqls(SplFileInfo $file, ContainerBuilder $container)
+    {
+        try {
+            $typesConfig = $this->parseSchemaToOverblogGraphQLTypesConfigArray($file->getContents());
+            $container->addResource(new FileResource($file->getRealPath()));
+        } catch (SyntaxError $e) {
+            throw new InvalidArgumentException(sprintf('The file "%s" does not contain valid GraphQL schema language.', $file), 0, $e);
         }
 
         return $typesConfig;
@@ -149,7 +204,7 @@ class OverblogGraphQLTypesExtension extends Extension
         $extension = $this->getMappingResourceExtension();
         $finder = new Finder();
 
-        $types = null === $type ? ['yml', 'xml'] : [$type];
+        $types = null === $type ? ['yml', 'xml', 'graphqls'] : [$type];
 
         foreach ($types as $type) {
             try {
@@ -191,5 +246,241 @@ class OverblogGraphQLTypesExtension extends Extension
     public function getConfiguration(array $config, ContainerBuilder $container)
     {
         return new TypesConfiguration();
+    }
+
+    private function parseSchemaToOverblogGraphQLTypesConfigArray($sourceString) {
+        $ast = Parser::parse($sourceString, ['noLocation' => true, 'noSource' => true]);
+
+        // fixme: here there be dragons.
+        //
+        // - the commented bits are almost definitely not needed.
+        // - the uncommented bits that refer to self:: methods are likely to be needed at some point, but
+        //      haven't been converted yet.
+
+        $types = Visitor::visit($ast, array(
+            'leave' => array(
+                NodeKind::NAME => function($node) {return '' . $node->value;},
+                NodeKind::VARIABLE => function($node) {return '$' . $node->name;},
+
+                NodeKind::DOCUMENT => function(DocumentNode $node) {
+                    return $node->definitions;
+                },
+
+                NodeKind::OPERATION_DEFINITION => function(OperationDefinitionNode $node) {
+                    $op = $node->operation;
+                    $name = $node->name;
+                    $varDefs = self::wrap('(', self::join($node->variableDefinitions, ', '), ')');
+                    $directives = self::join($node->directives, ' ');
+                    $selectionSet = $node->selectionSet;
+                    // Anonymous queries with no directives or variable definitions can use
+                    // the query short form.
+                    return !$name && !$directives && !$varDefs && $op === 'query'
+                        ? $selectionSet
+                        : self::join([$op, self::join([$name, $varDefs]), $directives, $selectionSet], ' ');
+                },
+                NodeKind::VARIABLE_DEFINITION => function(VariableDefinitionNode $node) {
+                    return $node->variable . ': ' . $node->type . self::wrap(' = ', $node->defaultValue);
+                },
+                //        NodeKind::SELECTION_SET => function(SelectionSet $node) {
+                //            return self::block($node->selections);
+                //        },
+                //        NodeKind::FIELD => function(Field $node) {
+                //            return self::join([
+                //                self::wrap('', $node->alias, ': ') . $node->name . self::wrap('(', self::join($node->arguments, ', '), ')'),
+                //                self::join($node->directives, ' '),
+                //                $node->selectionSet
+                //            ], ' ');
+                //        },
+                //        NodeKind::ARGUMENT => function(Argument $node) {
+                //            return $node->name . ': ' . $node->value;
+                //        },
+
+                // Fragments
+                //        NodeKind::FRAGMENT_SPREAD => function(FragmentSpread $node) {
+                //            return '...' . $node->name . self::wrap(' ', self::join($node->directives, ' '));
+                //        },
+                //        NodeKind::INLINE_FRAGMENT => function(InlineFragment $node) {
+                //            return self::join([
+                //                "...",
+                //                self::wrap('on ', $node->typeCondition),
+                //                self::join($node->directives, ' '),
+                //                $node->selectionSet
+                //            ], ' ');
+                //        },
+                NodeKind::FRAGMENT_DEFINITION => function(FragmentDefinitionNode $node) {
+                    return "fragment {$node->name} on {$node->typeCondition} "
+                        . self::wrap('', self::join($node->directives, ' '), ' ')
+                        . $node->selectionSet;
+                },
+
+                // Value
+                NodeKind::INT => function(IntValueNode  $node) {return $node->value;},
+                NodeKind::FLOAT => function(FloatValueNode $node) {return $node->value;},
+                NodeKind::STRING => function(StringValueNode $node) {return $node->value;},
+                NodeKind::BOOLEAN => function(BooleanValueNode $node) {return $node->value;},
+                NodeKind::ENUM => function(EnumValueNode $node) {return $node->value;},
+                // todo: these two probably won't work as is - they need to be tested with actual data
+                NodeKind::LST => function(ListValueNode $node) {return $node->values;},
+                NodeKind::OBJECT => function(ObjectValueNode $node) {return $node->fields;},
+                // todo: is this also a valid value for the purposes of defaultValue?
+                //        NodeKind::OBJECT_FIELD => function(ObjectField $node) {return $node->name . ': ' . $node->value;},
+                //
+                //        // Directive
+                //        NodeKind::DIRECTIVE => function(Directive $node) {
+                //            return '@' . $node->name . self::wrap('(', self::join($node->arguments, ', '), ')');
+                //        },
+
+                // Type
+                NodeKind::NAMED_TYPE => function(NamedTypeNode $node) {return $node->name;},
+                NodeKind::LIST_TYPE => function(ListTypeNode $node) {return '[' . $node->type . ']';},
+                NodeKind::NON_NULL_TYPE => function(NonNullTypeNode $node) {return $node->type . '!';},
+
+                // Type System Definitions
+                //        NodeKind::SCHEMA_DEFINITION => function(SchemaDefinition $def) {return 'schema ' . self::block($def->operationTypes);},
+                //        NodeKind::OPERATION_TYPE_DEFINITION => function(OperationTypeDefinition $def) {return $def->operation . ': ' . $def->type;},
+
+                NodeKind::SCALAR_TYPE_DEFINITION => function(ScalarTypeDefinitionNode $def) {
+                    // todo: boo, it seems that graphql-php-generator does not support custom scalars.
+                    return [
+                        self::NAME_TO_KEY => $def->name,
+                        'type' => 'scalar'
+                    ];
+                },
+                NodeKind::OBJECT_TYPE_DEFINITION => function(ObjectTypeDefinitionNode $def) {
+                    return [
+                        self::NAME_TO_KEY => $def->name,
+                        'type' => 'object',
+                        'config' => [
+                            'fields' => $def->fields,
+                            'interfaces' => $def->interfaces,
+                            'description' => $def->description
+                        ]
+                    ];
+                },
+                NodeKind::FIELD_DEFINITION => function(FieldDefinitionNode $def) {
+                    $description = $def->description;
+                    $resolver = null;
+                    if (strpos($def->description, '@@resolver') === 0) {
+                        $newLineStart = strpos($description, "\n");
+                        $resolver = '@=resolver'.substr($description, 10, $newLineStart - 10);
+                        $description = substr($description, $newLineStart + 1);
+                    }
+
+                    $config = [
+                        self::NAME_TO_KEY => $def->name,
+                        'type' => $def->type,
+                        'args' => $def->arguments,
+                        'description' => $description
+                    ];
+
+                    if ($resolver) {
+                        $config['resolve'] = $resolver;
+                    }
+
+                    return $config;
+                },
+                NodeKind::INPUT_VALUE_DEFINITION => function(InputValueDefinitionNode $def) {
+                    return [
+                        self::NAME_TO_KEY => $def->name,
+                        'type' => $def->type,
+                        'defaultValue' => $def->defaultValue,
+                        'description' => $def->description
+                    ];
+                },
+                NodeKind::INTERFACE_TYPE_DEFINITION => function(InterfaceTypeDefinitionNode $def) {
+                    return [
+                        self::NAME_TO_KEY => $def->name,
+                        'type' => 'interface',
+                        'config' => [
+                            'fields' => $def->fields,
+                            'description' => $def->description,
+                            'resolveType' => "@=resolver('resolve_type', [value])"
+                        ]
+                    ];
+                },
+                NodeKind::UNION_TYPE_DEFINITION => function(UnionTypeDefinitionNode $def) {
+                    return [
+                        self::NAME_TO_KEY => $def->name,
+                        'type' => 'union',
+                        'config' => [
+                            'types' => $def->types,
+                            'description' => $def->description,
+                            'resolveType' => "@=resolver('resolve_type', [value])"
+                        ],
+                    ];
+                },
+                NodeKind::ENUM_TYPE_DEFINITION => function(EnumTypeDefinitionNode $def) {
+                    return [
+                        self::NAME_TO_KEY => $def->name,
+                        'type' => 'enum',
+                        'config' => [
+                            'values' => $def->values,
+                            'description' => $def->description
+                        ]
+                    ];
+                },
+                NodeKind::ENUM_VALUE_DEFINITION => function(EnumValueDefinitionNode $def) {
+                    $description = $def->description;
+                    $value = null;
+                    if (strpos($def->description, '@@value(') === 0) {
+                        $newLineStart = strpos($description, "\n");
+                        $value = substr($description, 8, $newLineStart - 9);
+                        $description = substr($description, $newLineStart + 1);
+                    }
+
+                    $config = [
+                        'name' => $def->name,
+                        'description' => $description
+                    ];
+
+                    if ($value !== null) {
+                        $config['value'] = $value;
+                    }
+
+                    return $config;
+                },
+                NodeKind::INPUT_OBJECT_TYPE_DEFINITION => function(InputObjectTypeDefinitionNode $def) {
+                    return [
+                        self::NAME_TO_KEY => $def->name,
+                        'type' => 'input-object',
+                        'config' => [
+                            'fields' => $def->fields,
+                            'description' => $def->description
+                        ]
+                    ];
+                },
+                NodeKind::TYPE_EXTENSION_DEFINITION => function(TypeExtensionDefinitionNode $def) {return "extend {$def->definition}";},
+                NodeKind::DIRECTIVE_DEFINITION => function(DirectiveDefinitionNode $def) {
+                    return 'directive @' . $def->name . self::wrap('(', self::join($def->arguments, ', '), ')')
+                        . ' on ' . self::join($def->locations, ' | ');
+                }
+            )
+        ));
+
+        $types = $this->substituteKeys($types);
+
+        return $types;
+    }
+
+    // -.-
+
+    private function substituteKeys($array) {
+        $newArray = [];
+        foreach ($array as $key => $value) {
+            if (is_array($value)) {
+
+                if (isset($value[self::NAME_TO_KEY])) {
+                    $key = $value[self::NAME_TO_KEY];
+                    unset($value[self::NAME_TO_KEY]);
+                }
+
+                $substitutedValue = $this->substituteKeys($value);
+                $newArray[$key] = $substitutedValue;
+
+            } else {
+                $newArray[$key] = $value;
+            }
+        }
+        return $newArray;
     }
 }

--- a/DependencyInjection/OverblogGraphQLTypesExtension.php
+++ b/DependencyInjection/OverblogGraphQLTypesExtension.php
@@ -207,8 +207,9 @@ class OverblogGraphQLTypesExtension extends Extension
 
         foreach ($types as $type) {
             $finder = new Finder();
+            $pattern = '*.' . ($type === 'graphqls' ? $type : $extension . '.' . $type);
             try {
-                $finder->files()->in($configPath)->name('*.'.$extension.'.'.$type);
+                $finder->files()->in($configPath)->name($pattern);
             } catch (\InvalidArgumentException $e) {
                 continue;
             }

--- a/DependencyInjection/OverblogGraphQLTypesExtension.php
+++ b/DependencyInjection/OverblogGraphQLTypesExtension.php
@@ -202,11 +202,11 @@ class OverblogGraphQLTypesExtension extends Extension
         $container->addResource(new FileResource($resource));
 
         $extension = $this->getMappingResourceExtension();
-        $finder = new Finder();
 
         $types = null === $type ? ['yml', 'xml', 'graphqls'] : [$type];
 
         foreach ($types as $type) {
+            $finder = new Finder();
             try {
                 $finder->files()->in($configPath)->name('*.'.$extension.'.'.$type);
             } catch (\InvalidArgumentException $e) {

--- a/Generator/TypeGenerator.php
+++ b/Generator/TypeGenerator.php
@@ -17,7 +17,7 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class TypeGenerator extends BaseTypeGenerator
 {
-    const USE_FOR_CLOSURES = '$container, $request, $user, $token';
+    const USE_FOR_CLOSURES = '$container';
 
     private $cacheDir;
 

--- a/Resolver/ResolverResolver.php
+++ b/Resolver/ResolverResolver.php
@@ -11,8 +11,39 @@
 
 namespace Overblog\GraphQLBundle\Resolver;
 
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
 class ResolverResolver extends AbstractProxyResolver
 {
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * ResolverResolver constructor.
+     *
+     * @param ContainerInterface $container
+     */
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    public function getSolution($name)
+    {
+        $solution = parent::getSolution($name);
+
+        if (! $solution)  {
+            $typeOptions = $this->getSolutionOptions($name);
+            if ($typeOptions and $this->container->has($typeOptions['id'])) {
+                $solution = $this->container->get($typeOptions['id']);
+            }
+        }
+
+        return $solution;
+    }
+
     protected function unresolvableMessage($alias)
     {
         return sprintf('Unknown resolver with alias "%s" (verified service tag)', $alias);

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -39,15 +39,19 @@ services:
         public: false
         arguments:
             - "@overblog_graphql.type_resolver"
+            - "%overblog_graphql.definition.lazy_types_descriptor%"
             - false
 
     overblog_graphql.type_resolver:
         class: Overblog\GraphQLBundle\Resolver\TypeResolver
         arguments:
             -
+            - "@service_container"
 
     overblog_graphql.resolver_resolver:
         class: Overblog\GraphQLBundle\Resolver\ResolverResolver
+        arguments:
+            - "@service_container"
 
     overblog_graphql.mutation_resolver:
         class: Overblog\GraphQLBundle\Resolver\MutationResolver
@@ -79,7 +83,6 @@ services:
             - "%overblog_graphql.default_resolver%"
         calls:
             - ["addUseStatement", ["Symfony\\Component\\DependencyInjection\\ContainerInterface"]]
-            - ["addUseStatement", ["Symfony\\Component\\Security\\Core\\Authentication\\Token\\TokenInterface"]]
             - ["setExpressionLanguage", ["@overblog_graphql.expression_language"]]
 
     overblog_graphql.event_listener.classloader_listener:

--- a/Resources/skeleton/TypeSystem.php.skeleton
+++ b/Resources/skeleton/TypeSystem.php.skeleton
@@ -6,18 +6,6 @@
 {<traits>
 <spaces>public function __construct(ContainerInterface $container)
 <spaces>{
-<spaces><spaces>$request = null;
-<spaces><spaces>$token = null;
-<spaces><spaces>$user = null;
-<spaces><spaces>if ($container->has('request_stack')) {
-<spaces><spaces><spaces>$request = $container->get('request_stack')->getCurrentRequest();
-<spaces><spaces>}
-<spaces><spaces>if ($container->has('security.token_storage')) {
-<spaces><spaces><spaces>$token = $container->get('security.token_storage')->getToken();
-<spaces><spaces><spaces>if ($token instanceof TokenInterface) {
-<spaces><spaces><spaces><spaces>$user = $token->getUser();
-<spaces><spaces><spaces>}
-<spaces><spaces>}
 
 <spaces><spaces>parent::__construct(<config>);
 <spaces>}

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "symfony/framework-bundle": "^2.7|^3.1",
         "symfony/options-resolver": "^2.7|^3.1",
         "symfony/property-access": "^2.7|^3.1",
-        "webonyx/graphql-php": "^0.9.0"
+        "webonyx/graphql-php": "^0.9.2"
     },
     "suggest": {
         "twig/twig": "If you want to use graphiQL.",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require": {
         "php": "^5.4|~7.0",
         "doctrine/doctrine-cache-bundle": "^1.2",
-        "overblog/graphql-php-generator": "^0.4.1",
+        "overblog/graphql-php-generator": "^0.4.2",
         "symfony/expression-language": "^2.7|^3.1",
         "symfony/framework-bundle": "^2.7|^3.1",
         "symfony/options-resolver": "^2.7|^3.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #12
| License       | MIT

This PR adds the ability to define your schema in GraphQL schema shorthand.

It requires library version updates (patch version level) for better comment handling. Comments are the mechanism by which you can define elements that aren't reflected in schema shorthand: descriptions, resolvers and custom enum value values.

WIP - "men at work" warning - assume this branch will be rebased.

TODO, reminder to self:

- [ ] clean up `OverblogGraphQLTypesExtension::parseSchemaToOverblogGraphQLTypesConfigArray()`
- [ ] add unit tests (loading of the new configuration type etc)
- [ ] add ability to load multiple types of configuration files from the same directory
- [ ] add documentation with examples (esp. resolvers and custom enum value values)
- [ ] add credits on collaborated code
- [ ] improve commit messages where needed
