### PR TITLE
Bugfix: [Relay Pagination] Fixed query limit if no 'first' parameter set

### DIFF
--- a/Relay/Connection/Paginator.php
+++ b/Relay/Connection/Paginator.php
@@ -68,13 +68,13 @@ class Paginator
 
         // If we don't have a cursor or if it's not valid, then we must not use the slice method
         if (!is_numeric(ConnectionBuilder::cursorToOffset($args['after'])) || !$args['after']) {
-            $entities = call_user_func($this->fetcher, $offset, $limit + 1);
+            $entities = call_user_func($this->fetcher, $offset, $limit ? $limit + 1 : $limit);
 
             return $this->handleEntities($entities, function ($entities) use ($args) {
                 return ConnectionBuilder::connectionFromArray($entities, $args);
             });
         } else {
-            $entities = call_user_func($this->fetcher, $offset, $limit + 2);
+            $entities = call_user_func($this->fetcher, $offset, $limit ? $limit + 2 : $limit);
 
             return $this->handleEntities($entities, function ($entities) use ($args, $offset) {
                 return ConnectionBuilder::connectionFromArraySlice($entities, $args, [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | 
| License       | MIT

Currently with Relay pagination, if you don't include a `first` parameter in your query, your response will be limited to 1 result.

This is because the logic was, for instance: `$limit + 1`, so even if `$limit` was `null`, we'd still end up limiting to 1.
