### PR TITLE
Using current Twig namespace on configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -135,7 +135,7 @@ class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->scalarNode('graphiql')
-                            ->defaultValue('OverblogGraphQLBundle:GraphiQL:index.html.twig')
+                            ->defaultValue('@OverblogGraphQL/GraphiQL/index.html.twig')
                         ->end()
                     ->end()
                 ->end()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes/no
| Deprecations? | no
| Tests pass?   | yes/no
| Documented?   | no
| License       | MIT

- Updated to use the current way twig understands namespaces: https://symfony.com/doc/current/templating/namespaced_paths.html
- This will contribute for future SF 4.0 support

Quote from docs:

> In the past, Symfony used a different syntax to refer to templates. This format, which uses colons (:) to separate each template path section, is less consistent and has worse performance than the Twig syntax.

