### PR TITLE
Typo in exception

### DIFF
--- a/Config/Processor/InheritanceProcessor.php
+++ b/Config/Processor/InheritanceProcessor.php
@@ -121,7 +121,7 @@ final class InheritanceProcessor implements ProcessorInterface
     {
         if (!isset($configs[$name])) {
             throw new \InvalidArgumentException(sprintf(
-                'Type %s inherits by %s not found.',
+                'Type %s inherited by %s not found.',
                 json_encode($name),
                 json_encode($child)
             ));
@@ -142,9 +142,9 @@ final class InheritanceProcessor implements ProcessorInterface
     {
         if (empty($config['decorator']) && isset($config['type']) && !in_array($config['type'], $allowedTypes)) {
             throw new \InvalidArgumentException(sprintf(
-                'Type %s can\'t inherits %s because %s is not allowed type (%s).',
-                json_encode($name),
+                'Type %s can\'t inherit %s because its type (%s) is not allowed type (%s).',
                 json_encode($child),
+                json_encode($name),
                 json_encode($config['type']),
                 json_encode($allowedTypes)
             ));

--- a/Tests/Config/Processor/InheritanceProcessorTest.php
+++ b/Tests/Config/Processor/InheritanceProcessorTest.php
@@ -17,7 +17,7 @@ class InheritanceProcessorTest extends TestCase
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Type "toto" inherits by "bar" not found.
+     * @expectedExceptionMessage Type "toto" inherited by "bar" not found.
      */
     public function testExtendsUnknownType()
     {
@@ -53,7 +53,7 @@ class InheritanceProcessorTest extends TestCase
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Type "toto" can't inherits "bar" because "enum" is not allowed type (["object","interface"]).
+     * @expectedExceptionMessage Type "bar" can't inherit "toto" because its type ("enum") is not allowed type (["object","interface"]).
      */
     public function testNotAllowedType()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no test
| Documented?   | no
| Fixed tickets | none
| License       | MIT

- Entity type is interface2
- SubscriptionDiscount inherits Entity

Exception message is:
_Type "Entity" can't inherits "SubscriptionDiscount" because "interface2" is not allowed type (["object","interface"])_

and should be:
_Type "SubscriptionDiscount" can't inherit "Entity" because its type ("interface2") is not allowed type (["object","interface"])_

