### PR TITLE
[Documentation] ``services.yml`` didn't match ``CharacterResolver``

### DIFF
--- a/Resources/doc/definitions/type-system/interface.md
+++ b/Resources/doc/definitions/type-system/interface.md
@@ -54,20 +54,25 @@ namespace MyBundle\GraphQL\Resolver;
 
 require_once __DIR__ . '/../../../../vendor/webonyx/graphql-php/tests/StarWarsData.php';
 
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use GraphQL\Tests\StarWarsData;
+use Overblog\GraphQLBundle\Resolver\TypeResolver;
 
-class CharacterResolver implements ContainerAwareInterface
+class CharacterResolver
 {
-    use ContainerAwareTrait;
+    /**
+     * @var TypeResolver
+     */
+    private $typeResolver;
+    
+    public function __construct(TypeResolver $typeResolver)
+    {
+        $this->typeResolver = $typeResolver;
+    }
     
     public function resolveType($data)
     {
-        $typeResolver = $this->container->get('overblog_graphql.type_resolver');
-    
-        $humanType = $typeResolver->resolve('Human');
-        $droidType = $typeResolver->resolve('Droid');
+        $humanType = $this->typeResolver->resolve('Human');
+        $droidType = $this->typeResolver->resolve('Droid');
         
         $humans = StarWarsData::humans();
         $droids = StarWarsData::droids();


### PR DESCRIPTION
In ``services.yml`` the type resolver is an argument, but ``CharacterResolver`` doesn't have a ``__construct`` to handle that argument. It does work, because ``CharacterResolver`` is container aware. Replacing container aware by a construct makes the class look nice and the example more clear.
