### PR TITLE
Add GraphQL native UserError to white list

### DIFF
--- a/Error/ErrorHandler.php
+++ b/Error/ErrorHandler.php
@@ -12,7 +12,7 @@
 namespace Overblog\GraphQLBundle\Error;
 
 use GraphQL\Error\Error as GraphQLError;
-use GraphQL\Error\InvariantViolation;
+use GraphQL\Error\UserError as GraphQLUserError;
 use GraphQL\Executor\ExecutionResult;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
@@ -85,7 +85,7 @@ class ErrorHandler
             $rawException = $this->convertException($error->getPrevious());
 
             // raw GraphQL Error or InvariantViolation exception
-            if (null === $rawException || $rawException instanceof InvariantViolation) {
+            if (null === $rawException || $rawException instanceof GraphQLUserError) {
                 $treatedExceptions['errors'][] = $error;
                 continue;
             }

--- a/Tests/Error/ErrorHandlerTest.php
+++ b/Tests/Error/ErrorHandlerTest.php
@@ -12,7 +12,7 @@
 namespace Overblog\GraphQLBundle\Tests\Error;
 
 use GraphQL\Error\Error as GraphQLError;
-use GraphQL\Error\InvariantViolation;
+use GraphQL\Error\UserError as GraphQLUserError;
 use GraphQL\Executor\ExecutionResult;
 use Overblog\GraphQLBundle\Error\ErrorHandler;
 use Overblog\GraphQLBundle\Error\UserError;
@@ -39,7 +39,7 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
                 new GraphQLError('Error with wrapped user error', null, null, null, null, new UserError('My User Error')),
                 new GraphQLError('', null, null, null, null, new UserErrors(['My User Error 1', 'My User Error 2', new UserError('My User Error 3')])),
                 new GraphQLError('Error with wrapped user warning', null, null, null, null, new UserWarning('My User Warning')),
-                new GraphQLError('Invalid value!', null, null, null, null, new InvariantViolation('Invalid value!')),
+                new GraphQLError('Invalid value!', null, null, null, null, new GraphQLUserError('Invalid value!')),
             ]
         );
 


### PR DESCRIPTION
* Add GraphQL native UserError to white list
* Removed `InvariantViolation` from white list because this could lead to security issues ([see here](https://github.com/webonyx/graphql-php/issues/123))

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | none
| License       | MIT

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
