### PR TITLE
Improve fluent resolver aliases

### DIFF
--- a/Config/Processor/NamedConfigProcessor.php
+++ b/Config/Processor/NamedConfigProcessor.php
@@ -10,8 +10,9 @@ final class NamedConfigProcessor implements ProcessorInterface
     public static function process(array $configs)
     {
         foreach ($configs as $name => &$config) {
-            $config['config'] = isset($config['config']) && is_array($config['config']) ? $config['config'] : [];
-            $config['config']['name'] = $name;
+            if (empty($config['config']['name'])) {
+                $config['config']['name'] = $name;
+            }
         }
 
         return $configs;

--- a/Config/TypeDefinition.php
+++ b/Config/TypeDefinition.php
@@ -37,7 +37,7 @@ abstract class TypeDefinition
             ->ifTrue(function ($name) {
                 return !preg_match('/^[_a-z][_0-9a-z]*$/i', $name);
             })
-                ->thenInvalid('Invalid type name "%s". (see https://facebook.github.io/graphql/#Name)')
+                ->thenInvalid('Invalid type name "%s". (see http://facebook.github.io/graphql/October2016/#Name)')
         ->end();
 
         return $node;

--- a/DependencyInjection/Compiler/ConfigTypesPass.php
+++ b/DependencyInjection/Compiler/ConfigTypesPass.php
@@ -18,18 +18,16 @@ class ConfigTypesPass implements CompilerPassInterface
             ->compile(TypeGenerator::MODE_MAPPING_ONLY);
 
         foreach ($generatedClasses as $class => $file) {
-            $aliases = [preg_replace('/Type$/', '', substr(strrchr($class, '\\'), 1))];
-            $this->setTypeServiceDefinition($container, $class, $aliases);
+            $alias = preg_replace('/Type$/', '', substr(strrchr($class, '\\'), 1));
+            $this->setTypeServiceDefinition($container, $class, $alias);
         }
     }
 
-    private function setTypeServiceDefinition(ContainerBuilder $container, $class, array $aliases)
+    private function setTypeServiceDefinition(ContainerBuilder $container, $class, $alias)
     {
         $definition = $container->setDefinition($class, new Definition($class));
         $definition->setPublic(false);
         $definition->setArguments([new Reference(ConfigProcessor::class), new Reference(GlobalVariables::class)]);
-        foreach ($aliases as $alias) {
-            $definition->addTag(TypeTaggedServiceMappingPass::TAG_NAME, ['alias' => $alias, 'generated' => true]);
-        }
+        $definition->addTag(TypeTaggedServiceMappingPass::TAG_NAME, ['alias' => $alias, 'generated' => true]);
     }
 }

--- a/Resolver/FluentResolverInterface.php
+++ b/Resolver/FluentResolverInterface.php
@@ -6,11 +6,23 @@ interface FluentResolverInterface
 {
     public function resolve($input);
 
-    public function addSolution($name, callable $solutionFunc, array $solutionFuncArgs = [], array $options = []);
+    /**
+     * Add a solution to resolver.
+     *
+     * @param string      $id                the solution identifier
+     * @param array|mixed $solutionOrFactory the solution itself or array with a factory and it arguments if needed [$factory] or [$factory, $factoryArgs]
+     * @param string[]    $aliases           the solution aliases
+     * @param array       $options           extra options
+     *
+     * @return $this
+     */
+    public function addSolution($id, $solutionOrFactory, array $aliases = [], array $options = []);
 
-    public function getSolution($name);
+    public function getSolution($id);
 
     public function getSolutions();
 
-    public function getSolutionOptions($name);
+    public function getSolutionAliases($id);
+
+    public function getSolutionOptions($id);
 }

--- a/Tests/Functional/Command/fixtures/case-sensitive/debug-resolver.txt
+++ b/Tests/Functional/Command/fixtures/case-sensitive/debug-resolver.txt
@@ -5,14 +5,14 @@ GraphQL Resolvers Services
  ------------------------------------------------------------------------------ ------------------------------------------------------------------------------------------------- 
   id                                                                             aliases                                                                                          
  ------------------------------------------------------------------------------ ------------------------------------------------------------------------------------------------- 
-  Overblog\GraphQLBundle\GraphQL\Relay\Mutation\MutationFieldResolver            Overblog\GraphQLBundle\GraphQL\Relay\Mutation\MutationFieldResolver (method: __invoke)           
-                                                                                 relay_mutation_field (method: __invoke)                                                          
-  Overblog\GraphQLBundle\GraphQL\Relay\Node\GlobalIdFieldResolver                Overblog\GraphQLBundle\GraphQL\Relay\Node\GlobalIdFieldResolver (method: __invoke)               
-                                                                                 relay_globalid_field (method: __invoke)                                                          
-  Overblog\GraphQLBundle\GraphQL\Relay\Node\NodeFieldResolver                    Overblog\GraphQLBundle\GraphQL\Relay\Node\NodeFieldResolver (method: __invoke)                   
-                                                                                 relay_node_field (method: __invoke)                                                              
-  Overblog\GraphQLBundle\GraphQL\Relay\Node\PluralIdentifyingRootFieldResolver   Overblog\GraphQLBundle\GraphQL\Relay\Node\PluralIdentifyingRootFieldResolver (method: __invoke)  
-                                                                                 relay_plural_identifying_field (method: __invoke)                                                
+  Overblog\GraphQLBundle\GraphQL\Relay\Mutation\MutationFieldResolver            relay_mutation_field (method: __invoke)                                                          
+                                                                                 Overblog\GraphQLBundle\GraphQL\Relay\Mutation\MutationFieldResolver (method: __invoke)           
+  Overblog\GraphQLBundle\GraphQL\Relay\Node\GlobalIdFieldResolver                relay_globalid_field (method: __invoke)                                                          
+                                                                                 Overblog\GraphQLBundle\GraphQL\Relay\Node\GlobalIdFieldResolver (method: __invoke)               
+  Overblog\GraphQLBundle\GraphQL\Relay\Node\NodeFieldResolver                    relay_node_field (method: __invoke)                                                              
+                                                                                 Overblog\GraphQLBundle\GraphQL\Relay\Node\NodeFieldResolver (method: __invoke)                   
+  Overblog\GraphQLBundle\GraphQL\Relay\Node\PluralIdentifyingRootFieldResolver   relay_plural_identifying_field (method: __invoke)                                                
+                                                                                 Overblog\GraphQLBundle\GraphQL\Relay\Node\PluralIdentifyingRootFieldResolver (method: __invoke)  
  ------------------------------------------------------------------------------ ------------------------------------------------------------------------------------------------- 
 
 

--- a/Tests/Functional/Command/fixtures/debug-resolver.txt
+++ b/Tests/Functional/Command/fixtures/debug-resolver.txt
@@ -5,14 +5,14 @@ GraphQL Resolvers Services
  ------------------------------------------------------------------------------ ------------------------------------------------------------------------------------------------- 
   id                                                                             aliases                                                                                          
  ------------------------------------------------------------------------------ ------------------------------------------------------------------------------------------------- 
-  overblog\graphqlbundle\graphql\relay\mutation\mutationfieldresolver            Overblog\GraphQLBundle\GraphQL\Relay\Mutation\MutationFieldResolver (method: __invoke)           
-                                                                                 relay_mutation_field (method: __invoke)                                                          
-  overblog\graphqlbundle\graphql\relay\node\globalidfieldresolver                Overblog\GraphQLBundle\GraphQL\Relay\Node\GlobalIdFieldResolver (method: __invoke)               
-                                                                                 relay_globalid_field (method: __invoke)                                                          
-  overblog\graphqlbundle\graphql\relay\node\nodefieldresolver                    Overblog\GraphQLBundle\GraphQL\Relay\Node\NodeFieldResolver (method: __invoke)                   
-                                                                                 relay_node_field (method: __invoke)                                                              
-  overblog\graphqlbundle\graphql\relay\node\pluralidentifyingrootfieldresolver   Overblog\GraphQLBundle\GraphQL\Relay\Node\PluralIdentifyingRootFieldResolver (method: __invoke)  
-                                                                                 relay_plural_identifying_field (method: __invoke)                                                
+  overblog\graphqlbundle\graphql\relay\mutation\mutationfieldresolver            relay_mutation_field (method: __invoke)                                                          
+                                                                                 Overblog\GraphQLBundle\GraphQL\Relay\Mutation\MutationFieldResolver (method: __invoke)           
+  overblog\graphqlbundle\graphql\relay\node\globalidfieldresolver                relay_globalid_field (method: __invoke)                                                          
+                                                                                 Overblog\GraphQLBundle\GraphQL\Relay\Node\GlobalIdFieldResolver (method: __invoke)               
+  overblog\graphqlbundle\graphql\relay\node\nodefieldresolver                    relay_node_field (method: __invoke)                                                              
+                                                                                 Overblog\GraphQLBundle\GraphQL\Relay\Node\NodeFieldResolver (method: __invoke)                   
+  overblog\graphqlbundle\graphql\relay\node\pluralidentifyingrootfieldresolver   relay_plural_identifying_field (method: __invoke)                                                
+                                                                                 Overblog\GraphQLBundle\GraphQL\Relay\Node\PluralIdentifyingRootFieldResolver (method: __invoke)  
  ------------------------------------------------------------------------------ ------------------------------------------------------------------------------------------------- 
 
 

--- a/Tests/Resolver/AbstractProxyResolverTest.php
+++ b/Tests/Resolver/AbstractProxyResolverTest.php
@@ -7,7 +7,7 @@ abstract class AbstractProxyResolverTest extends AbstractResolverTest
     protected function getResolverSolutionsMapping()
     {
         return [
-            'Toto' => ['solutionFunc' => [$this, 'createToto'], 'solutionFuncArgs' => [], 'method' => 'resolve'],
+            'Toto' => ['factory' => [[$this, 'createToto'], []], 'aliases' => ['foo', 'bar', 'baz'], 'method' => 'resolve'],
         ];
     }
 
@@ -24,10 +24,33 @@ abstract class AbstractProxyResolverTest extends AbstractResolverTest
     }
 
     /**
+     * @param string $alias
+     *
+     * @dataProvider aliasProvider
+     */
+    public function testResolveAliasesMutation($alias)
+    {
+        $result = $this->resolver->resolve([$alias, ['my', 'resolve', 'test']]);
+        $this->assertSame(
+            $this->resolver->getSolution('Toto'),
+            $this->resolver->getSolution($alias)
+        );
+
+        $this->assertEquals(['my', 'resolve', 'test'], $result);
+    }
+
+    /**
      * @expectedException \Overblog\GraphQLBundle\Resolver\UnresolvableException
      */
     public function testResolveUnknownMutation()
     {
         $this->resolver->resolve('Fake');
+    }
+
+    public function aliasProvider()
+    {
+        yield ['foo'];
+        yield ['bar'];
+        yield ['baz'];
     }
 }

--- a/Tests/Resolver/AbstractResolverTest.php
+++ b/Tests/Resolver/AbstractResolverTest.php
@@ -19,7 +19,7 @@ abstract class AbstractResolverTest extends TestCase
         $this->resolver = $this->createResolver();
 
         foreach ($this->getResolverSolutionsMapping() as $name => $options) {
-            $this->resolver->addSolution($name, $options['solutionFunc'], $options['solutionFuncArgs'], $options);
+            $this->resolver->addSolution($name, $options['factory'], isset($options['aliases']) ? $options['aliases'] : [], $options);
         }
     }
 }

--- a/Tests/Resolver/TypeResolverTest.php
+++ b/Tests/Resolver/TypeResolverTest.php
@@ -17,8 +17,8 @@ class TypeResolverTest extends AbstractResolverTest
     protected function getResolverSolutionsMapping()
     {
         return [
-            'Toto' => ['solutionFunc' => [$this, 'createObjectType'], 'solutionFuncArgs' => [['name' => 'Toto']]],
-            'Tata' => ['solutionFunc' => [$this, 'createObjectType'], 'solutionFuncArgs' => [['name' => 'Tata']]],
+            'Toto' => ['factory' => [[$this, 'createObjectType'], [['name' => 'Toto']]], 'aliases' => ['foo']],
+            'Tata' => ['factory' => [[$this, 'createObjectType'], [['name' => 'Tata']]], 'aliases' => ['bar']],
         ];
     }
 
@@ -45,9 +45,7 @@ class TypeResolverTest extends AbstractResolverTest
      */
     public function testAddNotSupportedSolution()
     {
-        $this->resolver->addSolution('not-supported', function () {
-            return new \stdClass();
-        });
+        $this->resolver->addSolution('not-supported', new \stdClass());
         $this->resolver->getSolution('not-supported');
     }
 
@@ -133,5 +131,25 @@ class TypeResolverTest extends AbstractResolverTest
         $this->assertInstanceOf(ListOfType::class, $type);
         $this->assertInstanceOf(ListOfType::class, $type->getWrappedType());
         $this->assertEquals('Toto', $type->getWrappedType()->getWrappedType());
+    }
+
+    public function testAliases()
+    {
+        $this->assertSame(
+            $this->resolver->resolve('Tata'),
+            $this->resolver->resolve('bar')
+        );
+        $this->assertSame(
+            $this->resolver->getSolution('Tata'),
+            $this->resolver->getSolution('bar')
+        );
+        $this->assertSame(
+            $this->resolver->resolve('Toto'),
+            $this->resolver->resolve('foo')
+        );
+        $this->assertSame(
+            $this->resolver->getSolution('Toto'),
+            $this->resolver->getSolution('foo')
+        );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | none
| License       | MIT

Now fluent resolver use true aliases and stop duplicating resolver solution.