### PR TITLE
[Doc] ArgsBuilder: add missing lines in example

### DIFF
--- a/Resources/doc/definitions/builders/args.md
+++ b/Resources/doc/definitions/builders/args.md
@@ -72,22 +72,25 @@ this is equivalent to:
 
 ```yaml
 foo:
-    categories:
-        type: "[String!]!"
-        args:
-            limit:
-                type: "Int!"
-                defaultValue: 20
-            offset:
-                type: "Int!"
-                defaultValue: 0
-    categories2:
-        type: "[String!]!"
-        args:
-            limit:
-                type: "Int!"
-                defaultValue: 50
-            offset:
-                type: "Int!"
-                defaultValue: 0
+    type: "object"
+    config:
+        fields:
+            categories:
+                type: "[String!]!"
+                args:
+                    limit:
+                        type: "Int!"
+                        defaultValue: 20
+                    offset:
+                        type: "Int!"
+                        defaultValue: 0
+            categories2:
+                type: "[String!]!"
+                args:
+                    limit:
+                        type: "Int!"
+                        defaultValue: 50
+                    offset:
+                        type: "Int!"
+                        defaultValue: 0
 ```


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

In [Args Builder documentation](https://github.com/overblog/GraphQLBundle/blob/master/Resources/doc/definitions/builders/args.md), some lines were missing (`type:`, `config:` and `fields:`).