### PR TITLE
Fix readme missing link to fields builder docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Documentation
     - [Mutation](docs/definitions/relay/mutation.md)
   - [Builders](docs/definitions/builders/index.md)
     - [Field Builder](docs/definitions/builders/field.md)
+    - [Fields Builder](docs/definitions/builders/fields.md)
     - [Args Builder](docs/definitions/builders/args.md)
   - [Expression language](docs/definitions/expression-language.md)
   - [Debug](docs/definitions/debug/index.md)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets |
| License       | MIT

Just a missing doc link