### PR TITLE
Add description field to custom-scalar type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
         - php: 7.2
           env: SYMFONY_VERSION=3.3.*
         - php: 7.2
-          env: SYMFONY_VERSION=3.4.* GRAPHQLPHP_VERSION=0.10.0 DEPENDENCIES=dev
+          env: SYMFONY_VERSION=3.4.*
         - php: 7.2
           env: SYMFONY_VERSION=4.0.* TEST_COVERAGE=true
         - php: 7.2

--- a/Config/CustomScalarTypeDefinition.php
+++ b/Config/CustomScalarTypeDefinition.php
@@ -14,6 +14,7 @@ class CustomScalarTypeDefinition extends TypeDefinition
         $node
             ->children()
                 ->append($this->nameSection())
+                ->append($this->descriptionSection())
                 ->variableNode('serialize')->isRequired()->end()
                 ->variableNode('parseValue')->isRequired()->end()
                 ->variableNode('parseLiteral')->isRequired()->end()

--- a/Tests/Functional/App/config/customScalar/mapping/Query.types.yml
+++ b/Tests/Functional/App/config/customScalar/mapping/Query.types.yml
@@ -1,6 +1,7 @@
 DateTime:
     type: custom-scalar
     config:
+        description: "The DateTime type"
         serialize: ["Overblog\\GraphQLGenerator\\Tests\\DateTimeType", "serialize"]
         parseValue: ["Overblog\\GraphQLGenerator\\Tests\\DateTimeType", "parseValue"]
         parseLiteral: ["Overblog\\GraphQLGenerator\\Tests\\DateTimeType", "parseLiteral"]

--- a/Tests/Functional/Type/CustomScalarTest.php
+++ b/Tests/Functional/Type/CustomScalarTest.php
@@ -30,4 +30,10 @@ class CustomScalarTest extends TestCase
         ];
         $this->assertGraphQL($query, $expected);
     }
+
+    public function testDateTimeTypeDescription()
+    {
+        $dateTimeType = static::$kernel->getContainer()->get('overblog_graphql.type_resolver')->resolve('DateTime');
+        $this->assertEquals('The DateTime type', $dateTimeType->description);
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require": {
         "php": ">=5.6",
         "doctrine/doctrine-cache-bundle": "^1.2",
-        "overblog/graphql-php-generator": "^0.6.0",
+        "overblog/graphql-php-generator": "^0.7.0",
         "symfony/cache": "^3.1 || ^4.0",
         "symfony/config": "^3.1 || ^4.0",
         "symfony/dependency-injection": "^3.1 || ^4.0",
@@ -39,7 +39,7 @@
         "symfony/framework-bundle": "^3.1 || ^4.0",
         "symfony/options-resolver": "^3.1 || ^4.0",
         "symfony/property-access": "^3.1 || ^4.0",
-        "webonyx/graphql-php": "^0.10.0 || ^0.11.0"
+        "webonyx/graphql-php": "^0.11.2"
     },
     "suggest": {
         "nelmio/cors-bundle": "For more flexibility when using CORS prefight",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | 
| License       | MIT

When a new custom-scalar type defined we can't add description field to it. This patch add current functionality.
