### PR TITLE
Store totalCount in paginator

### DIFF
--- a/Relay/Connection/Output/Connection.php
+++ b/Relay/Connection/Output/Connection.php
@@ -19,6 +19,9 @@ final class Connection
     /** @var PageInfo */
     public $pageInfo;
 
+    /** @var int */
+    public $totalCount;
+
     public function __construct(array $edges, PageInfo $pageInfo)
     {
         $this->edges = $edges;

--- a/Tests/Relay/Connection/PaginatorTest.php
+++ b/Tests/Relay/Connection/PaginatorTest.php
@@ -294,7 +294,10 @@ class PaginatorTest extends \PHPUnit_Framework_TestCase
             ->getMock()
         ;
 
-        $promise->expects($this->once())->method('then');
+        $promise
+            ->expects($this->exactly(2))
+            ->method('then')
+            ->willReturnSelf();
 
         $paginator = new Paginator(function ($offset, $limit) use ($promise) {
             $this->assertSame(0, $offset);

--- a/Tests/Relay/Connection/PaginatorTest.php
+++ b/Tests/Relay/Connection/PaginatorTest.php
@@ -279,6 +279,8 @@ class PaginatorTest extends \PHPUnit_Framework_TestCase
             ['array' => $this->data]
         );
 
+        $this->assertSame(count($this->data), $result->totalCount);
+
         $this->assertCount(4, $result->edges);
         $this->assertSameEdgeNodeValue(['B', 'C', 'D', 'E'], $result);
         $this->assertTrue($result->pageInfo->hasPreviousPage);


### PR DESCRIPTION
WIP, waiting for your feedback and tests to be fixed

This PR adds a way to store the total count (if possible, so only via the `auto` method of the Paginator object).

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no yet, waiting feedback first
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
