### PR TITLE
Add info that type folders include sub-folders

### DIFF
--- a/Resources/doc/definitions/type-system/index.md
+++ b/Resources/doc/definitions/type-system/index.md
@@ -29,7 +29,7 @@ Types can be define 3 different ways:
                 types:
                     -
                         type: yaml # or xml or null
-                        dir: "%kernel.root_dir%/.../mapping"
+                        dir: "%kernel.root_dir%/.../mapping" # sub directories are also searched
                         # suffix: .types # use to change default file suffix
     ```
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #216 
| License       | MIT

Just adding documentation saying that type folders include sub-folders.
