### PR TITLE
Adjusted tagged proxy resolver method param to be optional

### DIFF
--- a/DependencyInjection/Compiler/ResolverTaggedServiceMappingPass.php
+++ b/DependencyInjection/Compiler/ResolverTaggedServiceMappingPass.php
@@ -27,7 +27,7 @@ class ResolverTaggedServiceMappingPass extends TaggedServiceMappingPass
     {
         parent::checkRequirements($id, $tag);
 
-        if (!isset($tag['method']) || !is_string($tag['method'])) {
+        if (isset($tag['method']) && !is_string($tag['method'])) {
             throw new \InvalidArgumentException(
                 sprintf('Service tagged "%s" must have valid "method" argument.', $id)
             );

--- a/Resolver/AbstractProxyResolver.php
+++ b/Resolver/AbstractProxyResolver.php
@@ -42,7 +42,7 @@ abstract class AbstractProxyResolver extends AbstractResolver
         }
 
         $options = $this->getSolutionOptions($alias);
-        $func = [$solution, $options['method']];
+        $func = isset($options['method']) ? [$solution, $options['method']] : $solution;
 
         return call_user_func_array($func, $funcArgs);
     }

--- a/Tests/Functional/app/Exception/ExampleException.php
+++ b/Tests/Functional/app/Exception/ExampleException.php
@@ -13,7 +13,7 @@ namespace Overblog\GraphQLBundle\Tests\Functional\app\Exception;
 
 class ExampleException
 {
-    public function throwException()
+    public function __invoke()
     {
         throw new \InvalidArgumentException('Invalid argument exception');
     }

--- a/Tests/Functional/app/config/exception/services.yml
+++ b/Tests/Functional/app/config/exception/services.yml
@@ -2,4 +2,4 @@ services:
     overblog_graphql.test.exception:
         class: Overblog\GraphQLBundle\Tests\Functional\app\Exception\ExampleException
         tags:
-            - { name: "overblog_graphql.resolver", alias: "example_exception", method: "throwException" }
+            - { name: "overblog_graphql.resolver", alias: "example_exception" }


### PR DESCRIPTION
Allow omitting resolver and mutation method in tag config #133

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #133
| License       | MIT