### PR TITLE
Regression: Fix graphiql route when running in the prod env

### DIFF
--- a/Resources/views/GraphiQL/index.html.twig
+++ b/Resources/views/GraphiQL/index.html.twig
@@ -46,7 +46,7 @@
         var xdebugToken = res.headers.get('X-Debug-Token')
         if (typeof Sfjs !== "undefined" && xdebugToken) {
           var toolbarElement = document.querySelector('.sf-toolbar')
-          var debugUrlPattern = "{{ url('_wdt', {'token': '__TOKEN__'}) }}"
+          var debugUrlPattern = "{{ app.debug ? url('_wdt', {'token': '__TOKEN__'}) : '/_wdt/__TOKEN__' }}"
           Sfjs.load(toolbarElement.id, debugUrlPattern.replace('__TOKEN__', xdebugToken ))
         }
         return res.text()

--- a/Resources/views/GraphiQL/index.html.twig
+++ b/Resources/views/GraphiQL/index.html.twig
@@ -43,12 +43,14 @@
         body: JSON.stringify(params),
         credentials: 'include',
       }).then((res) => {
-        var xdebugToken = res.headers.get('X-Debug-Token')
-        if (typeof Sfjs !== "undefined" && xdebugToken) {
-          var toolbarElement = document.querySelector('.sf-toolbar')
-          var debugUrlPattern = "{{ app.debug ? url('_wdt', {'token': '__TOKEN__'}) : '/_wdt/__TOKEN__' }}"
-          Sfjs.load(toolbarElement.id, debugUrlPattern.replace('__TOKEN__', xdebugToken ))
-        }
+        {% if app.debug %} 
+          var xdebugToken = res.headers.get('X-Debug-Token')
+          if (typeof Sfjs !== "undefined" && xdebugToken) {
+            var toolbarElement = document.querySelector('.sf-toolbar')
+            var debugUrlPattern = "{{ url('_wdt', {'token': '__TOKEN__'}) }}"
+            Sfjs.load(toolbarElement.id, debugUrlPattern.replace('__TOKEN__', xdebugToken ))
+          }
+        {% endif %}   
         return res.text()
       }).then((body) => {
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | -
| License       | MIT

When running in `prod` the `_wdt` route is not available.
Leads to this PHP error:

```
Uncaught PHP Exception Twig_Error_Runtime: "An exception has been thrown during the rendering of a template ("Unable to generate a URL for the named route "_wdt" as such route does not exist.").
```

 Regression introduced in [this commit](https://github.com/overblog/GraphQLBundle/commit/e5ae4ed0cc13df67af7f04544dcbe88d64e4805b). 

PS: I love this bundle!
