### PR TITLE
Wrapped complex expressions inside parenthesis to enforce operator priority

### DIFF
--- a/ExpressionLanguage/ExpressionFunction/GraphQL/IsTypeOf.php
+++ b/ExpressionLanguage/ExpressionFunction/GraphQL/IsTypeOf.php
@@ -11,7 +11,7 @@ final class IsTypeOf extends ExpressionFunction
         parent::__construct(
             $name,
             function ($className) {
-                return sprintf('($className = %s) && $value instanceof $className', $className);
+                return sprintf('(($className = %s) && $value instanceof $className)', $className);
             }
         );
     }

--- a/ExpressionLanguage/ExpressionFunction/Security/IsAuthenticated.php
+++ b/ExpressionLanguage/ExpressionFunction/Security/IsAuthenticated.php
@@ -11,7 +11,7 @@ final class IsAuthenticated extends ExpressionFunction
         parent::__construct(
             $name,
             function () {
-                return '$container->get(\'security.authorization_checker\')->isGranted(\'IS_AUTHENTICATED_REMEMBERED\') || $container->get(\'security.authorization_checker\')->isGranted(\'IS_AUTHENTICATED_FULLY\')';
+                return '($container->get(\'security.authorization_checker\')->isGranted(\'IS_AUTHENTICATED_REMEMBERED\') || $container->get(\'security.authorization_checker\')->isGranted(\'IS_AUTHENTICATED_FULLY\'))';
             }
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | not applicable
| Fixed tickets | no issue opened
| License       | MIT

I encountered an issue with some complex `access` expressions : 
```
"@=isAuthenticated() && (getUser().getId() == value.getId())"
```

Would mess with operator priorities by getting compiled to : 

```php
'access' => function ($value, $args, $context, ResolveInfo $info, $object) use ($globalVariable) {
    return ($globalVariable->get('container')->get('security.authorization_checker')->isGranted('IS_AUTHENTICATED_REMEMBERED') || $globalVariable->get('container')->get('security.authorization_checker')->isGranted('IS_AUTHENTICATED_FULLY') && (\Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\Security\Helper::getUser($globalVariable)->getId() == $value->getId()));
},
```