### PR TITLE
Improving Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
         - php: 5.5
           env: SYMFONY_VERSION=2.8.*
         - php: 5.6
-          env: SYMFONY_VERSION=3.1.*
+          env: SYMFONY_VERSION=3.1.* PHPUNIT_FLAGS="-d xdebug.max_nesting_level=1000 --coverage-clover=build/logs/clover.xml"
         - php: 7.0
           env: SYMFONY_VERSION=3.2.*
         - php: 7.1
@@ -32,10 +32,10 @@ before_install:
     - composer selfupdate
     - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" "symfony/framework-bundle:${SYMFONY_VERSION}" --dev --no-update; fi;
 
-install: composer update --prefer-dist --no-interaction
+install: composer update --prefer-dist --no-interaction --optimize-autoloader
 
 script:
-    - if [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then bin/phpunit -d xdebug.max_nesting_level=1000 --debug --coverage-clover=build/logs/clover.xml; else bin/phpunit --debug; fi
+    - bin/phpunit --debug ${PHPUNIT_FLAGS}
     - if [ "$TRAVIS_PHP_VERSION" == "7.0" ]; then bin/php-cs-fixer fix --diff --dry-run -v; fi;
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,11 @@ cache:
         - $HOME/.php_cs.cache
 
 before_install:
-    - if [[ "$TRAVIS_PHP_VERSION" != "5.6" && "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini || true; fi
+    - if [[ "$TRAVIS_PHP_VERSION" != "7.1" && "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini || true; fi
     - composer selfupdate
     - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" "symfony/framework-bundle:${SYMFONY_VERSION}" --dev --no-update; fi;
 
-install: composer update --prefer-dist --no-interaction --optimize-autoloader
+install: composer update --prefer-source --no-interaction --optimize-autoloader
 
 script:
     - bin/phpunit --debug ${PHPUNIT_FLAGS}

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ matrix:
         - php: 5.5
           env: SYMFONY_VERSION=2.8.*
         - php: 5.6
-          env: SYMFONY_VERSION=3.1.* PHPUNIT_FLAGS="-d xdebug.max_nesting_level=1000 --coverage-clover=build/logs/clover.xml"
+          env: SYMFONY_VERSION=3.1.*
         - php: 7.0
           env: SYMFONY_VERSION=3.2.*
         - php: 7.1
-          env: SYMFONY_VERSION=3.3.*
+          env: SYMFONY_VERSION=3.3.* PHPUNIT_FLAGS="-d xdebug.max_nesting_level=1000 --coverage-clover=build/logs/clover.xml"
         - php: hhvm
         - php: nightly
     allow_failures:
@@ -26,6 +26,7 @@ matrix:
 cache:
     directories:
         - $HOME/.composer/cache
+        - $HOME/.php_cs.cache
 
 before_install:
     - if [[ "$TRAVIS_PHP_VERSION" != "5.6" && "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini || true; fi
@@ -39,5 +40,5 @@ script:
     - if [ "$TRAVIS_PHP_VERSION" == "7.0" ]; then bin/php-cs-fixer fix --diff --dry-run -v; fi;
 
 after_script:
-    - if [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml; fi
-    - if [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then composer require "satooshi/php-coveralls:^1.0" && travis_retry php bin/coveralls -v; fi
+    - if [ "$TRAVIS_PHP_VERSION" == "7.1" ]; then wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml; fi
+    - if [ "$TRAVIS_PHP_VERSION" == "7.1" ]; then composer require "satooshi/php-coveralls:^1.0" && travis_retry php bin/coveralls -v; fi


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| License       | MIT

- Making travis file more readable within `script` test
- Using composer optimized autoloader for faster builds

Suggestions:
- Use `perfer-source` on composer, since we're saving composer cache by using the git repo it'll checkout the code faster, should I do it?
- Wouldn't be better to make the coverage under php 7+ due to performance?
- What about caching .php_cs.cache? It will always check for the updated files anyway