### PR TITLE
Impose explicit declaration of non detected types

### DIFF
--- a/Definition/Builder/SchemaBuilder.php
+++ b/Definition/Builder/SchemaBuilder.php
@@ -32,16 +32,17 @@ class SchemaBuilder
      * @param null|string            $mutationAlias
      * @param null|string            $subscriptionAlias
      * @param ResolverMapInterface[] $resolverMaps
+     * @param string[]               $types
      *
      * @return Schema
      */
-    public function create($queryAlias = null, $mutationAlias = null, $subscriptionAlias = null, array $resolverMaps = [])
+    public function create($queryAlias = null, $mutationAlias = null, $subscriptionAlias = null, array $resolverMaps = [], array $types = [])
     {
         $query = $this->typeResolver->resolve($queryAlias);
         $mutation = $this->typeResolver->resolve($mutationAlias);
         $subscription = $this->typeResolver->resolve($subscriptionAlias);
 
-        $schema = new Schema($this->buildSchemaArguments($query, $mutation, $subscription));
+        $schema = new Schema($this->buildSchemaArguments($query, $mutation, $subscription, $types));
         reset($resolverMaps);
         $this->decorator->decorate($schema, 1 === count($resolverMaps) ? current($resolverMaps) : new ResolverMaps($resolverMaps));
 
@@ -52,7 +53,7 @@ class SchemaBuilder
         return $schema;
     }
 
-    private function buildSchemaArguments(Type $query = null, Type $mutation = null, Type $subscription = null)
+    private function buildSchemaArguments(Type $query = null, Type $mutation = null, Type $subscription = null, array $types = [])
     {
         return [
             'query' => $query,
@@ -61,8 +62,8 @@ class SchemaBuilder
             'typeLoader' => function ($name) {
                 return $this->typeResolver->resolve($name);
             },
-            'types' => function () {
-                return $this->typeResolver->getSolutions();
+            'types' => function () use ($types) {
+                return array_map([$this->typeResolver, 'getSolution'], $types);
             },
         ];
     }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -200,6 +200,10 @@ class Configuration implements ConfigurationInterface
                         ->defaultValue([])
                         ->prototype('scalar')->end()
                     ->end()
+                    ->arrayNode('types')
+                        ->defaultValue([])
+                        ->prototype('scalar')->end()
+                    ->end()
                 ->end()
             ->end()
         ->end();

--- a/DependencyInjection/OverblogGraphQLExtension.php
+++ b/DependencyInjection/OverblogGraphQLExtension.php
@@ -235,6 +235,7 @@ class OverblogGraphQLExtension extends Extension implements PrependExtensionInte
                     array_map(function ($id) {
                         return new Reference($id);
                     }, $schemaConfig['resolver_maps']),
+                    $schemaConfig['types'],
                 ]);
                 $definition->setPublic(false);
                 $container->setDefinition($schemaID, $definition);

--- a/Resources/doc/definitions/relay/node/node.md
+++ b/Resources/doc/definitions/relay/node/node.md
@@ -37,3 +37,17 @@ User:
                 type: String
         interfaces: [Node]
 ```
+
+In above example `Photo` and `User` can't be detected by graphql-php during
+static schema analysis. That the reason why their should be explicitly declare
+in schema definition:
+
+```yaml
+overblog_graphql:
+    definitions:
+        schema:
+            query: Query
+            mutation: ~
+            # here how this can be done
+            types: [User, Photo]
+```

--- a/Resources/doc/definitions/schema.md
+++ b/Resources/doc/definitions/schema.md
@@ -69,6 +69,10 @@ overblog_graphql:
         schema:
             query: Query
             mutation: ~
+            # the name of extra types that can not be detected
+            # by graphql-php during static schema analysis.
+            # These types names should be explicitly declare here
+            types: []
 ```
 
 ## Batching

--- a/Tests/Functional/App/config/node/config.yml
+++ b/Tests/Functional/App/config/node/config.yml
@@ -17,6 +17,7 @@ overblog_graphql:
         schema:
             query: Query
             mutation: ~
+            types: [User, Photo]
         mappings:
             auto_discover: true
             types:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| Fixed tickets | none
| License       | MIT

### Explicitly declare non detected types

   **Before 0.11** all types was declare as non detected types, this was not the correct way of declaring types.
   This could lead to some performances issues or/and wrong types public exposition (in introspection query).
   [See webonyx/graphql-php documentations for more details](http://webonyx.github.io/graphql-php/type-system/schema/#configuration-options)

   **Since 0.11** Non detect types should be explicitly declare

   here a concrete example:
   ```yaml
   Query:
      type: object
      config:
         fields:
            foo: {type: FooInterface!}

   FooInterface:
      type: interface
      config:
         fields:
            id: {type: ID!}
         resolveType: '@=resolver("foo", [value])'

   Bar:
      type: object
      config:
         fields:
            id: {type: ID!}
            # ...
         interfaces: [FooInterface]

   Baz:
      type: object
      config:
         fields:
            id: {type: ID!}
            # ...
         interfaces: [FooInterface]
   ```
   In above example `Baz` an `Bar` can not be detected by graphql-php during static schema analysis,
   an `GraphQL\Error\InvariantViolation` exception will be throw with the following message:
   ```text
   Could not find possible implementing types for FooInterface in schema.
   Check that schema.types is defined and is an array of all possible types in the schema.
   ```
   here how this can be fix:

   ```yaml
   overblog_graphql:
      definitions:
         schema:
            query: Query
            types: [Bar, Baz]
   ```

