### PR TITLE
Disabled type resolver cache serialization

### DIFF
--- a/Resolver/TypeResolver.php
+++ b/Resolver/TypeResolver.php
@@ -24,7 +24,7 @@ class TypeResolver extends AbstractResolver
 
     public function __construct(CacheItemPoolInterface $cacheAdapter = null)
     {
-        $this->cacheAdapter = null !== $cacheAdapter ? $cacheAdapter : new ArrayAdapter();
+        $this->cacheAdapter = null !== $cacheAdapter ? $cacheAdapter : new ArrayAdapter(0, false);
     }
 
     /**


### PR DESCRIPTION
this was leading to duplication of types when unserialized cache

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | none
| License       | MIT

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
