### PR TITLE
Upgrade 0.11: Versions removal

### DIFF
--- a/UPGRADE-0.11.md
+++ b/UPGRADE-0.11.md
@@ -16,3 +16,21 @@ UPGRADE FROM 0.10 to 0.11
    - Installing OverblogGraphiQLBundle
      - `composer require --dev overblog/graphiql-bundle`
      - Follow instructions at https://github.com/overblog/GraphiQLBundle
+   - In case you have defined the `versions` in your configuration
+     - Remove it from `overblog_graphql`
+         ```diff
+         overblog_graphql:
+         -    versions:
+         -        graphiql: "0.11"
+         -        react: "15.6"
+         -        fetch: "2.0"
+         -        relay: "classic"
+         ```
+     - Add it to `overblog_graphiql`
+         ```diff
+         overblog_graphiql:
+         +    javascript_libraries:
+         +        graphiql: "0.11"
+         +        react: "15.6"
+         +        fetch: "2.0"
+        ```


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| License       | MIT

- Documenting the fact some graphiql versions were removed from the GraphQLBundle

How it looks like: https://github.com/renatomefi/overblog-GraphQLBundle/blob/documentation/upgrade-0.11-js-versions/UPGRADE-0.11.md