### PR TITLE
Allow different methods of batching

### DIFF
--- a/Controller/GraphController.php
+++ b/Controller/GraphController.php
@@ -60,6 +60,7 @@ class GraphController extends Controller
     private function processBatchQuery(Request $request, $schemaName = null)
     {
         $queries = $this->get('overblog_graphql.request_batch_parser')->parse($request);
+        $apolloBatching = 'apollo' === $this->getParameter('overblog_graphql.batching_method');
         $payloads = [];
 
         foreach ($queries as $query) {
@@ -71,7 +72,7 @@ class GraphController extends Controller
                 [],
                 $schemaName
             );
-            $payloads[] = ['id' => $query['id'], 'payload' => $payloadResult->toArray()];
+            $payloads[] = $apolloBatching ? $payloadResult->toArray() : ['id' => $query['id'], 'payload' => $payloadResult->toArray()];
         }
 
         return $payloads;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -38,6 +38,10 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
+                ->enumNode('batching_method')
+                    ->values(['relay', 'apollo'])
+                    ->defaultValue('relay')
+                ->end()
                 ->arrayNode('definitions')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/DependencyInjection/OverblogGraphQLExtension.php
+++ b/DependencyInjection/OverblogGraphQLExtension.php
@@ -34,6 +34,7 @@ class OverblogGraphQLExtension extends Extension implements PrependExtensionInte
 
         $config = $this->treatConfigs($configs, $container);
 
+        $this->setBatchingMethod($config, $container);
         $this->setExpressionLanguageDefaultParser($container);
         $this->setServicesAliases($config, $container);
         $this->setSchemaBuilderArguments($config, $container);
@@ -74,6 +75,11 @@ class OverblogGraphQLExtension extends Extension implements PrependExtensionInte
     {
         $container->setParameter($this->getAlias().'.auto_mapping.enabled', $config['definitions']['auto_mapping']['enabled']);
         $container->setParameter($this->getAlias().'.auto_mapping.directories', $config['definitions']['auto_mapping']['directories']);
+    }
+
+    private function setBatchingMethod(array $config, ContainerBuilder $container)
+    {
+        $container->setParameter($this->getAlias().'.batching_method', $config['batching_method']);
     }
 
     private function setExpressionLanguageDefaultParser(ContainerBuilder $container)

--- a/Resources/doc/data-fetching/batching.md
+++ b/Resources/doc/data-fetching/batching.md
@@ -1,0 +1,19 @@
+# Query batching
+
+The bundle supports batching using [ReactRelayNetworkLayer](https://github.com/nodkz/react-relay-network-layer) or [Apollo GraphQL](http://dev.apollodata.com/core/network.html#query-batching) directly.
+To use batching, you must use "/batch" as a suffix to your graphql endpoint (see routing config). 
+Then you can switch between implementations in your configuration like so:
+
+For Relay (default value):
+```yaml
+overblog_graphql:
+    batching_method: "relay"
+```
+
+For Apollo:
+```yaml
+overblog_graphql:
+    batching_method: "apollo"
+```
+
+Done!

--- a/Resources/doc/data-fetching/index.md
+++ b/Resources/doc/data-fetching/index.md
@@ -1,6 +1,7 @@
 Data fetching
 =============
 
+* [Batching](batching.md)
 * [Promise](promise.md)
 
 Next step [secure your server](../security/index.md).

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -3,7 +3,7 @@ OverblogGraphQLBundle
 
 This Symfony 2 / 3 bundle provide integration [GraphQL](https://facebook.github.io/graphql/) using [webonyx/graphql-php](https://github.com/webonyx/graphql-php)
 and [GraphQL Relay](https://facebook.github.io/relay/docs/graphql-relay-specification.html).
-It also supports batching using libs like [ReactRelayNetworkLayer](https://github.com/nodkz/react-relay-network-layer).
+It also supports batching using libs like [ReactRelayNetworkLayer](https://github.com/nodkz/react-relay-network-layer) or [Apollo GraphQL](http://dev.apollodata.com/core/network.html#query-batching).
 
 Requirements
 ------------


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #163 
| License       | MIT

Makes the batching method configurable. Apollo just wants the plain payload without any id attached to it. Not sure how to properly test the code since it requires switching a config value at run-time which is not possible as I just found out..

```php
/**
 * @param $uri
 * @dataProvider graphQLBatchEndpointUriProvider
 */
public function testBatchEndpointApolloStyleAction($uri)
{
	$client = static::createClient(['test_case' => 'connection']);

	$data = [
		[
			'query' => $this->friendsQuery
		],
		[
			'query' => $this->friendsTotalCountQuery
		]
	];

	$client->request('POST', $uri, [], [], ['CONTENT_TYPE' => 'application/json'], json_encode($data));
	$result = $client->getResponse()->getContent();

	$expected = [
		['data' => $this->expectedData],
		['data' => ['user' => ['friends' => ['totalCount' => 4]]]]
	];
	$this->assertEquals($expected, json_decode($result, true), $result);
}
```