### PR TITLE
Documentation/Type inheritance: fix typo

### DIFF
--- a/Resources/doc/definitions/type-inheritance.md
+++ b/Resources/doc/definitions/type-inheritance.md
@@ -58,7 +58,7 @@ ObjectA:
             bar: {type: String!}
             bar2: {type: String!}
             bar3: {type: String!}
-            foo: {type: String!}
+            baz: {type: String!}
 
 ObjectC:
     type: object


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | x
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Hi, 

I found a mistake in the doc. 
If I understand correctly this new feature (great work btw), `ObjectA` extends from `InterfaceA` and `ObjectC`.

Since `ObjectC` has one field `baz`, and `InterfaceA` has those fields :
- `bar`
- `bar2`
- `bar3`

That means that `ObjectA` should have those fields right? :
- `baz`
- `bar`
- `bar2`
- `bar3`