### PR TITLE
User Deprecated: Referencing controllers with a single colon is deprecated since Symfony 4.1

### DIFF
--- a/Resources/config/routing/graphql.yml
+++ b/Resources/config/routing/graphql.yml
@@ -1,23 +1,23 @@
 overblog_graphql_endpoint:
     path: /
     defaults:
-        _controller: overblog_graphql.controller.graphql::endpointAction
+        _controller: Overblog\GraphQLBundle\Controller\GraphController::endpointAction
         _format: "json"
 
 overblog_graphql_batch_endpoint:
     path: /batch
     defaults:
-        _controller: overblog_graphql.controller.graphql::batchEndpointAction
+        _controller: Overblog\GraphQLBundle\Controller\GraphController::batchEndpointAction
         _format: "json"
 
 overblog_graphql_multiple_endpoint:
     path: /graphql/{schemaName}
     defaults:
-        _controller: overblog_graphql.controller.graphql::endpointAction
+        _controller: Overblog\GraphQLBundle\Controller\GraphController::endpointAction
         _format: "json"
 
 overblog_graphql_batch_multiple_endpoint:
     path: /graphql/{schemaName}/batch
     defaults:
-        _controller: overblog_graphql.controller.graphql::batchEndpointAction
+        _controller: Overblog\GraphQLBundle\Controller\GraphController::batchEndpointAction
         _format: "json"

--- a/Resources/config/routing/graphql.yml
+++ b/Resources/config/routing/graphql.yml
@@ -1,23 +1,23 @@
 overblog_graphql_endpoint:
     path: /
     defaults:
-        _controller: overblog_graphql.controller.graphql:endpointAction
+        _controller: overblog_graphql.controller.graphql::endpointAction
         _format: "json"
 
 overblog_graphql_batch_endpoint:
     path: /batch
     defaults:
-        _controller: overblog_graphql.controller.graphql:batchEndpointAction
+        _controller: overblog_graphql.controller.graphql::batchEndpointAction
         _format: "json"
 
 overblog_graphql_multiple_endpoint:
     path: /graphql/{schemaName}
     defaults:
-        _controller: overblog_graphql.controller.graphql:endpointAction
+        _controller: overblog_graphql.controller.graphql::endpointAction
         _format: "json"
 
 overblog_graphql_batch_multiple_endpoint:
     path: /graphql/{schemaName}/batch
     defaults:
-        _controller: overblog_graphql.controller.graphql:batchEndpointAction
+        _controller: overblog_graphql.controller.graphql::batchEndpointAction
         _format: "json"

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -119,6 +119,10 @@ services:
             - "@overblog_graphql.request_parser"
             - "%overblog_graphql.handle_cors%"
             - "%overblog_graphql.batching_method%"
+            
+    Overblog\GraphQLBundle\Controller\GraphController:
+        public: true
+        alias: 'overblog_graphql.controller.graphql'
 
     overblog_graphql.command.dump_schema:
         class: Overblog\GraphQLBundle\Command\GraphQLDumpSchemaCommand


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | /no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #... 
| License       | MIT

A new deprectated is coming with SF 4.1 ;-) 

> With Passion !
