### PR TITLE
Add content to body with OPTIONS verb

### DIFF
--- a/src/Controller/GraphController.php
+++ b/src/Controller/GraphController.php
@@ -82,7 +82,7 @@ class GraphController
     private function createResponse(Request $request, string $schemaName = null, bool $batched)
     {
         if ('OPTIONS' === $request->getMethod()) {
-            $response = new Response('', 200);
+            $response = new JsonResponse([], 200);
         } else {
             if (!\in_array($request->getMethod(), ['POST', 'GET'])) {
                 return new Response('', 405);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

OPTIONS http request is used by browsers to fetch CORS from server. I would like to change the content of body because I think an empty response is a bad behavior.
We use Cloudflare in front of our API and it considers that empty body response is an error.
I'm not sure about what we need to send instead of an empty response and I suggest an empty array.