### PR TITLE
add inheritance exception mapping option

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -121,6 +121,7 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                         ->end()
+                        ->booleanNode('map_exceptions_to_parent')->defaultFalse()->end()
                         ->arrayNode('exceptions')
                             ->addDefaultsIfNotSet()
                             ->children()

--- a/DependencyInjection/OverblogGraphQLExtension.php
+++ b/DependencyInjection/OverblogGraphQLExtension.php
@@ -181,6 +181,13 @@ class OverblogGraphQLExtension extends Extension implements PrependExtensionInte
             $errorHandlerDefinition->replaceArgument(0, $config['definitions']['internal_error_message']);
         }
 
+        if (isset($config['definitions']['map_exceptions_to_parent'])) {
+            $errorHandlerDefinition->replaceArgument(
+                3,
+                $config['definitions']['map_exceptions_to_parent']
+            );
+        }
+
         if (isset($config['definitions']['exceptions'])) {
             $errorHandlerDefinition
                 ->replaceArgument(2, $this->buildExceptionMap($config['definitions']['exceptions']))

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -9,6 +9,7 @@ services:
             - ~
             - "@?logger"
             - []
+            - false
 
     overblog_graphql.executor.default:
         class: Overblog\GraphQLBundle\Executor\Executor

--- a/Resources/doc/security/errors-handling.md
+++ b/Resources/doc/security/errors-handling.md
@@ -108,6 +108,9 @@ overblog_graphql:
     #... 
     definitions:
         #...
+        # change to true to try to map an exception to a parent exception if the exact exception is not in 
+        # the mapping
+        map_exceptions_to_parent: false
         exceptions:
             warnings:
                 - "Symfony\\Component\\Routing\\Exception\\ResourceNotFoundException"

--- a/Tests/Error/ChildOfInvalidArgumentException.php
+++ b/Tests/Error/ChildOfInvalidArgumentException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Overblog\GraphQLBundle\Tests\Error;
+
+use InvalidArgumentException;
+
+final class ChildOfInvalidArgumentException extends InvalidArgumentException
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| Fixed tickets | 
| License       | MIT

We would very much like to have the possibility of adding an exception to `overblog_graphql.definitions.exceptions.errors` and have its subclasses also be caught and handled by the ErrorHandler. (it would avoid us to explicitly add all exceptions to the config)

This PR adds an option to the config, to do exactly that.
