### PR TITLE
Add config option to disable introspection query

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -2,6 +2,7 @@
 
 namespace Overblog\GraphQLBundle\DependencyInjection;
 
+use GraphQL\Validator\Rules\DisableIntrospection;
 use GraphQL\Validator\Rules\QueryComplexity;
 use GraphQL\Validator\Rules\QueryDepth;
 use Overblog\GraphQLBundle\Error\ErrorHandler;
@@ -166,6 +167,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->append($this->securityQuerySection('query_max_depth', QueryDepth::DISABLED))
                 ->append($this->securityQuerySection('query_max_complexity', QueryComplexity::DISABLED))
+                ->append($this->securityQuerySection('disable_introspection', DisableIntrospection::DISABLED))
                 ->booleanNode('handle_cors')->defaultFalse()->end()
             ->end()
         ->end();

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -2,7 +2,6 @@
 
 namespace Overblog\GraphQLBundle\DependencyInjection;
 
-use GraphQL\Validator\Rules\DisableIntrospection;
 use GraphQL\Validator\Rules\QueryComplexity;
 use GraphQL\Validator\Rules\QueryDepth;
 use Overblog\GraphQLBundle\Error\ErrorHandler;
@@ -167,7 +166,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->append($this->securityQuerySection('query_max_depth', QueryDepth::DISABLED))
                 ->append($this->securityQuerySection('query_max_complexity', QueryComplexity::DISABLED))
-                ->append($this->securityQuerySection('disable_introspection', DisableIntrospection::DISABLED))
+                ->booleanNode('enable_introspection')->defaultTrue()->end()
                 ->booleanNode('handle_cors')->defaultFalse()->end()
             ->end()
         ->end();

--- a/DependencyInjection/OverblogGraphQLExtension.php
+++ b/DependencyInjection/OverblogGraphQLExtension.php
@@ -162,6 +162,11 @@ class OverblogGraphQLExtension extends Extension implements PrependExtensionInte
 
     private function setSecurity(array $config, ContainerBuilder $container)
     {
+        if (!empty($config['security']['disable_introspection'])) {
+            $executorDefinition = $container->getDefinition($this->getAlias().'.request_executor');
+            $executorDefinition->addMethodCall('disableIntrospectionQuery');
+        }
+
         foreach ($config['security'] as $key => $value) {
             $container->setParameter(sprintf('%s.%s', $this->getAlias(), $key), $value);
         }

--- a/DependencyInjection/OverblogGraphQLExtension.php
+++ b/DependencyInjection/OverblogGraphQLExtension.php
@@ -162,7 +162,7 @@ class OverblogGraphQLExtension extends Extension implements PrependExtensionInte
 
     private function setSecurity(array $config, ContainerBuilder $container)
     {
-        if (!empty($config['security']['disable_introspection'])) {
+        if (false === $config['security']['enable_introspection']) {
             $executorDefinition = $container->getDefinition($this->getAlias().'.request_executor');
             $executorDefinition->addMethodCall('disableIntrospectionQuery');
         }

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Documentation
   - [Fields public control](Resources/doc/security/fields-public-control.md)
   - [Limiting query depth](Resources/doc/security/limiting-query-depth.md)
   - [Query complexity analysis](Resources/doc/security/query-complexity-analysis.md)
+  - [Disable introspection](Resources/doc/security/disable_introspection.md)
 - [Errors handling](Resources/doc/error-handling/index.md)
 - [Events](Resources/doc/events/index.md)
 

--- a/Request/Executor.php
+++ b/Request/Executor.php
@@ -7,6 +7,7 @@ use GraphQL\Executor\Promise\Promise;
 use GraphQL\Executor\Promise\PromiseAdapter;
 use GraphQL\Type\Schema;
 use GraphQL\Validator\DocumentValidator;
+use GraphQL\Validator\Rules\DisableIntrospection;
 use GraphQL\Validator\Rules\QueryComplexity;
 use GraphQL\Validator\Rules\QueryDepth;
 use Overblog\GraphQLBundle\Event\Events;
@@ -111,6 +112,11 @@ class Executor
         /** @var QueryComplexity $queryComplexity */
         $queryComplexity = DocumentValidator::getRule('QueryComplexity');
         $queryComplexity->setMaxQueryComplexity($maxQueryComplexity);
+    }
+
+    public function disableIntrospectionQuery()
+    {
+        DocumentValidator::addRule(new DisableIntrospection());
     }
 
     /**

--- a/Resources/doc/security/disable_introspection.md
+++ b/Resources/doc/security/disable_introspection.md
@@ -1,0 +1,19 @@
+Disable introspection
+=====================
+
+This bundle supports [webonyx/graphql-php validation rule to disable introspection queries](webonyx/graphql-php).
+
+Introspection is a mechanism for fetching schema structure. It is used by tools like GraphiQL for auto-completion, query validation, etc.
+
+It means that anybody can get a full description of your schema by sending a special query containing meta fields __type and __schema.
+
+If you are not planning to expose your API to the general public, it makes sense to disable this feature in production. By disabling, tools like GraphiQL won't work anymore.
+
+```yaml
+#app/config/config.yml
+overblog_graphql:
+    security:
+        disable_introspection: '%kernel.debug%'
+```
+
+Introspection is enabled by default.

--- a/Resources/doc/security/disable_introspection.md
+++ b/Resources/doc/security/disable_introspection.md
@@ -1,7 +1,7 @@
 Disable introspection
 =====================
 
-This bundle supports [webonyx/graphql-php validation rule to disable introspection queries](webonyx/graphql-php).
+This bundle supports [webonyx/graphql-php validation rule to disable introspection queries](http://webonyx.github.io/graphql-php/security/#disabling-introspection).
 
 Introspection is a mechanism for fetching schema structure. It is used by tools like GraphiQL for auto-completion, query validation, etc.
 
@@ -13,7 +13,7 @@ If you are not planning to expose your API to the general public, it makes sense
 #app/config/config.yml
 overblog_graphql:
     security:
-        disable_introspection: '%kernel.debug%'
+        enable_introspection: '%kernel.debug%'
 ```
 
 Introspection is enabled by default.

--- a/Resources/doc/security/index.md
+++ b/Resources/doc/security/index.md
@@ -6,5 +6,6 @@ Security
 * [Fields public control](fields-public-control.md)
 * [Limiting query depth](limiting-query-depth.md)
 * [Query complexity analysis](query-complexity-analysis.md)
+* [Disable introspection](disable_introspection.md)
 
 Next step [handling errors](../error-handling/index.md)

--- a/Tests/Functional/App/config/disableIntrospection/config.yml
+++ b/Tests/Functional/App/config/disableIntrospection/config.yml
@@ -4,7 +4,7 @@ imports:
 
 overblog_graphql:
     security:
-        disable_introspection: true
+        enable_introspection: false
     definitions:
         class_namespace: "Overblog\\GraphQLBundle\\QueryComplexity\\__DEFINITIONS__"
         schema:

--- a/Tests/Functional/App/config/disableIntrospection/config.yml
+++ b/Tests/Functional/App/config/disableIntrospection/config.yml
@@ -1,0 +1,17 @@
+imports:
+    - { resource: ../config.yml }
+    - { resource: ../connection/services.yml }
+
+overblog_graphql:
+    security:
+        disable_introspection: true
+    definitions:
+        class_namespace: "Overblog\\GraphQLBundle\\QueryComplexity\\__DEFINITIONS__"
+        schema:
+            query: Query
+            mutation: ~
+        mappings:
+            types:
+                -
+                    type: yaml
+                    dir: "%kernel.root_dir%/config/queryComplexity/mapping"

--- a/Tests/Functional/Security/DisableIntrospectionTest.php
+++ b/Tests/Functional/Security/DisableIntrospectionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Overblog\GraphQLBundle\Tests\Functional\Security;
+
+use Overblog\GraphQLBundle\Tests\Functional\TestCase;
+
+class DisableIntrospectionTest extends TestCase
+{
+    private $introspectionQuery = <<<'EOF'
+query {
+  __schema {
+    types {
+      name
+      description
+    }
+  }
+}
+EOF;
+
+    public function testIntrospectionDisabled()
+    {
+        $expected = [
+            'errors' => [
+                [
+                    'message' => 'GraphQL introspection is not allowed, but the query contained __schema or __type',
+                    'category' => 'graphql',
+                    'locations' => [
+                        [
+                            'line' => 2,
+                            'column' => 3,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertResponse($this->introspectionQuery, $expected, self::ANONYMOUS_USER, 'disableIntrospection');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| Fixed tickets | -
| License       | MIT

This PR adds a configuration setting to disable introspection queries. See http://webonyx.github.io/graphql-php/security/#disabling-introspection

I have added a test case, but 12 tests did already fail on branch 0.11.