### PR TITLE
Remove autowiring deprecation warning

### DIFF
--- a/DependencyInjection/Compiler/AutowiringTypesPass.php
+++ b/DependencyInjection/Compiler/AutowiringTypesPass.php
@@ -14,6 +14,7 @@ namespace Overblog\GraphQLBundle\DependencyInjection\Compiler;
 use GraphQL\Executor\Promise\PromiseAdapter;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
 
 class AutowiringTypesPass implements CompilerPassInterface
 {
@@ -24,6 +25,9 @@ class AutowiringTypesPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $container->findDefinition('overblog_graphql.promise_adapter')->setAutowiringTypes([PromiseAdapter::class]);
+        version_compare(Kernel::VERSION, '3.3.0', '>=') ?
+            $container->setAlias(PromiseAdapter::class, 'overblog_graphql.promise_adapter') :
+            $container->findDefinition('overblog_graphql.promise_adapter')->setAutowiringTypes([PromiseAdapter::class])
+        ;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Documented?   | no
| Fixed tickets | #204 
| License       | MIT

this remove deprecation message (`Autowiring-types are deprecated since Symfony 3.3 and will be removed in 4.0. Use aliases instead.`)
