### PR TITLE
use ParserInterface in GraphController constructor instead of parser classes

### DIFF
--- a/Controller/GraphController.php
+++ b/Controller/GraphController.php
@@ -35,9 +35,9 @@ class GraphController
     private $graphQLBatchingMethod;
 
     public function __construct(
-        GraphQLRequest\BatchParser $batchParser,
+        GraphQLRequest\ParserInterface $batchParser,
         GraphQLRequest\Executor $requestExecutor,
-        GraphQLRequest\Parser $requestParser,
+        GraphQLRequest\ParserInterface $requestParser,
         $shouldHandleCORS,
         $graphQLBatchingMethod
     ) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Documented?   | no
| Fixed tickets | 
| License       | MIT

Hi there.
I think using interfaces in __construct parameters will be better. I want to override parser but cannot do that without this changes.

Test not passed with and without my changes.
```
RuntimeException: Type class for alias "RootQuery" could not be load. If you are using your own classLoader verify the path and the namespace please.
Class 'Overblog\GraphQLBundle\Access\__DEFINITIONS__\RootQueryType' not found
```

```
ERRORS!
Tests: 254, Assertions: 492, Errors: 10.

Remaining deprecation notices (1)

Autowire custom tagged (type, resolver or mutation) services is deprecated as of 0.9 and will be removed in 1.0. Use AutoMapping or set it manually instead: 1x
    1x in ResolverTaggedServiceMappingPassTest::testCompilationWorksPassConfigDirective from Overblog\GraphQLBundle\Tests\DependencyInjection\Compiler
```

