### PR TITLE
Fix sf toolbar updates when using graphiql

### DIFF
--- a/Resources/views/GraphiQL/index.html.twig
+++ b/Resources/views/GraphiQL/index.html.twig
@@ -44,9 +44,10 @@
         credentials: 'include',
       }).then((res) => {
         var xdebugToken = res.headers.get('X-Debug-Token')
-        if (typeof Sfjs !== "undefined") {
+        if (typeof Sfjs !== "undefined" && xdebugToken) {
           var toolbarElement = document.querySelector('.sf-toolbar')
-          Sfjs.load(toolbarElement.id, '/_wdt/' + xdebugToken)
+          var debugUrlPattern = "{{ url('_wdt', {'token': '__TOKEN__'}) }}"
+          Sfjs.load(toolbarElement.id, debugUrlPattern.replace('__TOKEN__', xdebugToken ))
         }
         return res.text()
       }).then((body) => {

--- a/Tests/Functional/app/config/routing.yml
+++ b/Tests/Functional/app/config/routing.yml
@@ -3,3 +3,6 @@ overblog_graphql_endpoint:
 
 overblog_graphql_graphiql:
     resource: "@OverblogGraphQLBundle/Resources/config/routing/graphiql.yml"
+
+_wdt:
+    path: /_wdt/{token}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | none
| License       | MIT

Takes account of the generated url to avoid 404 when using `app_dev.php` base path.
