### PR TITLE
Add format option to `graphql:dump-schema` command

### DIFF
--- a/Tests/Functional/Command/schema.graphqls
+++ b/Tests/Functional/Command/schema.graphqls
@@ -1,0 +1,66 @@
+# Information about pagination in a connection.
+type PageInfo {
+  # When paginating forwards, are there more items?
+  hasNextPage: Boolean!
+
+  # When paginating backwards, are there more items?
+  hasPreviousPage: Boolean!
+
+  # When paginating backwards, the cursor to continue.
+  startCursor: String
+
+  # When paginating forwards, the cursor to continue.
+  endCursor: String
+}
+
+type Query {
+  user: User
+}
+
+type User {
+  # the user name
+  name: String
+  friends(after: String = null, first: Int = null, before: String = null, last: Int = null): friendConnection
+  friendsForward(after: String = null, first: Int = null): userConnection
+  friendsBackward(before: String = null, last: Int = null): userConnection
+}
+
+# A connection to a list of items.
+type friendConnection {
+  totalCount: Int
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # Information to aid in pagination.
+  edges: [friendEdge]
+}
+
+# An edge in a connection.
+type friendEdge {
+  friendshipTime: String
+
+  # The item at the end of the edge.
+  node: User
+
+  # A cursor for use in pagination.
+  cursor: String!
+}
+
+# A connection to a list of items.
+type userConnection {
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # Information to aid in pagination.
+  edges: [userEdge]
+}
+
+# An edge in a connection.
+type userEdge {
+  # The item at the end of the edge.
+  node: User
+
+  # A cursor for use in pagination.
+  cursor: String!
+}

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "symfony/framework-bundle": "^2.7|^3.1",
         "symfony/options-resolver": "^2.7|^3.1",
         "symfony/property-access": "^2.7|^3.1",
-        "webonyx/graphql-php": "^0.9.0"
+        "webonyx/graphql-php": "^0.9.4"
     },
     "suggest": {
         "twig/twig": "If you want to use graphiQL.",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | none
| License       | MIT

Schema can also be dump in `graphqls` format...
