### PR TITLE
Handle NonNull wrapped types & add tests

### DIFF
--- a/src/Transformer/ArgumentsTransformer.php
+++ b/src/Transformer/ArgumentsTransformer.php
@@ -7,6 +7,7 @@ namespace Overblog\GraphQLBundle\Transformer;
 use GraphQL\Type\Definition\EnumType;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\ListOfType;
+use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use Overblog\GraphQLBundle\Error\InvalidArgumentError;
@@ -80,6 +81,10 @@ class ArgumentsTransformer
     {
         if (null === $data) {
             return $data;
+        }
+
+        if ($type instanceof NonNull) {
+            $type = $type->getWrappedType();
         }
 
         if ($multiple) {

--- a/tests/Transformer/InputType2.php
+++ b/tests/Transformer/InputType2.php
@@ -9,4 +9,6 @@ class InputType2
     public $field1;
 
     public $field2;
+
+    public $field3;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| Tests pass?   | yes
| License       | MIT

Fix a bug in the arguments transformer when a type is non null, we must populate objects based on the wrapped type.
