### PR TITLE
Fix hhvm travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: php
 
 branches:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Documented?   | no
| Fixed tickets | none
| License       | MIT

Fix this error HHVM is no longer supported on Ubuntu Precise. Please consider using Trusty with `dist: trusty`.
