### PR TITLE
Disable MapClassLoader usage on php7

### DIFF
--- a/Generator/TypeGenerator.php
+++ b/Generator/TypeGenerator.php
@@ -210,10 +210,13 @@ CODE;
     public function loadClasses($forceReload = false)
     {
         if (!self::$classMapLoaded || $forceReload) {
-            $classes = require $this->getClassesMap();
 
-            $mapClassLoader = new MapClassLoader($classes);
-            $mapClassLoader->register();
+            if (PHP_VERSION_ID < 70000) {
+                $classes = require $this->getClassesMap();
+
+                $mapClassLoader = new MapClassLoader($classes);
+                $mapClassLoader->register();
+            }
 
             self::$classMapLoaded = true;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | 
| License       | MIT

Disable the usage of MapClassLoader for php7 as it has been deprecated and is unnecessary in php7. Removes the deprecated warning on latest versions of Symfony.

See http://symfony.com/blog/new-in-symfony-3-3-deprecated-the-classloader-component.
