### PR TITLE
379 log graph ql errors

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -9,6 +9,7 @@ use GraphQL\Validator\Rules\QueryDepth;
 use Overblog\GraphQLBundle\Error\ErrorHandler;
 use Overblog\GraphQLBundle\EventListener\ErrorLoggerListener;
 use Overblog\GraphQLBundle\Resolver\Resolver;
+use Psr\Log\LogLevel;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\EnumNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\ScalarNodeDefinition;
@@ -86,6 +87,7 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('log')->defaultTrue()->end()
                 ->scalarNode('logger_service')->defaultValue(ErrorLoggerListener::DEFAULT_LOGGER_SERVICE)->end()
                 ->booleanNode('map_exceptions_to_parent')->defaultFalse()->end()
+                ->scalarNode('log_level')->defaultValue(LogLevel::DEBUG)->end()
                 ->arrayNode('exceptions')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/src/DependencyInjection/OverblogGraphQLExtension.php
+++ b/src/DependencyInjection/OverblogGraphQLExtension.php
@@ -187,7 +187,7 @@ class OverblogGraphQLExtension extends Extension implements PrependExtensionInte
 
             $errorHandlerListenerDefinition = $container->setDefinition(ErrorHandlerListener::class, new Definition(ErrorHandlerListener::class));
             $errorHandlerListenerDefinition->setPublic(true)
-                ->setArguments([new Reference($id), new Reference(ErrorHandlerListener::DEFAULT_LOGGER_SERVICE), $config['errors_handler']['rethrow_internal_exceptions'], $config['errors_handler']['debug']])
+                ->setArguments([new Reference($id), new Reference(ErrorHandlerListener::DEFAULT_LOGGER_SERVICE), $config['errors_handler']['rethrow_internal_exceptions'], $config['errors_handler']['debug'], $config['errors_handler']['log_level']])
                 ->addTag('kernel.event_listener', ['event' => Events::POST_EXECUTOR, 'method' => 'onPostExecutor'])
             ;
 

--- a/src/DependencyInjection/OverblogGraphQLExtension.php
+++ b/src/DependencyInjection/OverblogGraphQLExtension.php
@@ -187,7 +187,7 @@ class OverblogGraphQLExtension extends Extension implements PrependExtensionInte
 
             $errorHandlerListenerDefinition = $container->setDefinition(ErrorHandlerListener::class, new Definition(ErrorHandlerListener::class));
             $errorHandlerListenerDefinition->setPublic(true)
-                ->setArguments([new Reference($id), $config['errors_handler']['rethrow_internal_exceptions'], $config['errors_handler']['debug']])
+                ->setArguments([new Reference($id), new Reference(ErrorHandlerListener::DEFAULT_LOGGER_SERVICE), $config['errors_handler']['rethrow_internal_exceptions'], $config['errors_handler']['debug']])
                 ->addTag('kernel.event_listener', ['event' => Events::POST_EXECUTOR, 'method' => 'onPostExecutor'])
             ;
 

--- a/src/EventListener/ErrorHandlerListener.php
+++ b/src/EventListener/ErrorHandlerListener.php
@@ -7,6 +7,7 @@ namespace Overblog\GraphQLBundle\EventListener;
 use Overblog\GraphQLBundle\Error\ErrorHandler;
 use Overblog\GraphQLBundle\Event\ExecutorResultEvent;
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use Psr\Log\NullLogger;
 
 final class ErrorHandlerListener
@@ -25,16 +26,21 @@ final class ErrorHandlerListener
     /** @var LoggerInterface */
     private $logger;
 
+    /** @var string */
+    private $errorLevel;
+
     public function __construct(
         ErrorHandler $errorHandler,
         LoggerInterface $logger,
         bool $throwException = false,
-        bool $debug = false
+        bool $debug = false,
+        string $errorLevel = LogLevel::ERROR
     ) {
         $this->errorHandler = $errorHandler;
         $this->throwException = $throwException;
         $this->debug = $debug;
         $this->logger = null === $logger ? new NullLogger() : $logger;
+        $this->errorLevel = $errorLevel;
     }
 
     public function onPostExecutor(ExecutorResultEvent $executorResultEvent): void
@@ -44,7 +50,7 @@ final class ErrorHandlerListener
         $result = $result->toArray();
 
         if (isset($result['errors'])) {
-            $this->logger->error(__METHOD__.' : '.\json_encode($result['errors']));
+            $this->logger->{$this->errorLevel}(__METHOD__.' : '.\json_encode($result['errors']));
         }
     }
 }

--- a/src/EventListener/ErrorHandlerListener.php
+++ b/src/EventListener/ErrorHandlerListener.php
@@ -34,7 +34,7 @@ final class ErrorHandlerListener
         LoggerInterface $logger,
         bool $throwException = false,
         bool $debug = false,
-        string $errorLevel = LogLevel::ERROR
+        string $errorLevel = LogLevel::DEBUG
     ) {
         $this->errorHandler = $errorHandler;
         $this->throwException = $throwException;

--- a/src/EventListener/ErrorHandlerListener.php
+++ b/src/EventListener/ErrorHandlerListener.php
@@ -6,9 +6,13 @@ namespace Overblog\GraphQLBundle\EventListener;
 
 use Overblog\GraphQLBundle\Error\ErrorHandler;
 use Overblog\GraphQLBundle\Event\ExecutorResultEvent;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 final class ErrorHandlerListener
 {
+    public const DEFAULT_LOGGER_SERVICE = 'logger';
+
     /** @var ErrorHandler */
     private $errorHandler;
 
@@ -18,16 +22,29 @@ final class ErrorHandlerListener
     /** @var bool */
     private $debug;
 
-    public function __construct(ErrorHandler $errorHandler, $throwException = false, $debug = false)
-    {
+    /** @var LoggerInterface */
+    private $logger;
+
+    public function __construct(
+        ErrorHandler $errorHandler,
+        LoggerInterface $logger,
+        bool $throwException = false,
+        bool $debug = false
+    ) {
         $this->errorHandler = $errorHandler;
         $this->throwException = $throwException;
         $this->debug = $debug;
+        $this->logger = null === $logger ? new NullLogger() : $logger;
     }
 
     public function onPostExecutor(ExecutorResultEvent $executorResultEvent): void
     {
         $result = $executorResultEvent->getResult();
         $this->errorHandler->handleErrors($result, $this->throwException, $this->debug);
+        $result = $result->toArray();
+
+        if (isset($result['errors'])) {
+            $this->logger->error(__METHOD__.' : '.\json_encode($result['errors']));
+        }
     }
 }

--- a/src/EventListener/ErrorHandlerListener.php
+++ b/src/EventListener/ErrorHandlerListener.php
@@ -50,7 +50,7 @@ final class ErrorHandlerListener
         $result = $result->toArray();
 
         if (isset($result['errors'])) {
-            $this->logger->{$this->errorLevel}(__METHOD__.' : '.\json_encode($result['errors']));
+            $this->logger->{$this->errorLevel}('GraphQL request resulted with an error.', $result['errors']);
         }
     }
 }

--- a/tests/DependencyInjection/OverblogGraphQLTypesExtensionTest.php
+++ b/tests/DependencyInjection/OverblogGraphQLTypesExtensionTest.php
@@ -12,6 +12,7 @@ use Overblog\GraphQLBundle\Error\UserWarning;
 use Overblog\GraphQLBundle\Tests\DependencyInjection\Builder\PagerArgs;
 use Overblog\GraphQLBundle\Tests\DependencyInjection\Builder\RawIdField;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LogLevel;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 
@@ -97,6 +98,7 @@ class OverblogGraphQLTypesExtensionTest extends TestCase
                                 \InvalidArgumentException::class,
                             ],
                         ],
+                        'log_level' => LogLevel::DEBUG,
                     ],
                 ],
             ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Documented?   | no
| Fixed tickets | #379 
| License       | MIT

Just add a logger to catch errors from graphQl results

I thinks, we can closed my old PR #396, because, of the link to our repository is lost 
```
mauriau wants to merge 1 commit into overblog:master from *unknown repository* 
```
