### PR TITLE
symfony/class-loader dependency is now explicit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "doctrine/doctrine-cache-bundle": "^1.2",
         "overblog/graphql-php-generator": "^0.5.0",
         "symfony/cache": "^3.1",
+        "symfony/class-loader": "^2.8 || ^3.0",
         "symfony/expression-language": "^2.8 || ^3.0",
         "symfony/framework-bundle": "^2.8 || ^3.0",
         "symfony/options-resolver": "^2.8 || ^3.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| License       | MIT

I was installing the bundle using symfony flex, since it's declaring every dependency to be a minimal install this bundle couldn't work because class loader wasn't available. It's being used on TypeGenerator

This fixes the issue to install the bundle on symfony flex and also helps on a future deprecation of the library since it's going to be removed on symfony 4

