### PR TITLE
Fix deprecation on symfony 4.2

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -37,8 +37,10 @@ class Configuration implements ConfigurationInterface
 
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root(self::NAME);
+        $treeBuilder = new TreeBuilder(self::NAME);
+
+        // BC layer for symfony/config 4.1 and older
+        $rootNode = \method_exists($treeBuilder, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root(self::NAME);
 
         $rootNode
             ->children()
@@ -54,9 +56,9 @@ class Configuration implements ConfigurationInterface
 
     private function batchingMethodSection()
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('batching_method', 'enum');
         /** @var EnumNodeDefinition $node */
-        $node = $builder->root('batching_method', 'enum');
+        $node = \method_exists($builder, 'getRootNode') ? $builder->getRootNode() : $builder->root('batching_method', 'enum');
 
         $node
             ->values(['relay', 'apollo'])
@@ -68,9 +70,9 @@ class Configuration implements ConfigurationInterface
 
     private function errorsHandlerSection()
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('errors_handler');
         /** @var ArrayNodeDefinition $node */
-        $node = $builder->root('errors_handler');
+        $node = \method_exists($builder, 'getRootNode') ? $builder->getRootNode() : $builder->root('errors_handler');
         $node
             ->treatFalseLike(['enabled' => false])
             ->treatTrueLike(['enabled' => true])
@@ -103,9 +105,9 @@ class Configuration implements ConfigurationInterface
 
     private function definitionsSection()
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('definitions');
         /** @var ArrayNodeDefinition $node */
-        $node = $builder->root('definitions');
+        $node = \method_exists($builder, 'getRootNode') ? $builder->getRootNode() : $builder->root('definitions');
         $node
             ->addDefaultsIfNotSet()
             ->children()
@@ -134,9 +136,9 @@ class Configuration implements ConfigurationInterface
 
     private function servicesSection()
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('services');
         /** @var ArrayNodeDefinition $node */
-        $node = $builder->root('services');
+        $node = \method_exists($builder, 'getRootNode') ? $builder->getRootNode() : $builder->root('services');
         $node
             ->addDefaultsIfNotSet()
             ->children()
@@ -158,9 +160,9 @@ class Configuration implements ConfigurationInterface
 
     private function securitySection()
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('security');
         /** @var ArrayNodeDefinition $node */
-        $node = $builder->root('security');
+        $node = \method_exists($builder, 'getRootNode') ? $builder->getRootNode() : $builder->root('security');
         $node
             ->addDefaultsIfNotSet()
             ->children()
@@ -176,9 +178,9 @@ class Configuration implements ConfigurationInterface
 
     private function definitionsSchemaSection()
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('schema');
         /** @var ArrayNodeDefinition $node */
-        $node = $builder->root('schema');
+        $node = \method_exists($builder, 'getRootNode') ? $builder->getRootNode() : $builder->root('schema');
         $node
             ->beforeNormalization()
                 ->ifTrue(function ($v) {
@@ -212,9 +214,9 @@ class Configuration implements ConfigurationInterface
 
     private function definitionsAutoMappingSection()
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('auto_mapping');
         /** @var ArrayNodeDefinition $node */
-        $node = $builder->root('auto_mapping');
+        $node = \method_exists($builder, 'getRootNode') ? $builder->getRootNode() : $builder->root('auto_mapping');
         $node
             ->treatFalseLike(['enabled' => false])
             ->treatTrueLike(['enabled' => true])
@@ -234,8 +236,8 @@ class Configuration implements ConfigurationInterface
 
     private function definitionsMappingsSection()
     {
-        $builder = new TreeBuilder();
-        $node = $builder->root('mappings');
+        $builder = new TreeBuilder('mappings');
+        $node = \method_exists($builder, 'getRootNode') ? $builder->getRootNode() : $builder->root('mappings');
         $node
             ->children()
                 ->arrayNode('auto_discover')
@@ -288,9 +290,9 @@ class Configuration implements ConfigurationInterface
      */
     private function builderSection($name)
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder($name);
         /** @var ArrayNodeDefinition $node */
-        $node = $builder->root($name);
+        $node = \method_exists($builder, 'getRootNode') ? $builder->getRootNode() : $builder->root($name);
         $node->beforeNormalization()
             ->ifTrue(function ($v) {
                 return \is_array($v) && !empty($v);
@@ -328,9 +330,9 @@ class Configuration implements ConfigurationInterface
      */
     private function securityQuerySection($name, $disabledValue)
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder($name, 'scalar');
         /** @var ScalarNodeDefinition $node */
-        $node = $builder->root($name, 'scalar');
+        $node = \method_exists($builder, 'getRootNode') ? $builder->getRootNode() : $builder->root($name, 'scalar');
         $node->beforeNormalization()
                 ->ifTrue(function ($v) {
                     return \is_string($v) && \is_numeric($v);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | n/a
| License       | MIT

Upgrading to sf 4.2, you get the following deprecation:

> A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.
Show context    Hide trace
{▼
  /Volumes/HD/Sites/geolid/lisa/graph/vendor/symfony/config/Definition/Builder/TreeBuilder.php:30 {▶}
  /Volumes/HD/Sites/geolid/lisa/graph/vendor/overblog/graphql-bundle/src/DependencyInjection/Configuration.php:40 {▶}

Here is the fix.