### PR TITLE
change argument check from isset to array_key_exist

### DIFF
--- a/src/Definition/Argument.php
+++ b/src/Definition/Argument.php
@@ -14,12 +14,12 @@ class Argument implements \ArrayAccess, \Countable
 
     public function offsetExists($offset)
     {
-        return isset($this->arguments[$offset]);
+        return \array_key_exists($offset, $this->arguments);
     }
 
     public function offsetGet($offset)
     {
-        return isset($this->arguments[$offset]) ? $this->arguments[$offset] : null;
+        return $this->offsetExists($offset) ? $this->arguments[$offset] : null;
     }
 
     public function offsetSet($offset, $value)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| License       | MIT

Current approach doesn't allow to pass `null` value as a value and when you call `getRawArguments()` you can see `null`-valued parameter, but `offsetExists()` return `false`.

See #442