### PR TITLE
abstract resolver for access control

### DIFF
--- a/Definition/Resolver/AbstractResolver.php
+++ b/Definition/Resolver/AbstractResolver.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Overblog\GraphQLBundle\Definition\Resolver;
+
+use Overblog\GraphQLBundle\Error\UserWarning;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+
+/**
+ * Class AbstractResolver
+ * This class provides a base for Query and Mutation resolver implementing these Symfony controller methods:
+ * - isGranted
+ * - denyAccessUnlessGranted
+ * @package Overblog\GraphQLBundle\Definition\Resolver
+ * @author Sylvain Fabre sylvain@assoconnect.com
+ */
+Abstract class AbstractResolver
+{
+
+    private $authorizationChecker;
+
+    /**
+     * @required
+     */
+    public function setAuthorizationChecker(AuthorizationCheckerInterface $authorizationChecker)
+    {
+        $this->authorizationChecker = $authorizationChecker;
+    }
+
+    /**
+     * Checks if the attributes are granted against the current authentication token and optionally supplied subject.
+     *
+     * @final
+     */
+    public function isGranted($attributes, $subject = null): bool
+    {
+        return $this->authorizationChecker->isGranted($attributes, $subject);
+    }
+
+    /**
+     * Throws an exception unless the attributes are granted against the current authentication token and optionally
+     * supplied subject.
+     *
+     * @throws UserWarning
+     *
+     * @final
+     */
+    public function denyAccessUnlessGranted($attributes, $subject = null, string $message = 'Access denied to this field')
+    {
+        if (!$this->isGranted($attributes, $subject)) {
+            throw new UserWarning($message);
+        }
+    }
+
+}

--- a/Tests/Definition/Resolver/AbstractResolverTest.php
+++ b/Tests/Definition/Resolver/AbstractResolverTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Overblog\GraphQLBundle\Tests\Definition\Resolver;
+
+use Overblog\GraphQLBundle\Definition\Resolver\AbstractResolver;
+use Overblog\GraphQLBundle\Error\UserWarning;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+Class AbstractResolverTest extends TestCase
+{
+
+    public function testIsGranted()
+    {
+        $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authorizationChecker->expects($this->once())->method('isGranted')->willReturn(true);
+
+        /** @var AbstractResolver $controller */
+        $controller = $this->getMockForAbstractClass(AbstractResolver::class);
+        $controller->setAuthorizationChecker($authorizationChecker);
+
+        $this->assertTrue($controller->isGranted('foo'));
+    }
+
+    /**
+     * @expectedException \Overblog\GraphQLBundle\Error\UserWarning
+     */
+    public function testDenyAccessUnlessGranted()
+    {
+        $controller = $this->getMockBuilder(AbstractResolver::class)
+            ->setMethods(array('isGranted'))
+            ->getMock();
+        $controller->expects($this->any())
+            ->method('isGranted')
+            ->willReturn(false);
+
+        /** @var AbstractResolver $controller */
+        $controller->denyAccessUnlessGranted('foo');
+    }
+
+}


### PR DESCRIPTION
Adds `isGranted` and `denyAccessUnlessGranted` to a base resolver class to check access like with Symfony controllers