### PR TITLE
Validate configuration for `MutationFieldDefinition`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     },
     "require": {
         "php": ">=7.1",
+        "ext-json": "*",
         "psr/log": "^1.0",
         "symfony/config": "^3.4 || ^4.0",
         "symfony/dependency-injection": "^3.4 || ^4.0",
@@ -38,7 +39,7 @@
         "symfony/options-resolver": "^3.4 || ^4.0",
         "symfony/property-access": "^3.4 || ^4.0",
         "webonyx/graphql-php": "^0.13.0"
-},
+    },
     "replace": {
         "overblog/graphql-php-generator": "self.version"
     },

--- a/src/Relay/Mutation/MutationFieldDefinition.php
+++ b/src/Relay/Mutation/MutationFieldDefinition.php
@@ -14,13 +14,11 @@ final class MutationFieldDefinition implements MappingInterface
     public function toMappingDefinition(array $config): array
     {
         $mutateAndGetPayload = $this->cleanMutateAndGetPayload($config);
-        $payloadType = isset($config['payloadType']) && \is_string($config['payloadType']) ? $config['payloadType'] : null;
-        $inputType = isset($config['inputType']) && \is_string($config['inputType']) ? $config['inputType'].'!' : null;
 
         return [
-            'type' => $payloadType,
+            'type' => $this->extractPayloadType($config),
             'args' => [
-                'input' => ['type' => $inputType],
+                'input' => ['type' => $this->extractInputType($config)],
             ],
             'resolve' => "@=resolver('relay_mutation_field', [args, context, info, mutateAndGetPayloadCallback($mutateAndGetPayload)])",
         ];
@@ -60,5 +58,15 @@ final class MutationFieldDefinition implements MappingInterface
         if (!\is_array($mutateAndGetPayload)) {
             throw new InvalidArgumentException(\sprintf('Invalid format for "%s" configuration.', self::KEY_MUTATE_GET_PAYLOAD));
         }
+    }
+
+    private function extractPayloadType(array $config): ?string
+    {
+        return isset($config['payloadType']) && \is_string($config['payloadType']) ? $config['payloadType'] : null;
+    }
+
+    private function extractInputType(array $config): ?string
+    {
+        return isset($config['inputType']) && \is_string($config['inputType']) ? $config['inputType'].'!' : null;
     }
 }

--- a/src/Relay/Mutation/MutationFieldDefinition.php
+++ b/src/Relay/Mutation/MutationFieldDefinition.php
@@ -4,17 +4,16 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Relay\Mutation;
 
+use InvalidArgumentException;
 use Overblog\GraphQLBundle\Definition\Builder\MappingInterface;
 
 final class MutationFieldDefinition implements MappingInterface
 {
+    private const KEY_MUTATE_GET_PAYLOAD = 'mutateAndGetPayload';
+
     public function toMappingDefinition(array $config): array
     {
-        if (!\array_key_exists('mutateAndGetPayload', $config)) {
-            throw new \InvalidArgumentException('Mutation "mutateAndGetPayload" config is required.');
-        }
-
-        $mutateAndGetPayload = $this->cleanMutateAndGetPayload($config['mutateAndGetPayload']);
+        $mutateAndGetPayload = $this->cleanMutateAndGetPayload($config);
         $payloadType = isset($config['payloadType']) && \is_string($config['payloadType']) ? $config['payloadType'] : null;
         $inputType = isset($config['inputType']) && \is_string($config['inputType']) ? $config['inputType'].'!' : null;
 
@@ -27,14 +26,39 @@ final class MutationFieldDefinition implements MappingInterface
         ];
     }
 
-    private function cleanMutateAndGetPayload($mutateAndGetPayload)
+    private function cleanMutateAndGetPayload($config): string
     {
-        if (\is_string($mutateAndGetPayload) && 0 === \strpos($mutateAndGetPayload, '@=')) {
-            $cleanMutateAndGetPayload = \substr($mutateAndGetPayload, 2);
-        } else {
-            $cleanMutateAndGetPayload = \json_encode($mutateAndGetPayload);
+        $mutateAndGetPayload = $config[self::KEY_MUTATE_GET_PAYLOAD] ?? null;
+        $this->ensureValidMutateAndGetPayloadConfiguration($mutateAndGetPayload);
+
+        if (\is_string($mutateAndGetPayload)) {
+            return \substr($mutateAndGetPayload, 2);
         }
 
-        return $cleanMutateAndGetPayload;
+        return \json_encode($mutateAndGetPayload);
+    }
+
+    /**
+     * @param mixed $mutateAndGetPayload
+     *
+     * @throws InvalidArgumentException
+     */
+    private function ensureValidMutateAndGetPayloadConfiguration($mutateAndGetPayload): void
+    {
+        if (\is_string($mutateAndGetPayload) && 0 === \strpos($mutateAndGetPayload, '@=')) {
+            return;
+        }
+
+        if (null === $mutateAndGetPayload) {
+            throw new InvalidArgumentException(\sprintf('Mutation "%s" config is required.', self::KEY_MUTATE_GET_PAYLOAD));
+        }
+
+        if (\is_string($mutateAndGetPayload)) {
+            throw new InvalidArgumentException(\sprintf('Cannot parse "%s" configuration string.', self::KEY_MUTATE_GET_PAYLOAD));
+        }
+
+        if (!\is_array($mutateAndGetPayload)) {
+            throw new InvalidArgumentException(\sprintf('Invalid format for "%s" configuration.', self::KEY_MUTATE_GET_PAYLOAD));
+        }
     }
 }

--- a/tests/Relay/Mutation/MutationFieldDefinitionTest.php
+++ b/tests/Relay/Mutation/MutationFieldDefinitionTest.php
@@ -20,9 +20,37 @@ class MutationFieldDefinitionTest extends TestCase
     /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Mutation "mutateAndGetPayload" config is required.
+     *
+     * @dataProvider undefinedMutateAndGetPayloadProvider
      */
-    public function testUndefinedMutateAndGetPayloadConfig(): void
+    public function testUndefinedMutateAndGetPayloadConfig(array $config): void
     {
-        $this->definition->toMappingDefinition([]);
+        $this->definition->toMappingDefinition($config);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Cannot parse "mutateAndGetPayload" configuration string.
+     */
+    public function testInvalidMutateAndGetPayloadString(): void
+    {
+        $this->definition->toMappingDefinition(['mutateAndGetPayload' => 'Some invalid string']);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Invalid format for "mutateAndGetPayload" configuration.
+     */
+    public function testInvalidMutateAndGetPayloadFormat(): void
+    {
+        $this->definition->toMappingDefinition(['mutateAndGetPayload' => 123]);
+    }
+
+    public function undefinedMutateAndGetPayloadProvider(): array
+    {
+        return [
+            [[]],
+            [['mutateAndGetPayload' => null]],
+        ];
     }
 }

--- a/tests/Relay/Mutation/MutationFieldDefinitionTest.php
+++ b/tests/Relay/Mutation/MutationFieldDefinitionTest.php
@@ -18,6 +18,17 @@ class MutationFieldDefinitionTest extends TestCase
     }
 
     /**
+     * @dataProvider validConfigurationProvider
+     */
+    public function testToMappingDefinition(array $config, array $expectedMapping): void
+    {
+        self::assertEquals(
+            $expectedMapping,
+            $this->definition->toMappingDefinition($config)
+        );
+    }
+
+    /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Mutation "mutateAndGetPayload" config is required.
      *
@@ -44,6 +55,38 @@ class MutationFieldDefinitionTest extends TestCase
     public function testInvalidMutateAndGetPayloadFormat(): void
     {
         $this->definition->toMappingDefinition(['mutateAndGetPayload' => 123]);
+    }
+
+    public function validConfigurationProvider(): array
+    {
+        return [
+            'types not string return null' => [[
+                'payloadType' => 123,
+                'inputType' => [],
+                'mutateAndGetPayload' => '@=foobar',
+            ], [
+                'type' => null,
+                'args' => [
+                    'input' => [
+                        'type' => null,
+                    ],
+                ],
+                'resolve' => '@=resolver(\'relay_mutation_field\', [args, context, info, mutateAndGetPayloadCallback(foobar)])',
+            ]],
+            'types set as string return expected type string' => [[
+                'payloadType' => 'foo',
+                'inputType' => 'bar',
+                'mutateAndGetPayload' => '@=foobar',
+            ], [
+                'type' => 'foo',
+                'args' => [
+                    'input' => [
+                        'type' => 'bar!',
+                    ],
+                ],
+                'resolve' => '@=resolver(\'relay_mutation_field\', [args, context, info, mutateAndGetPayloadCallback(foobar)])',
+            ]],
+        ];
     }
 
     public function undefinedMutateAndGetPayloadProvider(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| License       | MIT

The reason for this change is that when you use Symfony Expression language to configure mutation types, there is really no validation for it. If, for instance, one just passes a string without the expression trigger `@=`, the string will just be `json_encoded` and you won't end up with a valid callable, i.e.:
```
"mutation('graphql.some_mutation', [value['foo'], value['bar']])"
"{"mutation":"graphql.some_other_mutation"}"
```
(correct), versus:
```
""mutation('graphql.some_mutation', [value['foo'], value['bar']])""
```
(incorrect).

It would then not not be able to resolve the mutation response and complain that it
`Cannot return null for non-nullable field some_mutation.id`, which doesn't tell the developer anything. It took our team a really long time to figure out we were missing the `=` in the expression trigger.

Therefore (as far as I understand it) we should always expect either an expression string or an array. Please let me know if I've misunderstood and we should also accept regular string callables. In that case, we should probably change where it `json_encode`s any string that is not an expression.

Lastly the `MutationFieldDefinition` class was lacking some coverage so that's been improved a bit. 