### PR TITLE
Update « extends » to « inherits » in type inheritance documentation

### DIFF
--- a/Resources/doc/definitions/type-inheritance.md
+++ b/Resources/doc/definitions/type-inheritance.md
@@ -19,7 +19,7 @@ ObjectA:
     type: object
     # ObjectB inherited config (fields, args...) from ObjectA
     heirs: [ObjectB]
-    extends: [InterfaceA, ObjectC]
+    inherits: [InterfaceA, ObjectC]
 
 ObjectC:
     type: object


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | x
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

The old key `extends` was still used in an example.
And since it was removed for the key `inherits`, I just updated the example :man_shrugging: 