### PR TITLE
Supporting webonyx/graphql-php ^0.11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
           env: SYMFONY_VERSION=3.2.*
         - php: 7.1
           env: SYMFONY_VERSION=3.3.* PHPUNIT_FLAGS="-d xdebug.max_nesting_level=1000 --coverage-clover=build/logs/clover.xml"
+        - php: 7.1
+          env: GRAPHQLPHP_VERSION=0.10.0
         - php: hhvm
         - php: nightly
     allow_failures:
@@ -32,6 +34,7 @@ before_install:
     - if [[ "$TRAVIS_PHP_VERSION" != "7.1" && "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini || true; fi
     - composer selfupdate
     - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" "symfony/framework-bundle:${SYMFONY_VERSION}" --dev --no-update; fi;
+    - if [ "$GRAPHQLPHP_VERSION" != "" ]; then composer require "webonyx/graphql-php:${GRAPHQLPHP_VERSION}" --dev --no-update; fi;
 
 install: composer update --prefer-source --no-interaction --optimize-autoloader
 

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "symfony/framework-bundle": "^2.8 || ^3.0",
         "symfony/options-resolver": "^2.8 || ^3.0",
         "symfony/property-access": "^2.8 || ^3.0",
-        "webonyx/graphql-php": "^0.10.1"
+        "webonyx/graphql-php": "^0.10.0 || ^0.11.0"
     },
     "suggest": {
         "nelmio/cors-bundle": "For more flexibility when using CORS prefight",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #193
| License       | MIT

It's still a bit restrictive, but as I can see there is no branch for 0.12. I suggest to keep an eye on the library release cycle and try to align it.
Since their objective is to keep versioning in sync with the JS library wouldn't be hard to keep track of it