### PR TITLE
Finding and testing lowest possible versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,13 @@ matrix:
     fast_finish: true
     include:
         - php: 5.6
-          env: SYMFONY_VERSION=3.1.*
+          env: COMPOSER_UPDATE_FLAGS=--prefer-lowest SYMFONY_DEPRECATIONS_HELPER=disabled
+        - php: 5.6
+          env: SYMFONY_VERSION=3.1.* SYMFONY_DEPRECATIONS_HELPER=disabled
         - php: 7.0
           env: SYMFONY_VERSION=3.2.*
+        - php: 7.1
+          env: PHP_CS_FIXER=true
         - php: 7.1
           env: SYMFONY_VERSION=3.3.* TEST_COVERAGE=true
         - php: 7.1
@@ -33,9 +37,10 @@ cache:
     directories:
         - $HOME/.composer/cache
         - $HOME/.php_cs.cache
+        - vendor/
 
 before_install:
-    - if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
+    - if [ ${DEPENDENCIES} = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
     - if [ ${TEST_COVERAGE} != true ]; then phpenv config-rm xdebug.ini || true; fi
     - composer selfupdate
     - if [ $SYMFONY_VERSION ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --dev --no-update; fi;
@@ -45,7 +50,7 @@ install: composer update --prefer-source --no-interaction --optimize-autoloader 
 
 script:
     - bin/phpunit --debug $( if [ $TEST_COVERAGE = true ]; then echo "-d xdebug.max_nesting_level=1000 --coverage-clover=build/logs/clover.xml"; fi; )
-    - if [ ${TRAVIS_PHP_VERSION} == "7.0" ]; then composer require --dev 'friendsofphp/php-cs-fixer:^2.0' && bin/php-cs-fixer fix --diff --dry-run -v; fi;
+    - if [ ${PHP_CS_FIXER} = true ]; then composer require --dev 'friendsofphp/php-cs-fixer:^2.0' && bin/php-cs-fixer fix --diff --dry-run -v; fi;
 
 after_script:
     - if [ ${TEST_COVERAGE} = true ]; then wget https://scrutinizer-ci.com/ocular.phar && travis_retry php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml; fi

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "react/promise": "To use ReactPHP promise adapter"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.1 || ^5.5 || ^6.0",
+        "phpunit/phpunit": "^5.5 || ^6.0",
         "react/promise": "^2.5",
         "sensio/framework-extra-bundle": "^3.0",
         "symfony/asset": "^3.1 || ^4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| License       | MIT

- Trying to find out the lowest possible versions the bundle is compatible with
- Slight improves on travis build

----- OLD
- Sadly we don't support expression language 3.1
- Check it's constructor: https://github.com/symfony/symfony/blob/v3.1.10/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php#L38
- Now on version 3.2: https://github.com/symfony/symfony/blob/v3.2.0/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php#L40

And that's how we use it, as on 3.2: https://github.com/overblog/GraphQLBundle/blob/v0.9.2/ExpressionLanguage/ExpressionLanguage.php#L26
