### PR TITLE
Compatible with PHP 7.2+ and PHPUnit 6+

### DIFF
--- a/Tests/Definition/ArgumentTest.php
+++ b/Tests/Definition/ArgumentTest.php
@@ -12,8 +12,9 @@
 namespace Overblog\GraphQLBundle\Tests\Definition;
 
 use Overblog\GraphQLBundle\Definition\Argument;
+use PHPUnit\Framework\TestCase;
 
-class ArgumentTest extends \PHPUnit_Framework_TestCase
+class ArgumentTest extends TestCase
 {
     /**
      * @var array

--- a/Tests/DependencyInjection/Compiler/ResolverTaggedServiceMappingPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ResolverTaggedServiceMappingPassTest.php
@@ -13,13 +13,14 @@ namespace Overblog\GraphQLBundle\Tests\DependencyInjection\Compiler;
 
 use Overblog\GraphQLBundle\DependencyInjection\Compiler\ResolverTaggedServiceMappingPass;
 use Overblog\GraphQLBundle\Resolver\ResolverResolver;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
 /**
  * Class ResolverTaggedServiceMappingPassTest.
  */
-class ResolverTaggedServiceMappingPassTest extends \PHPUnit_Framework_TestCase
+class ResolverTaggedServiceMappingPassTest extends TestCase
 {
     /**
      * @var ContainerBuilder

--- a/Tests/DependencyInjection/OverblogGraphQLTypesExtensionTest.php
+++ b/Tests/DependencyInjection/OverblogGraphQLTypesExtensionTest.php
@@ -17,10 +17,11 @@ use Overblog\GraphQLBundle\Error\UserError;
 use Overblog\GraphQLBundle\Error\UserWarning;
 use Overblog\GraphQLBundle\Tests\DependencyInjection\Builder\PagerArgs;
 use Overblog\GraphQLBundle\Tests\DependencyInjection\Builder\RawIdField;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 
-class OverblogGraphQLTypesExtensionTest extends \PHPUnit_Framework_TestCase
+class OverblogGraphQLTypesExtensionTest extends TestCase
 {
     /**
      * @var ContainerBuilder

--- a/Tests/Error/ErrorHandlerTest.php
+++ b/Tests/Error/ErrorHandlerTest.php
@@ -18,8 +18,9 @@ use Overblog\GraphQLBundle\Error\ErrorHandler;
 use Overblog\GraphQLBundle\Error\UserError;
 use Overblog\GraphQLBundle\Error\UserErrors;
 use Overblog\GraphQLBundle\Error\UserWarning;
+use PHPUnit\Framework\TestCase;
 
-class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
+class ErrorHandlerTest extends TestCase
 {
     /** @var ErrorHandler */
     private $errorHandler;

--- a/Tests/Executor/Promise/Adapter/ReactPromiseAdapterTest.php
+++ b/Tests/Executor/Promise/Adapter/ReactPromiseAdapterTest.php
@@ -13,9 +13,10 @@ namespace Overblog\GraphQLBundle\Tests\Error;
 
 use GraphQL\Executor\Promise\Promise;
 use Overblog\GraphQLBundle\Executor\Promise\Adapter\ReactPromiseAdapter;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\PhpProcess;
 
-class ReactPromiseAdapterTest extends \PHPUnit_Framework_TestCase
+class ReactPromiseAdapterTest extends TestCase
 {
     /** @var ReactPromiseAdapter */
     private $adapter;

--- a/Tests/ExpressionLanguage/AuthorizationExpressionProviderTest.php
+++ b/Tests/ExpressionLanguage/AuthorizationExpressionProviderTest.php
@@ -13,9 +13,10 @@ namespace Overblog\GraphQLBundle\Tests\Error;
 
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionLanguage;
 use Overblog\GraphQLBundle\Tests\DIContainerMockTrait;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
-class AuthorizationExpressionProviderTest extends \PHPUnit_Framework_TestCase
+class AuthorizationExpressionProviderTest extends TestCase
 {
     use DIContainerMockTrait;
 

--- a/Tests/ExpressionLanguage/ConfigExpressionProviderTest.php
+++ b/Tests/ExpressionLanguage/ConfigExpressionProviderTest.php
@@ -13,8 +13,9 @@ namespace Overblog\GraphQLBundle\Tests\Error;
 
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionLanguage;
 use Overblog\GraphQLBundle\Tests\DIContainerMockTrait;
+use PHPUnit\Framework\TestCase;
 
-class ConfigExpressionProviderTest extends \PHPUnit_Framework_TestCase
+class ConfigExpressionProviderTest extends TestCase
 {
     use DIContainerMockTrait;
 

--- a/Tests/Functional/Controller/GraphControllerTest.php
+++ b/Tests/Functional/Controller/GraphControllerTest.php
@@ -209,7 +209,7 @@ EOF;
         $client->request('POST', $uri, [], [], ['CONTENT_TYPE' => 'application/json'], json_encode($data));
         $result = $client->getResponse()->getContent();
 
-        $expected  = [
+        $expected = [
             ['id' => 'friends', 'payload' => ['data' => $this->expectedData]],
             ['id' => 'friendsTotalCount', 'payload' => ['data' => ['user' => ['friends' => ['totalCount' => 4]]]]],
         ];

--- a/Tests/Relay/Connection/Output/AbstractConnectionBuilderTest.php
+++ b/Tests/Relay/Connection/Output/AbstractConnectionBuilderTest.php
@@ -14,8 +14,9 @@ namespace Overblog\GraphQLBundle\Tests\Relay\Connection\Output;
 use Overblog\GraphQLBundle\Relay\Connection\Output\Connection;
 use Overblog\GraphQLBundle\Relay\Connection\Output\Edge;
 use Overblog\GraphQLBundle\Relay\Connection\Output\PageInfo;
+use PHPUnit\Framework\TestCase;
 
-abstract class AbstractConnectionBuilderTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractConnectionBuilderTest extends TestCase
 {
     protected $letters = ['A', 'B', 'C', 'D', 'E'];
 

--- a/Tests/Relay/Connection/PaginatorTest.php
+++ b/Tests/Relay/Connection/PaginatorTest.php
@@ -15,8 +15,9 @@ use GraphQL\Executor\Promise\Promise;
 use Overblog\GraphQLBundle\Definition\Argument;
 use Overblog\GraphQLBundle\Relay\Connection\Output\Connection;
 use Overblog\GraphQLBundle\Relay\Connection\Paginator;
+use PHPUnit\Framework\TestCase;
 
-class PaginatorTest extends \PHPUnit_Framework_TestCase
+class PaginatorTest extends TestCase
 {
     protected $data = ['A', 'B', 'C', 'D', 'E'];
 

--- a/Tests/Relay/Mutation/MutationFieldDefinitionTest.php
+++ b/Tests/Relay/Mutation/MutationFieldDefinitionTest.php
@@ -12,8 +12,9 @@
 namespace Overblog\GraphQLBundle\Tests\Relay\Node;
 
 use Overblog\GraphQLBundle\Relay\Mutation\MutationFieldDefinition;
+use PHPUnit\Framework\TestCase;
 
-class MutationFieldDefinitionTest extends \PHPUnit_Framework_TestCase
+class MutationFieldDefinitionTest extends TestCase
 {
     /**
      * @var MutationFieldDefinition

--- a/Tests/Relay/Node/GlobalIdTest.php
+++ b/Tests/Relay/Node/GlobalIdTest.php
@@ -12,8 +12,9 @@
 namespace Overblog\GraphQLBundle\Tests\Relay\Node;
 
 use Overblog\GraphQLBundle\Relay\Node\GlobalId;
+use PHPUnit\Framework\TestCase;
 
-class GlobalIdTest extends \PHPUnit_Framework_TestCase
+class GlobalIdTest extends TestCase
 {
     public function testToGlobalId()
     {

--- a/Tests/Relay/Node/NodeFieldDefinitionTest.php
+++ b/Tests/Relay/Node/NodeFieldDefinitionTest.php
@@ -13,8 +13,9 @@ namespace Overblog\GraphQLBundle\Tests\Relay\Node;
 
 use Overblog\GraphQLBundle\GraphQL\Relay\Node\NodeFieldResolver;
 use Overblog\GraphQLBundle\Relay\Node\NodeFieldDefinition;
+use PHPUnit\Framework\TestCase;
 
-class NodeFieldDefinitionTest extends \PHPUnit_Framework_TestCase
+class NodeFieldDefinitionTest extends TestCase
 {
     /**
      * @var NodeFieldDefinition

--- a/Tests/Relay/Node/PluralIdentifyingRootFieldDefinitionTest.php
+++ b/Tests/Relay/Node/PluralIdentifyingRootFieldDefinitionTest.php
@@ -13,8 +13,9 @@ namespace Overblog\GraphQLBundle\Tests\Relay\Node;
 
 use Overblog\GraphQLBundle\GraphQL\Relay\Node\PluralIdentifyingRootFieldResolver;
 use Overblog\GraphQLBundle\Relay\Node\PluralIdentifyingRootFieldDefinition;
+use PHPUnit\Framework\TestCase;
 
-class PluralIdentifyingRootFieldDefinitionTest extends \PHPUnit_Framework_TestCase
+class PluralIdentifyingRootFieldDefinitionTest extends TestCase
 {
     /**
      * @var PluralIdentifyingRootFieldDefinition

--- a/Tests/Request/ExecutorTest.php
+++ b/Tests/Request/ExecutorTest.php
@@ -17,8 +17,9 @@ use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
 use Overblog\GraphQLBundle\Executor\Executor;
 use Overblog\GraphQLBundle\Request\Executor as RequestExecutor;
+use PHPUnit\Framework\TestCase;
 
-class ExecutorTest extends \PHPUnit_Framework_TestCase
+class ExecutorTest extends TestCase
 {
     /** @var RequestExecutor */
     private $executor;

--- a/Tests/Resolver/AbstractResolverTest.php
+++ b/Tests/Resolver/AbstractResolverTest.php
@@ -12,8 +12,9 @@
 namespace Overblog\GraphQLBundle\Tests\Resolver;
 
 use Overblog\GraphQLBundle\Resolver\AbstractResolver;
+use PHPUnit\Framework\TestCase;
 
-abstract class AbstractResolverTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractResolverTest extends TestCase
 {
     /** @var AbstractResolver */
     protected $resolver;

--- a/Tests/Resolver/ResolverTest.php
+++ b/Tests/Resolver/ResolverTest.php
@@ -13,8 +13,9 @@ namespace Overblog\GraphQLBundle\Tests\Resolver;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use Overblog\GraphQLBundle\Resolver\Resolver;
+use PHPUnit\Framework\TestCase;
 
-class ResolverTest extends \PHPUnit_Framework_TestCase
+class ResolverTest extends TestCase
 {
     /**
      * @param $fieldName

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^1.11",
-        "phpunit/phpunit": "^4.1 || ^5.5",
+        "phpunit/phpunit": "^4.1 || ^5.5 || ^6.0",
         "react/promise": "^2.5",
         "sensio/framework-extra-bundle": "^3.0",
         "sllh/php-cs-fixer-styleci-bridge": "^1.5",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| License       | MIT

The current nightly building is failing because on PHP 7.2+ the function each is deprecated, this one is being used on phpunit 4 and 5.
By upgrading phpunit to 6 the build will normally run on php 7.2+
The change which is regards to the TestCase class still works on phpunit 4, thus making sure no BC break is introduced

![screenshot from 2017-09-18 14-19-12](https://user-images.githubusercontent.com/823634/30541584-62c8d48a-9c7c-11e7-90a8-4136708e034c.png)
