### PR TITLE
Refactor Commands to be services

### DIFF
--- a/Command/DebugCommand.php
+++ b/Command/DebugCommand.php
@@ -2,16 +2,45 @@
 
 namespace Overblog\GraphQLBundle\Command;
 
+use Overblog\GraphQLBundle\Resolver\MutationResolver;
 use Overblog\GraphQLBundle\Resolver\ResolverInterface;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Overblog\GraphQLBundle\Resolver\ResolverResolver;
+use Overblog\GraphQLBundle\Resolver\TypeResolver;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-class DebugCommand extends ContainerAwareCommand
+class DebugCommand extends Command
 {
     private static $categories = ['type', 'mutation', 'resolver'];
+
+    /**
+     * @var TypeResolver
+     */
+    private $typeResolver;
+
+    /**
+     * @var MutationResolver
+     */
+    private $mutationResolver;
+
+    /**
+     * @var ResolverResolver
+     */
+    private $resolverResolver;
+
+    public function __construct(
+        TypeResolver $typeResolver,
+        MutationResolver $mutationResolver,
+        ResolverResolver $resolverResolver
+    ) {
+        parent::__construct();
+        $this->typeResolver = $typeResolver;
+        $this->mutationResolver = $mutationResolver;
+        $this->resolverResolver = $resolverResolver;
+    }
 
     protected function configure()
     {
@@ -42,8 +71,10 @@ class DebugCommand extends ContainerAwareCommand
         $tableHeaders = ['id', 'aliases'];
         foreach ($categories as $category) {
             $io->title(sprintf('GraphQL %ss Services', ucfirst($category)));
+
             /** @var ResolverInterface $resolver */
-            $resolver = $this->getContainer()->get(sprintf('overblog_graphql.%s_resolver', $category));
+            $resolver = $this->{$category.'Resolver'};
+
             $solutions = $this->retrieveSolutions($resolver);
             $this->renderTable($tableHeaders, $solutions, $io);
         }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -113,3 +113,13 @@ services:
             - "%kernel.root_dir%"
         tags:
             - { name: console.command }
+
+    overblog_graphql.command.debug:
+        class: Overblog\GraphQLBundle\Command\DebugCommand
+        public: false
+        arguments:
+            - "@overblog_graphql.type_resolver"
+            - "@overblog_graphql.mutation_resolver"
+            - "@overblog_graphql.resolver_resolver"
+        tags:
+            - { name: console.command }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -103,3 +103,13 @@ services:
             - "@overblog_graphql.request_parser"
             - "%overblog_graphql.handle_cors%"
             - "%overblog_graphql.batching_method%"
+
+    overblog_graphql.command.dump_schema:
+        class: Overblog\GraphQLBundle\Command\GraphQLDumpSchemaCommand
+        public: false
+        arguments:
+            - "@overblog_graphql.request_executor"
+            - "%overblog_graphql.versions.relay%"
+            - "%kernel.root_dir%"
+        tags:
+            - { name: console.command }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -106,7 +106,6 @@ services:
 
     overblog_graphql.command.dump_schema:
         class: Overblog\GraphQLBundle\Command\GraphQLDumpSchemaCommand
-        public: false
         arguments:
             - "@overblog_graphql.request_executor"
             - "%overblog_graphql.versions.relay%"
@@ -116,7 +115,6 @@ services:
 
     overblog_graphql.command.debug:
         class: Overblog\GraphQLBundle\Command\DebugCommand
-        public: false
         arguments:
             - "@overblog_graphql.type_resolver"
             - "@overblog_graphql.mutation_resolver"

--- a/Tests/Functional/Command/DebugCommandTest.php
+++ b/Tests/Functional/Command/DebugCommandTest.php
@@ -26,9 +26,9 @@ class DebugCommandTest extends TestCase
         $kernel = $client->getKernel();
 
         $application = new Application($kernel);
-        $application->add(new DebugCommand());
         $this->command = $application->find('graphql:debug');
         $this->commandTester = new CommandTester($this->command);
+
         foreach (DebugCommand::getCategories() as $category) {
             $this->logs[$category] = trim(
                 file_get_contents(

--- a/Tests/Functional/Command/GraphDumpSchemaCommandTest.php
+++ b/Tests/Functional/Command/GraphDumpSchemaCommandTest.php
@@ -3,7 +3,6 @@
 namespace Overblog\GraphQLBundle\Tests\Functional\Command;
 
 use Overblog\GraphQLBundle\Tests\Functional\TestCase;
-use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -21,13 +20,11 @@ class GraphDumpSchemaCommandTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $client = static::createClient(['test_case' => 'connection']);
-        $kernel = $client->getKernel();
+        static::bootKernel(['test_case' => 'connection']);
 
-        $application = new Application($kernel);
-        $this->command = $application->find('graphql:dump-schema');
+        $this->command = static::$kernel->getContainer()->get('overblog_graphql.command.dump_schema');
         $this->commandTester = new CommandTester($this->command);
-        $this->cacheDir = $kernel->getCacheDir();
+        $this->cacheDir = static::$kernel->getCacheDir();
     }
 
     /**
@@ -40,7 +37,6 @@ class GraphDumpSchemaCommandTest extends TestCase
         $file = $this->cacheDir.'/schema.'.$format;
 
         $input = [
-            'command' => $this->command->getName(),
             '--file' => $file,
         ];
 
@@ -60,7 +56,6 @@ class GraphDumpSchemaCommandTest extends TestCase
         $file = $this->cacheDir.'/schema.json';
         $this->assertCommandExecution(
             [
-                'command' => $this->command->getName(),
                 '--file' => $file,
                 '--classic' => true,
                 '--format' => 'json',
@@ -76,7 +71,6 @@ class GraphDumpSchemaCommandTest extends TestCase
         $file = $this->cacheDir.'/schema.json';
         $this->assertCommandExecution(
             [
-                'command' => $this->command->getName(),
                 '--file' => $file,
                 '--modern' => true,
                 '--format' => 'json',
@@ -94,7 +88,6 @@ class GraphDumpSchemaCommandTest extends TestCase
     public function testInvalidFormat()
     {
         $this->commandTester->execute([
-            'command' => $this->command->getName(),
             '--format' => 'fake',
         ]);
     }
@@ -106,7 +99,6 @@ class GraphDumpSchemaCommandTest extends TestCase
     public function testInvalidModernAndClassicUsedTogether()
     {
         $this->commandTester->execute([
-            'command' => $this->command->getName(),
             '--format' => 'json',
             '--classic' => true,
             '--modern' => true,

--- a/Tests/Functional/Command/GraphDumpSchemaCommandTest.php
+++ b/Tests/Functional/Command/GraphDumpSchemaCommandTest.php
@@ -2,7 +2,6 @@
 
 namespace Overblog\GraphQLBundle\Tests\Functional\Command;
 
-use Overblog\GraphQLBundle\Command\GraphQLDumpSchemaCommand;
 use Overblog\GraphQLBundle\Tests\Functional\TestCase;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Command\Command;
@@ -26,7 +25,6 @@ class GraphDumpSchemaCommandTest extends TestCase
         $kernel = $client->getKernel();
 
         $application = new Application($kernel);
-        $application->add(new GraphQLDumpSchemaCommand());
         $this->command = $application->find('graphql:dump-schema');
         $this->commandTester = new CommandTester($this->command);
         $this->cacheDir = $kernel->getCacheDir();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | fixes some deprecations
| Tests pass?   | yes
| Documented?   | no
| License       | MIT

- Now all commands can be services
- When using the services in the tests avoids the commands auto registering, removing 14 deprecation warnings from the tests
- Using services allows the users to take over or change services by their desires using compiler passes