### PR TITLE
Fix for #387

### DIFF
--- a/src/Resolver/AccessResolver.php
+++ b/src/Resolver/AccessResolver.php
@@ -7,6 +7,8 @@ namespace Overblog\GraphQLBundle\Resolver;
 use GraphQL\Executor\Promise\Adapter\SyncPromise;
 use GraphQL\Executor\Promise\Promise;
 use GraphQL\Executor\Promise\PromiseAdapter;
+use GraphQL\Type\Definition\ListOfType;
+use GraphQL\Type\Definition\ResolveInfo;
 use Overblog\GraphQLBundle\Error\UserError;
 use Overblog\GraphQLBundle\Error\UserWarning;
 use Overblog\GraphQLBundle\Relay\Connection\Output\Connection;
@@ -59,7 +61,9 @@ class AccessResolver
 
     private function processFilter($result, $accessChecker, $resolveArgs)
     {
-        if (\is_array($result)) {
+        /** @var ResolveInfo $resolveInfo */
+        $resolveInfo = $resolveArgs[3];
+        if (\is_array($result) && $resolveInfo->returnType instanceof ListOfType) {
             $result = \array_map(
                 function ($object) use ($accessChecker, $resolveArgs) {
                     return $this->hasAccess($accessChecker, $object, $resolveArgs) ? $object : null;

--- a/tests/Functional/App/config/access/mapping/access.types.yml
+++ b/tests/Functional/App/config/access/mapping/access.types.yml
@@ -6,6 +6,10 @@ RootQuery:
             user:
                 type: User
                 resolve: '@=resolver("query")'
+            youShallNotSeeThisUnauthenticated:
+                type: SecureField
+                access: '@=isFullyAuthenticated()'
+                resolve: '@=[]'
 
 Mutation:
     type: object
@@ -47,6 +51,17 @@ User:
                 type: String!
         interfaces: [Human]
         isTypeOf: true
+
+SecureField:
+    type: object
+    config:
+        fields:
+            secretValue:
+                type: String!
+                resolve: 'top secret'
+            youAreAuthenticated:
+                type: Boolean!
+                resolve: '@=isFullyAuthenticated()'
 
 friendConnection:
     type: relay-connection

--- a/tests/Functional/Security/AccessTest.php
+++ b/tests/Functional/Security/AccessTest.php
@@ -99,15 +99,17 @@ EOF;
             ],
             'extensions' => [
                 'warnings' => [
-                    'message' => 'Access denied to this field.',
-                    'locations' => [
-                        [
-                            'line' => 3,
-                            'column' => 5,
+                    [
+                        'message' => 'Access denied to this field.',
+                        'locations' => [
+                            [
+                                'line' => 2,
+                                'column' => 3,
+                            ],
                         ],
-                    ],
-                    'path' => ['youShallNotSeeThisUnauthenticated'],
-                    'category' => 'user',
+                        'path' => ['youShallNotSeeThisUnauthenticated'],
+                        'category' => 'user',
+                    ]
                 ],
             ],
         ];

--- a/tests/Functional/Security/AccessTest.php
+++ b/tests/Functional/Security/AccessTest.php
@@ -91,6 +91,39 @@ EOF;
         $this->assertResponse($this->userNameQuery, $expected, static::ANONYMOUS_USER, 'access');
     }
 
+    public function testNonAuthenticatedUserAccessSecuredFieldWhichInitiallyResolvesToArray()
+    {
+        $expected = [
+            'data' => [
+                'youShallNotSeeThisUnauthenticated' => null,
+            ],
+            'extensions' => [
+                'warnings' => [
+                    'message' => 'Access denied to this field.',
+                    'locations' => [
+                        [
+                            'line' => 3,
+                            'column' => 5,
+                        ],
+                    ],
+                    'path' => ['youShallNotSeeThisUnauthenticated'],
+                    'category' => 'user',
+                ],
+            ],
+        ];
+
+        $query = <<<'EOF'
+{
+  youShallNotSeeThisUnauthenticated {
+    secretValue
+    youAreAuthenticated
+  }
+}
+EOF;
+
+        $this->assertResponse($query, $expected, static::ANONYMOUS_USER, 'access');
+    }
+
     public function testFullyAuthenticatedUserAccessToUserName(): void
     {
         $expected = [

--- a/tests/Functional/Security/AccessTest.php
+++ b/tests/Functional/Security/AccessTest.php
@@ -91,7 +91,7 @@ EOF;
         $this->assertResponse($this->userNameQuery, $expected, static::ANONYMOUS_USER, 'access');
     }
 
-    public function testNonAuthenticatedUserAccessSecuredFieldWhichInitiallyResolvesToArray()
+    public function testNonAuthenticatedUserAccessSecuredFieldWhichInitiallyResolvesToArray(): void
     {
         $expected = [
             'data' => [
@@ -109,7 +109,7 @@ EOF;
                         ],
                         'path' => ['youShallNotSeeThisUnauthenticated'],
                         'category' => 'user',
-                    ]
+                    ],
                 ],
             ],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | bugfix?
| Fixed tickets | #387
| License       | MIT

Resolved array values has been treated as ListOfType in regards to access check. Full information see #387 