### PR TITLE
Fix transforming falsy values (fixes #486)

### DIFF
--- a/src/Transformer/ArgumentsTransformer.php
+++ b/src/Transformer/ArgumentsTransformer.php
@@ -78,7 +78,7 @@ class ArgumentsTransformer
      */
     private function populateObject(Type $type, $data, bool $multiple, ResolveInfo $info)
     {
-        if (!$data) {
+        if ($data === null) {
             return $data;
         }
 

--- a/src/Transformer/ArgumentsTransformer.php
+++ b/src/Transformer/ArgumentsTransformer.php
@@ -78,7 +78,7 @@ class ArgumentsTransformer
      */
     private function populateObject(Type $type, $data, bool $multiple, ResolveInfo $info)
     {
-        if ($data === null) {
+        if (null === $data) {
             return $data;
         }
 

--- a/tests/Transformer/ArgumentsTransformerTest.php
+++ b/tests/Transformer/ArgumentsTransformerTest.php
@@ -129,6 +129,10 @@ class ArgumentsTransformerTest extends TestCase
         $this->assertEquals(2, \count($res5[1]->field1));
         $this->assertInternalType('int', $res5[3]);
         $this->assertEquals($res5[4], 'test_string');
+
+        $data = [];
+        $res6 = $builder->getInstanceAndValidate('InputType1', $data, $info, 'input1');
+        $this->assertInstanceOf(InputType1::class, $res6);
     }
 
     public function testRaisedErrors(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #486
| License       | MIT

This fixes #486 by skipping object population only if the value is strictly null