### PR TITLE
Fixed continuity error in documentation

### DIFF
--- a/Resources/doc/definitions/type-inheritance.md
+++ b/Resources/doc/definitions/type-inheritance.md
@@ -17,7 +17,7 @@ Character:
     heirs: # the opposite of « inherits »
            # optional if « inherits » already exists on daughters classes
       - CharacterWarrior
-      - WizardWarrior
+      - CharacterWizard
     config:
         fields:
             id: {type: Int!}


### PR DESCRIPTION
Replaced one occurrence of "WizardWarrior" with "CharacterWizard".

