### PR TITLE
Add support for schema typeLoader

### DIFF
--- a/Definition/Builder/SchemaBuilder.php
+++ b/Definition/Builder/SchemaBuilder.php
@@ -47,7 +47,8 @@ class SchemaBuilder
             'query' => $query,
             'mutation' => $mutation,
             'subscription' => $subscription,
-            'types' => $this->typeResolver->getSolutions(),
+            'typeLoader' => [$this->typeResolver, 'resolve'],
+            'types' => [$this->typeResolver, 'getSolutions'],
         ]);
         if ($this->enableValidation) {
             $schema->assertValid();

--- a/DependencyInjection/Compiler/TaggedServiceMappingPass.php
+++ b/DependencyInjection/Compiler/TaggedServiceMappingPass.php
@@ -61,7 +61,9 @@ abstract class TaggedServiceMappingPass implements CompilerPassInterface
             $cleanOptions = $options;
             $solutionID = $options['id'];
 
-            $solutionDefinition = $container->findDefinition($options['id']);
+            $solutionDefinition = $container->findDefinition($solutionID);
+            // make solution service public to improve lazy loading
+            $solutionDefinition->setPublic(true);
 
             $methods = array_map(
                 function ($methodCall) {
@@ -80,7 +82,10 @@ abstract class TaggedServiceMappingPass implements CompilerPassInterface
                 $solutionDefinition->addMethodCall('setContainer', [new Reference('service_container')]);
             }
 
-            $resolverDefinition->addMethodCall('addSolution', [$name, new Reference($solutionID), $cleanOptions]);
+            $resolverDefinition->addMethodCall(
+                'addSolution',
+                [$name, [new Reference('service_container'), 'get'], [$solutionID],  $cleanOptions]
+            );
         }
     }
 

--- a/Resolver/ResolverInterface.php
+++ b/Resolver/ResolverInterface.php
@@ -15,7 +15,7 @@ interface ResolverInterface
 {
     public function resolve($input);
 
-    public function addSolution($name, $solution, $extraOptions = []);
+    public function addSolution($name, callable $solutionFunc, array $solutionFuncArgs = [], array $options = []);
 
     public function getSolution($name);
 

--- a/Resolver/TypeResolver.php
+++ b/Resolver/TypeResolver.php
@@ -43,11 +43,6 @@ class TypeResolver extends AbstractResolver
             $type = $this->string2Type($alias);
             $item->set($type);
             $this->cacheAdapter->save($item);
-
-            // also add solution with real type name if needed for typeLoader when using autoMapping
-            if ($type && !isset($this->getSolutions()[$type->name])) {
-                $this->addSolution($type->name, $type);
-            }
         }
 
         return $item->get();
@@ -102,6 +97,16 @@ class TypeResolver extends AbstractResolver
         }
 
         return false;
+    }
+
+    protected function postLoadSolution($solution)
+    {
+        // also add solution with real type name if needed for typeLoader when using autoMapping
+        if ($solution && !isset($this->getSolutions()[$solution->name])) {
+            $this->addSolution($solution->name, function () use ($solution) {
+                return $solution;
+            });
+        }
     }
 
     protected function supportedSolutionClass()

--- a/Resolver/TypeResolver.php
+++ b/Resolver/TypeResolver.php
@@ -40,8 +40,14 @@ class TypeResolver extends AbstractResolver
         $item = $this->cacheAdapter->getItem(md5($alias));
 
         if (!$item->isHit()) {
-            $item->set($this->string2Type($alias));
+            $type = $this->string2Type($alias);
+            $item->set($type);
             $this->cacheAdapter->save($item);
+
+            // also add solution with real type name if needed for typeLoader when using autoMapping
+            if ($type && !isset($this->getSolutions()[$type->name])) {
+                $this->addSolution($type->name, $type);
+            }
         }
 
         return $item->get();

--- a/Tests/Functional/App/config/global/config.yml
+++ b/Tests/Functional/App/config/global/config.yml
@@ -12,6 +12,7 @@ services:
 
 overblog_graphql:
     definitions:
+        config_validation: false
         schema:
             query: Query
             mutation: ~

--- a/Tests/Resolver/AbstractProxyResolverTest.php
+++ b/Tests/Resolver/AbstractProxyResolverTest.php
@@ -16,8 +16,13 @@ abstract class AbstractProxyResolverTest extends AbstractResolverTest
     protected function getResolverSolutionsMapping()
     {
         return [
-            'Toto' => ['solution' => new Toto(), 'method' => 'resolve'],
+            'Toto' => ['solutionFunc' => [$this, 'createToto'], 'solutionFuncArgs' => [],  'method' => 'resolve'],
         ];
+    }
+
+    public function createToto()
+    {
+        return new Toto();
     }
 
     public function testResolveKnownMutation()

--- a/Tests/Resolver/AbstractResolverTest.php
+++ b/Tests/Resolver/AbstractResolverTest.php
@@ -27,7 +27,7 @@ abstract class AbstractResolverTest extends \PHPUnit_Framework_TestCase
         $this->resolver = $this->createResolver();
 
         foreach ($this->getResolverSolutionsMapping() as $name => $options) {
-            $this->resolver->addSolution($name, $options['solution'], $options);
+            $this->resolver->addSolution($name, $options['solutionFunc'], $options['solutionFuncArgs'], $options);
         }
     }
 }

--- a/Tests/Resolver/TypeResolverTest.php
+++ b/Tests/Resolver/TypeResolverTest.php
@@ -26,9 +26,14 @@ class TypeResolverTest extends AbstractResolverTest
     protected function getResolverSolutionsMapping()
     {
         return [
-            'Toto' => ['solution' => new ObjectType(['name' => 'Toto'])],
-            'Tata' => ['solution' => new ObjectType(['name' => 'Tata'])],
+            'Toto' => ['solutionFunc' => [$this, 'createObjectType'], 'solutionFuncArgs' => [['name' => 'Toto']]],
+            'Tata' => ['solutionFunc' => [$this, 'createObjectType'], 'solutionFuncArgs' => [['name' => 'Tata']]],
         ];
+    }
+
+    public function createObjectType(array $config)
+    {
+        return new ObjectType($config);
     }
 
     /**
@@ -37,7 +42,10 @@ class TypeResolverTest extends AbstractResolverTest
      */
     public function testAddNotSupportedSolution()
     {
-        $this->resolver->addSolution('not-supported', new \stdClass());
+        $this->resolver->addSolution('not-supported', function () {
+            return new \stdClass();
+        });
+        $this->resolver->getSolution('not-supported');
     }
 
     public function testResolveKnownType()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #184 
| License       | MIT

This change introduce lazy loading for `TypeResolver` but also for resolver and mutation... Unfortunately when enabling the schema validation with `assertValid` method the `config.types` is required because `config.typeLoader` does not provide any full loader method.

**edit**: [here is the solution](https://github.com/webonyx/graphql-php/issues/168)