### PR TITLE
Add a NAME constant in generated type classes

### DIFF
--- a/Generator/TypeGenerator.php
+++ b/Generator/TypeGenerator.php
@@ -161,6 +161,11 @@ CODE;
         }
     }
 
+    protected function generateTypeName(array $config)
+    {
+        return $this->varExport($config['config']['name']);
+    }
+
     public function compile($mode)
     {
         $cacheDir = $this->getCacheDir();

--- a/Resources/skeleton/TypeSystem.php.skeleton
+++ b/Resources/skeleton/TypeSystem.php.skeleton
@@ -4,6 +4,7 @@
 <classDocBlock>
 <classType>class <className> extends <parentClassName><implements>
 {<traits>
+<spaces>const NAME = <typeName>;
 
 <spaces>public function __construct(ConfigProcessor $configProcessor, GlobalVariables $globalVariables = null)
 <spaces>{


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #300 
| License       | MIT

This adds a NAME constant in generated type classes, like this:

```
/**
 * THIS FILE WAS GENERATED AND SHOULD NOT BE MODIFIED!
 */
final class ViewerType extends InputObjectType implements GeneratedTypeInterface
{
    const NAME = 'Viewer';

    public function __construct(ConfigProcessor $configProcessor, GlobalVariables $globalVariables = null)
    {
        $configLoader = function(GlobalVariables $globalVariable) {

```

I'm not sure how to add tests for this, though.