### PR TITLE
feature #290

### DIFF
--- a/src/Config/Processor.php
+++ b/src/Config/Processor.php
@@ -19,8 +19,8 @@ class Processor implements ProcessorInterface
     public const PROCESSORS = [
         self::BEFORE_NORMALIZATION => [
             RelayProcessor::class,
-            NamedConfigProcessor::class,
             BuilderProcessor::class,
+            NamedConfigProcessor::class,
             InheritanceProcessor::class,
         ],
         self::NORMALIZATION => [ExpressionProcessor::class],

--- a/src/Config/Processor/BuilderProcessor.php
+++ b/src/Config/Processor/BuilderProcessor.php
@@ -47,19 +47,42 @@ final class BuilderProcessor implements ProcessorInterface
      */
     public static function process(array $configs): array
     {
+        $addedTypes = [];
+        // map: "type name" => "provided by" for better DX, while debugging accidental type overrides in builders
+        $reservedTypesMap = \array_combine(
+            \array_keys($configs),
+            \array_fill(0, \count($configs), 'configs')
+        );
+
         foreach ($configs as &$config) {
             if (isset($config['config']['builders']) && \is_array($config['config']['builders'])) {
-                $buildersFields = self::processFieldsBuilders($config['config']['builders']);
-                $config['config']['fields'] = isset($config['config']['fields']) ? \array_merge($buildersFields, $config['config']['fields']) : $buildersFields;
+                ['fields' => $buildersFields, 'types' => $buildersTypes] = self::processFieldsBuilders(
+                    $config['config']['builders'],
+                    $reservedTypesMap
+                );
+
+                $config['config']['fields'] = isset($config['config']['fields'])
+                    ? \array_merge($buildersFields, $config['config']['fields'])
+                    : $buildersFields;
+
+                $addedTypes = \array_merge($addedTypes, $buildersTypes);
+
                 unset($config['config']['builders']);
             }
 
             if (isset($config['config']['fields']) && \is_array($config['config']['fields'])) {
-                $config['config']['fields'] = self::processFieldBuilders($config['config']['fields']);
+                ['fields' => $buildersFields, 'types' => $buildersTypes] = self::processFieldBuilders(
+                    $config['config']['fields'],
+                    $reservedTypesMap
+                );
+
+                $config['config']['fields'] = $buildersFields;
+
+                $addedTypes = \array_merge($addedTypes, $buildersTypes);
             }
         }
 
-        return $configs;
+        return \array_merge($configs, $addedTypes);
     }
 
     public static function addBuilderClass($name, $type, $builderClass): void
@@ -100,8 +123,10 @@ final class BuilderProcessor implements ProcessorInterface
         }
     }
 
-    private static function processFieldBuilders(array $fields)
+    private static function processFieldBuilders(array $fields, array &$reservedTypesMap)
     {
+        $newTypes = [];
+
         foreach ($fields as &$field) {
             $fieldBuilderName = null;
 
@@ -126,30 +151,92 @@ final class BuilderProcessor implements ProcessorInterface
             }
 
             if ($fieldBuilderName) {
-                $buildField = self::getBuilder($fieldBuilderName, self::BUILDER_FIELD_TYPE)->toMappingDefinition($builderConfig);
-                $field = \is_array($field) ? \array_merge($buildField, $field) : $buildField;
+                $mapping = self::getFieldBuilderMapping($fieldBuilderName, self::BUILDER_FIELD_TYPE, $builderConfig, $reservedTypesMap);
+
+                $fieldMapping = $mapping['field'];
+                $field = \is_array($field) ? \array_merge($fieldMapping, $field) : $fieldMapping;
+                $newTypes = \array_merge($newTypes, $mapping['types']);
             }
             if (isset($field['argsBuilder'])) {
                 $field = self::processFieldArgumentsBuilders($field);
             }
         }
 
-        return $fields;
+        return [
+            'fields' => $fields,
+            'types' => $newTypes,
+        ];
     }
 
-    private static function processFieldsBuilders(array $builders)
+    private static function processFieldsBuilders(array $builders, array &$reservedTypesMap)
     {
         $fields = [];
+        $newTypes = [];
+
         foreach ($builders as $builder) {
             $builderName = $builder['builder'];
-            $builderConfig = null;
-            if (isset($builder['builderConfig'])) {
-                $builderConfig = $builder['builderConfig'];
-            }
-            $fields = \array_merge($fields, self::getBuilder($builderName, self::BUILDER_FIELDS_TYPE)->toMappingDefinition($builderConfig));
+            $builderConfig = $builder['builderConfig'] ?? null;
+
+            $mapping = self::getFieldBuilderMapping($builderName, self::BUILDER_FIELDS_TYPE, $builderConfig, $reservedTypesMap);
+
+            $fields = \array_merge($fields, $mapping['fields']);
+            $newTypes = \array_merge($newTypes, $mapping['types']);
         }
 
-        return $fields;
+        return [
+            'fields' => $fields,
+            'types' => $newTypes,
+        ];
+    }
+
+    /**
+     * @param string $builderName
+     * @param string $builderType
+     * @param array  $builderConfig
+     * @param array  $reservedTypesMap
+     *
+     * @return array
+     *
+     * @throws InvalidConfigurationException
+     */
+    private static function getFieldBuilderMapping(string $builderName, string $builderType, array $builderConfig, array &$reservedTypesMap)
+    {
+        $builder = self::getBuilder($builderName, $builderType);
+        $mapping = $builder->toMappingDefinition($builderConfig);
+
+        $fieldMappingKey = null;
+
+        if (self::BUILDER_FIELD_TYPE === $builderType) {
+            $fieldMappingKey = 'field';
+        } elseif (self::BUILDER_FIELDS_TYPE === $builderType) {
+            $fieldMappingKey = 'fields';
+        }
+
+        $fieldMapping = $mapping[$fieldMappingKey] ?? $mapping;
+        $typesMapping = [];
+
+        if (isset($mapping[$fieldMappingKey], $mapping['types'])) {
+            $builderClass = \get_class($builder);
+
+            foreach ($mapping['types'] as $typeName => $typeConfig) {
+                if (isset($reservedTypesMap[$typeName])) {
+                    throw new InvalidConfigurationException(\sprintf(
+                        'Type "%s" emitted by builder "%s" already exists. Type was provided by "%s". Builder may only emit new types. Overriding is not allowed.',
+                        $typeName,
+                        $builderClass,
+                        $reservedTypesMap[$typeName]
+                    ));
+                }
+
+                $reservedTypesMap[$typeName] = $builderClass;
+                $typesMapping[$typeName] = $typeConfig;
+            }
+        }
+
+        return [
+            $fieldMappingKey => $fieldMapping,
+            'types' => $typesMapping,
+        ];
     }
 
     /**

--- a/tests/DependencyInjection/Builder/BoxFields.php
+++ b/tests/DependencyInjection/Builder/BoxFields.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\DependencyInjection\Builder;
+
+use Overblog\GraphQLBundle\Definition\Builder\MappingInterface;
+
+class BoxFields implements MappingInterface
+{
+    public function toMappingDefinition(array $config): array
+    {
+        $mapping = [];
+
+        foreach ($config as $boxField => $itemType) {
+            $boxType = $itemType.'Box';
+
+            $mapping['fields'][$boxField] = ['type' => $boxType.'!'];
+            $mapping['types'][$boxType] = [
+                'type' => 'object',
+                'config' => [
+                    'fields' => [
+                        'isEmpty' => ['type' => 'Boolean!'],
+                        'item' => ['type' => $itemType],
+                    ],
+                ],
+            ];
+        }
+
+        return $mapping;
+    }
+}

--- a/tests/DependencyInjection/Builder/MutationField.php
+++ b/tests/DependencyInjection/Builder/MutationField.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\DependencyInjection\Builder;
+
+use Overblog\GraphQLBundle\Definition\Builder\MappingInterface;
+
+final class MutationField implements MappingInterface
+{
+    public function toMappingDefinition(array $config): array
+    {
+        $name = $config['name'] ?? null;
+        $resolver = $config['resolver'] ?? null;
+        $inputFields = $config['inputFields'] ?? [];
+
+        $successPayloadFields = $config['payloadFields'] ?? null;
+        $failurePayloadFields = [
+            '_error' => ['type' => 'String'],
+        ];
+
+        foreach (\array_keys($inputFields) as $fieldName) {
+            $failurePayloadFields[$fieldName] = ['type' => 'String'];
+        }
+
+        $payloadTypeName = $name.'Payload';
+        $payloadSuccessTypeName = $name.'SuccessPayload';
+        $payloadFailureTypeName = $name.'FailurePayload';
+        $inputTypeName = $name.'Input';
+
+        $field = [
+            'type' => $payloadTypeName.'!',
+            'resolve' => \sprintf('@=mutation("%s", [args["input"]])', $resolver),
+            'args' => [
+                'input' => $inputTypeName.'!',
+            ],
+        ];
+
+        $types = [
+            $inputTypeName => [
+                'type' => 'input-object',
+                'config' => [
+                    'fields' => $inputFields,
+                ],
+            ],
+            $payloadTypeName => [
+                'type' => 'union',
+                'config' => [
+                    'types' => [$payloadSuccessTypeName, $payloadFailureTypeName],
+                    'resolveType' => \sprintf(
+                        '@=resolver("PayloadTypeResolver", [value, "%s", "%s"])',
+                        $payloadSuccessTypeName,
+                        $payloadFailureTypeName
+                    ),
+                ],
+            ],
+            $payloadSuccessTypeName => [
+                'type' => 'object',
+                'config' => [
+                    'fields' => $successPayloadFields,
+                ],
+            ],
+            $payloadFailureTypeName => [
+                'type' => 'object',
+                'config' => [
+                    'fields' => $failurePayloadFields,
+                ],
+            ],
+        ];
+
+        return ['field' => $field, 'types' => $types];
+    }
+}

--- a/tests/DependencyInjection/OverblogGraphQLTypesExtensionTest.php
+++ b/tests/DependencyInjection/OverblogGraphQLTypesExtensionTest.php
@@ -9,10 +9,13 @@ use Overblog\GraphQLBundle\Config\Processor\InheritanceProcessor;
 use Overblog\GraphQLBundle\DependencyInjection\OverblogGraphQLExtension;
 use Overblog\GraphQLBundle\DependencyInjection\OverblogGraphQLTypesExtension;
 use Overblog\GraphQLBundle\Error\UserWarning;
+use Overblog\GraphQLBundle\Tests\DependencyInjection\Builder\BoxFields;
+use Overblog\GraphQLBundle\Tests\DependencyInjection\Builder\MutationField;
 use Overblog\GraphQLBundle\Tests\DependencyInjection\Builder\PagerArgs;
 use Overblog\GraphQLBundle\Tests\DependencyInjection\Builder\RawIdField;
 use Overblog\GraphQLBundle\Tests\DependencyInjection\Builder\TimestampFields;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 
@@ -81,6 +84,31 @@ class OverblogGraphQLTypesExtensionTest extends TestCase
     }
 
     /**
+     * @dataProvider fieldBuilderTypeOverrideNotAllowedProvider
+     * @runInSeparateProcess
+     *
+     * @param array  $builders
+     * @param array  $configs
+     * @param string $exceptionClass
+     * @param string $exceptionMessage
+     */
+    public function testFieldBuilderTypeOverrideNotAllowed(array $builders, array $configs, string $exceptionClass, string $exceptionMessage): void
+    {
+        $ext = new OverblogGraphQLExtension();
+        $ext->load(
+            [
+                ['definitions' => ['builders' => $builders]],
+            ],
+            $this->container
+        );
+
+        $this->expectException($exceptionClass);
+        $this->expectExceptionMessage($exceptionMessage);
+
+        $this->extension->load([$configs], $this->container);
+    }
+
+    /**
      * @runInSeparateProcess
      */
     public function testCustomExceptions(): void
@@ -126,9 +154,11 @@ class OverblogGraphQLTypesExtensionTest extends TestCase
                         'builders' => [
                             'field' => [
                                 'RawId' => RawIdField::class,
+                                'Mutation' => MutationField::class,
                             ],
                             'fields' => [
                                 'Timestamps' => TimestampFields::class,
+                                'Boxes' => BoxFields::class,
                             ],
                             'args' => [
                                 [
@@ -172,6 +202,40 @@ class OverblogGraphQLTypesExtensionTest extends TestCase
                                 'categories2' => [
                                     'type' => '[String!]!',
                                     'argsBuilder' => ['builder' => 'Pager', 'config' => ['defaultLimit' => 50]],
+                                ],
+                            ],
+                        ],
+                    ],
+                    'Boxes' => [
+                        'type' => 'object',
+                        'config' => [
+                            'builders' => [
+                                [
+                                    'builder' => 'Boxes',
+                                    'builderConfig' => [
+                                        'foo' => 'Foo',
+                                        'bar' => 'Bar',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    'Mutation' => [
+                        'type' => 'object',
+                        'config' => [
+                            'fields' => [
+                                'foo' => [
+                                    'builder' => 'Mutation',
+                                    'builderConfig' => [
+                                        'name' => 'Foo',
+                                        'resolver' => 'Mutation.foo',
+                                        'inputFields' => [
+                                            'bar' => ['type' => 'String!'],
+                                        ],
+                                        'payloadFields' => [
+                                            'fooString' => ['type' => 'String!'],
+                                        ],
+                                    ],
                                 ],
                             ],
                         ],
@@ -259,6 +323,123 @@ class OverblogGraphQLTypesExtensionTest extends TestCase
                         'interfaces' => [],
                     ],
                 ],
+                'Boxes' => [
+                    'type' => 'object',
+                    'class_name' => 'BoxesType',
+                    InheritanceProcessor::INHERITS_KEY => [],
+                    'decorator' => false,
+                    'config' => [
+                        'fields' => [
+                            'foo' => ['type' => 'FooBox!', 'args' => []],
+                            'bar' => ['type' => 'BarBox!', 'args' => []],
+                        ],
+                        'name' => 'Boxes',
+                        'builders' => [],
+                        'interfaces' => [],
+                    ],
+                ],
+                'Mutation' => [
+                    'type' => 'object',
+                    'class_name' => 'MutationType',
+                    InheritanceProcessor::INHERITS_KEY => [],
+                    'decorator' => false,
+                    'config' => [
+                        'fields' => [
+                            'foo' => [
+                                'type' => 'FooPayload!',
+                                'resolve' => '@=mutation("Mutation.foo", [args["input"]])',
+                                'args' => [
+                                    'input' => ['type' => 'FooInput!'],
+                                ],
+                            ],
+                        ],
+                        'name' => 'Mutation',
+                        'builders' => [],
+                        'interfaces' => [],
+                    ],
+                ],
+                'FooBox' => [
+                    'type' => 'object',
+                    'class_name' => 'FooBoxType',
+                    InheritanceProcessor::INHERITS_KEY => [],
+                    'decorator' => false,
+                    'config' => [
+                        'fields' => [
+                            'isEmpty' => ['type' => 'Boolean!', 'args' => []],
+                            'item' => ['type' => 'Foo', 'args' => []],
+                        ],
+                        'name' => 'FooBox',
+                        'builders' => [],
+                        'interfaces' => [],
+                    ],
+                ],
+                'BarBox' => [
+                    'type' => 'object',
+                    'class_name' => 'BarBoxType',
+                    InheritanceProcessor::INHERITS_KEY => [],
+                    'decorator' => false,
+                    'config' => [
+                        'fields' => [
+                            'isEmpty' => ['type' => 'Boolean!', 'args' => []],
+                            'item' => ['type' => 'Bar', 'args' => []],
+                        ],
+                        'name' => 'BarBox',
+                        'builders' => [],
+                        'interfaces' => [],
+                    ],
+                ],
+                'FooInput' => [
+                    'type' => 'input-object',
+                    'class_name' => 'FooInputType',
+                    InheritanceProcessor::INHERITS_KEY => [],
+                    'decorator' => false,
+                    'config' => [
+                        'fields' => [
+                            'bar' => ['type' => 'String!'],
+                        ],
+                        'name' => 'FooInput',
+                    ],
+                ],
+                'FooPayload' => [
+                    'type' => 'union',
+                    'class_name' => 'FooPayloadType',
+                    InheritanceProcessor::INHERITS_KEY => [],
+                    'decorator' => false,
+                    'config' => [
+                        'types' => ['FooSuccessPayload', 'FooFailurePayload'],
+                        'resolveType' => '@=resolver("PayloadTypeResolver", [value, "FooSuccessPayload", "FooFailurePayload"])',
+                        'name' => 'FooPayload',
+                    ],
+                ],
+                'FooSuccessPayload' => [
+                    'type' => 'object',
+                    'class_name' => 'FooSuccessPayloadType',
+                    InheritanceProcessor::INHERITS_KEY => [],
+                    'decorator' => false,
+                    'config' => [
+                        'fields' => [
+                            'fooString' => ['type' => 'String!', 'args' => []],
+                        ],
+                        'name' => 'FooSuccessPayload',
+                        'builders' => [],
+                        'interfaces' => [],
+                    ],
+                ],
+                'FooFailurePayload' => [
+                    'type' => 'object',
+                    'class_name' => 'FooFailurePayloadType',
+                    InheritanceProcessor::INHERITS_KEY => [],
+                    'decorator' => false,
+                    'config' => [
+                        'fields' => [
+                            '_error' => ['type' => 'String', 'args' => []],
+                            'bar' => ['type' => 'String', 'args' => []],
+                        ],
+                        'name' => 'FooFailurePayload',
+                        'builders' => [],
+                        'interfaces' => [],
+                    ],
+                ],
             ],
             $this->container->getParameter('overblog_graphql_types.config')
         );
@@ -291,5 +472,111 @@ class OverblogGraphQLTypesExtensionTest extends TestCase
         ];
 
         return $config;
+    }
+
+    public function fieldBuilderTypeOverrideNotAllowedProvider()
+    {
+        $expectedMessage = 'Type "%s" emitted by builder "%s" already exists. Type was provided by "%s". Builder may only emit new types. Overriding is not allowed.';
+
+        $simpleObjectType = [
+            'type' => 'object',
+            'config' => [
+                'fields' => [
+                    'value' => ['type' => 'String'],
+                ],
+            ],
+        ];
+
+        $mutationFieldBuilder = [
+            'builder' => 'Mutation',
+            'builderConfig' => [
+                'name' => 'Foo',
+                'resolver' => 'Mutation.foo',
+                'inputFields' => [
+                    'bar' => ['type' => 'String!'],
+                ],
+                'payloadFields' => [
+                    'fooString' => ['type' => 'String!'],
+                ],
+            ],
+        ];
+
+        $boxFieldsBuilders = [
+            [
+                'builder' => 'Boxes',
+                'builderConfig' => [
+                    'foo' => 'Foo',
+                    'bar' => 'Bar',
+                ],
+            ],
+        ];
+
+        return [
+            [
+                ['field' => ['Mutation' => MutationField::class]],
+                [
+                    'Mutation' => [
+                        'type' => 'object',
+                        'config' => [
+                            'fields' => [
+                                'foo' => $mutationFieldBuilder,
+                            ],
+                        ],
+                    ],
+                    'FooInput' => $simpleObjectType,
+                ],
+                InvalidConfigurationException::class,
+                \sprintf($expectedMessage, 'FooInput', MutationField::class, 'configs'),
+            ],
+            [
+                ['field' => ['Mutation' => MutationField::class]],
+                [
+                    'Mutation' => [
+                        'type' => 'object',
+                        'config' => [
+                            'fields' => [
+                                'foo' => $mutationFieldBuilder,
+                                'bar' => $mutationFieldBuilder,
+                            ],
+                        ],
+                    ],
+                ],
+                InvalidConfigurationException::class,
+                \sprintf($expectedMessage, 'FooInput', MutationField::class, MutationField::class),
+            ],
+            [
+                ['fields' => ['Boxes' => BoxFields::class]],
+                [
+                    'Boxes' => [
+                        'type' => 'object',
+                        'config' => [
+                            'builders' => $boxFieldsBuilders,
+                        ],
+                    ],
+                    'FooBox' => $simpleObjectType,
+                ],
+                InvalidConfigurationException::class,
+                \sprintf($expectedMessage, 'FooBox', BoxFields::class, 'configs'),
+            ],
+            [
+                ['fields' => ['Boxes' => BoxFields::class]],
+                [
+                    'Boxes' => [
+                        'type' => 'object',
+                        'config' => [
+                            'builders' => $boxFieldsBuilders,
+                        ],
+                    ],
+                    'OtherBoxes' => [
+                        'type' => 'object',
+                        'config' => [
+                            'builders' => $boxFieldsBuilders,
+                        ],
+                    ],
+                ],
+                InvalidConfigurationException::class,
+                \sprintf($expectedMessage, 'FooBox', BoxFields::class, BoxFields::class),
+            ],
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #290
| License       | MIT

Todo:
- [x] Implement: Allow `field` builder emit extra types (BC)
- [x] Unit test for the above
- [x] Implement: Allow `fields` builder emit extra types (BC)
- [x] Unit test for the above
- [x] Adjust things according to decisions below
- [x] Tests for api abuse detecting, when builders accidentally override types

Todo decision making (please give your feedback on this):
- [x] Should extra types emitted by builders be allowed to override existing types or not? 
**Current behavior**: override. 
**My suggetion**: Do not allow, throw exception - otherwise hard to debug issues can happen.
- [x] Should extra types emitted by `fields` builders be allowed to use other builders?
**Current behavior**: No, they are not processed. Those  types are "completed" as provided by the builder
**My suggestion**: Leave it this way. Prevents a lot of configuration complexity and handling of infinite recursions is not needed this way.