### PR TITLE
Fixed syntax of fieldsDefaultPublic in example

### DIFF
--- a/docs/security/fields-public-control.md
+++ b/docs/security/fields-public-control.md
@@ -25,8 +25,8 @@ You can also use `config.fieldsDefaultPublic` to handle the setting globally on 
 ```yaml
 AnObject:
     type: object
-    fieldsDefaultPublic: "@=service('my_service').isGranted(typeName, fieldName)"
     config:
+        fieldsDefaultPublic: "@=service('my_service').isGranted(typeName, fieldName)"
         fields:
             id:
                 type: "String!"


### PR DESCRIPTION
This field goes under `config`, not at the root.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| License       | MIT

Simple doc fix for the usage example of `fieldsDefaultPublic`, supposed to go below `config`.