### PR TITLE
Custom argument class

### DIFF
--- a/docs/definitions/resolver-map.md
+++ b/docs/definitions/resolver-map.md
@@ -60,8 +60,7 @@ namespace App\Resolver;
 use GraphQL\Error\Error;
 use GraphQL\Language\AST\StringValueNode;
 use GraphQL\Type\Definition\ResolveInfo;
-use GraphQL\Utils;
-use Overblog\GraphQLBundle\Definition\Argument;
+use Overblog\GraphQLBundle\Definition\ArgumentInterface;
 use Overblog\GraphQLBundle\Resolver\ResolverMap;
 
 class MyResolverMap extends ResolverMap
@@ -70,7 +69,7 @@ class MyResolverMap extends ResolverMap
     {
         return [
             'Query' => [
-                self::RESOLVE_FIELD => function ($value, Argument $args, \ArrayObject $context, ResolveInfo $info) {
+                self::RESOLVE_FIELD => function ($value, ArgumentInterface $args, \ArrayObject $context, ResolveInfo $info) {
                     if ('baz' === $info->fieldName) {
                         $id = (int) $args['id'];
 

--- a/src/Config/Processor/BuilderProcessor.php
+++ b/src/Config/Processor/BuilderProcessor.php
@@ -148,7 +148,7 @@ final class BuilderProcessor implements ProcessorInterface
                 unset($field['builderConfig']);
             }
 
-            if ($fieldBuilderName) {
+            if (\is_string($fieldBuilderName)) {
                 $mapping = self::getFieldBuilderMapping($fieldBuilderName, self::BUILDER_FIELD_TYPE, $builderConfig, $reservedTypesMap);
 
                 $fieldMapping = $mapping['field'];

--- a/src/Definition/Argument.php
+++ b/src/Definition/Argument.php
@@ -4,43 +4,70 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Definition;
 
-class Argument implements \ArrayAccess, \Countable
+class Argument implements ArgumentInterface
 {
     /** @var array */
-    private $arguments;
+    private $rawArguments = [];
 
-    public function __construct(array $arguments = null)
+    public function __construct(?array $rawArguments = null)
     {
-        $this->arguments = null === $arguments ? [] : $arguments;
+        $this->exchangeArray($rawArguments);
+    }
+
+    public function exchangeArray($array): array
+    {
+        $old = $this->rawArguments;
+        $this->rawArguments = $array ?? [];
+
+        return $old;
+    }
+
+    public function getArrayCopy(): array
+    {
+        return $this->rawArguments;
+    }
+
+    /**
+     * @return array
+     *
+     * @deprecated This method is deprecated since 0.12 and will be removed in 0.13. You should use getArrayCopy method instead.
+     */
+    public function getRawArguments(): array
+    {
+        @\trigger_error(
+            \sprintf(
+                'This "%s" method is deprecated since 0.12 and will be removed in 0.13. You should use "%s::getArrayCopy" instead.',
+                __METHOD__,
+                __CLASS__
+            ),
+            \E_USER_DEPRECATED
+        );
+
+        return $this->getArrayCopy();
     }
 
     public function offsetExists($offset)
     {
-        return \array_key_exists($offset, $this->arguments);
+        return \array_key_exists($offset, $this->rawArguments);
     }
 
     public function offsetGet($offset)
     {
-        return $this->offsetExists($offset) ? $this->arguments[$offset] : null;
+        return $this->offsetExists($offset) ? $this->rawArguments[$offset] : null;
     }
 
     public function offsetSet($offset, $value): void
     {
-        $this->arguments[$offset] = $value;
+        $this->rawArguments[$offset] = $value;
     }
 
     public function offsetUnset($offset): void
     {
-        unset($this->arguments[$offset]);
-    }
-
-    public function getRawArguments()
-    {
-        return $this->arguments;
+        unset($this->rawArguments[$offset]);
     }
 
     public function count()
     {
-        return \count($this->arguments);
+        return \count($this->rawArguments);
     }
 }

--- a/src/Definition/ArgumentFactory.php
+++ b/src/Definition/ArgumentFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Definition;
+
+class ArgumentFactory
+{
+    private $className;
+
+    public function __construct(string $className)
+    {
+        $this->className = $className;
+    }
+
+    /**
+     * @param array|null $rawArguments
+     *
+     * @return ArgumentInterface
+     */
+    public function create(?array $rawArguments): ArgumentInterface
+    {
+        $className = $this->className;
+        /** @var ArgumentInterface $arguments */
+        $arguments = new $className();
+        $arguments->exchangeArray($rawArguments);
+
+        return $arguments;
+    }
+
+    public function wrapResolverArgs(callable $resolver): \Closure
+    {
+        return function () use ($resolver) {
+            $args = \func_get_args();
+            if (isset($args[1]) && !$args[1] instanceof ArgumentInterface) {
+                $args[1] = $this->create($args[1]);
+            }
+
+            return $resolver(...$args);
+        };
+    }
+}

--- a/src/Definition/ArgumentInterface.php
+++ b/src/Definition/ArgumentInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Definition;
+
+interface ArgumentInterface extends \ArrayAccess, \Countable
+{
+    /**
+     * @param $array
+     *
+     * @return array the old array
+     */
+    public function exchangeArray($array): array;
+
+    public function getArrayCopy(): array;
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -6,6 +6,7 @@ namespace Overblog\GraphQLBundle\DependencyInjection;
 
 use GraphQL\Validator\Rules\QueryComplexity;
 use GraphQL\Validator\Rules\QueryDepth;
+use Overblog\GraphQLBundle\Definition\Argument;
 use Overblog\GraphQLBundle\Error\ErrorHandler;
 use Overblog\GraphQLBundle\EventListener\ErrorLoggerListener;
 use Overblog\GraphQLBundle\Resolver\Resolver;
@@ -109,10 +110,11 @@ class Configuration implements ConfigurationInterface
     {
         $builder = new TreeBuilder('definitions');
         /** @var ArrayNodeDefinition $node */
-        $node = \method_exists($builder, 'getRootNode') ? $builder->getRootNode() : $builder->root('definitions');
+        $node = self::getRootNodeWithoutDeprecation($builder, 'definitions');
         $node
             ->addDefaultsIfNotSet()
             ->children()
+                ->scalarNode('argument_class')->defaultValue(Argument::class)->end()
                 ->variableNode('default_resolver')->defaultValue([Resolver::class, 'defaultResolveFn'])->end()
                 ->scalarNode('class_namespace')->defaultValue('Overblog\\GraphQLBundle\\__DEFINITIONS__')->end()
                 ->scalarNode('cache_dir')->defaultNull()->end()

--- a/src/DependencyInjection/OverblogGraphQLExtension.php
+++ b/src/DependencyInjection/OverblogGraphQLExtension.php
@@ -115,6 +115,7 @@ class OverblogGraphQLExtension extends Extension implements PrependExtensionInte
         $container->setParameter($this->getAlias().'.class_namespace', $config['definitions']['class_namespace']);
         $container->setParameter($this->getAlias().'.cache_dir', $config['definitions']['cache_dir']);
         $container->setParameter($this->getAlias().'.cache_dir_permissions', $config['definitions']['cache_dir_permissions']);
+        $container->setParameter($this->getAlias().'.argument_class', $config['definitions']['argument_class']);
     }
 
     private function setBatchingMethod(array $config, ContainerBuilder $container): void

--- a/src/Generator/TypeGenerator.php
+++ b/src/Generator/TypeGenerator.php
@@ -6,7 +6,6 @@ namespace Overblog\GraphQLBundle\Generator;
 
 use Composer\Autoload\ClassLoader;
 use Overblog\GraphQLBundle\Config\Processor;
-use Overblog\GraphQLBundle\Definition\Argument;
 use Overblog\GraphQLBundle\Definition\Type\CustomScalarType;
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionLanguage;
 use Overblog\GraphQLGenerator\Generator\TypeGenerator as BaseTypeGenerator;
@@ -158,17 +157,15 @@ CODE;
             return $resolveComplexity;
         }
 
-        $argumentClass = $this->shortenClassName(Argument::class);
-
         $code = <<<'CODE'
 function ($childrenComplexity, $args = []) <closureUseStatements>{
 <spaces><spaces>$resolveComplexity = %s;
 
-<spaces><spaces>return call_user_func_array($resolveComplexity, [$childrenComplexity, new %s($args)]);
+<spaces><spaces>return call_user_func_array($resolveComplexity, [$childrenComplexity, $globalVariable->get('argumentFactory')->create($args)]);
 <spaces>}
 CODE;
 
-        $code = \sprintf($code, $resolveComplexity, $argumentClass);
+        $code = \sprintf($code, $resolveComplexity);
 
         return $code;
     }

--- a/src/GraphQL/Relay/Mutation/MutationFieldResolver.php
+++ b/src/GraphQL/Relay/Mutation/MutationFieldResolver.php
@@ -5,24 +5,26 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\GraphQL\Relay\Mutation;
 
 use GraphQL\Executor\Promise\PromiseAdapter;
-use Overblog\GraphQLBundle\Definition\Argument;
+use Overblog\GraphQLBundle\Definition\ArgumentFactory;
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
 use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
 use Overblog\GraphQLBundle\Resolver\Resolver;
 
 final class MutationFieldResolver implements ResolverInterface, AliasedInterface
 {
-    /** @var PromiseAdapter */
     private $promiseAdapter;
 
-    public function __construct(PromiseAdapter $promiseAdapter)
+    private $argumentFactory;
+
+    public function __construct(PromiseAdapter $promiseAdapter, ArgumentFactory $argumentFactory)
     {
         $this->promiseAdapter = $promiseAdapter;
+        $this->argumentFactory = $argumentFactory;
     }
 
     public function __invoke($args, $context, $info, \Closure $mutateAndGetPayloadCallback)
     {
-        $input = new Argument($args['input']);
+        $input = $this->argumentFactory->create($args['input']);
 
         return $this->promiseAdapter->createFulfilled($mutateAndGetPayloadCallback($input, $context, $info))
             ->then(function ($payload) use ($input) {

--- a/src/Relay/Connection/ConnectionBuilder.php
+++ b/src/Relay/Connection/ConnectionBuilder.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Relay\Connection;
 
-use Overblog\GraphQLBundle\Definition\Argument;
+use Overblog\GraphQLBundle\Definition\ArgumentInterface;
 use Overblog\GraphQLBundle\Relay\Connection\Output\Connection;
 use Overblog\GraphQLBundle\Relay\Connection\Output\Edge;
 use Overblog\GraphQLBundle\Relay\Connection\Output\PageInfo;
@@ -43,8 +43,8 @@ class ConnectionBuilder
      * a connection object for use in GraphQL. It uses array offsets as pagination,
      * so pagination will only work if the array is static.
      *
-     * @param array          $data
-     * @param array|Argument $args
+     * @param array                   $data
+     * @param array|ArgumentInterface $args
      *
      * @return ConnectionInterface
      */
@@ -64,8 +64,8 @@ class ConnectionBuilder
      * A version of `connectionFromArray` that takes a promised array, and returns a
      * promised connection.
      *
-     * @param mixed          $dataPromise a promise
-     * @param array|Argument $args
+     * @param mixed                   $dataPromise a promise
+     * @param array|ArgumentInterface $args
      *
      * @return mixed a promise
      */
@@ -87,16 +87,16 @@ class ConnectionBuilder
      * to materialize the entire array, and instead wish pass in a slice of the
      * total result large enough to cover the range specified in `args`.
      *
-     * @param array          $arraySlice
-     * @param array|Argument $args
-     * @param array          $meta
+     * @param array                   $arraySlice
+     * @param array|ArgumentInterface $args
+     * @param array                   $meta
      *
      * @return ConnectionInterface
      */
     public function connectionFromArraySlice(array $arraySlice, $args, array $meta): ConnectionInterface
     {
         $connectionArguments = $this->getOptionsWithDefaults(
-            $args instanceof Argument ? $args->getRawArguments() : $args,
+            $args instanceof ArgumentInterface ? $args->getArrayCopy() : $args,
             [
                 'after' => '',
                 'before' => '',
@@ -172,9 +172,9 @@ class ConnectionBuilder
      * A version of `connectionFromArraySlice` that takes a promised array slice,
      * and returns a promised connection.
      *
-     * @param mixed          $dataPromise a promise
-     * @param array|Argument $args
-     * @param array          $meta
+     * @param mixed                   $dataPromise a promise
+     * @param array|ArgumentInterface $args
+     * @param array                   $meta
      *
      * @return mixed a promise
      */

--- a/src/Resolver/Resolver.php
+++ b/src/Resolver/Resolver.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Resolver;
 
 use GraphQL\Type\Definition\ResolveInfo;
-use Overblog\GraphQLBundle\Definition\Argument;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 
@@ -45,18 +44,6 @@ class Resolver
         } elseif (\is_object($objectOrArray) && self::isWritable($objectOrArray, $fieldName)) {
             self::getAccessor()->setValue($objectOrArray, $fieldName, $value);
         }
-    }
-
-    public static function wrapArgs(callable $resolver)
-    {
-        return static function () use ($resolver) {
-            $args = \func_get_args();
-            if (\count($args) > 1 && !$args[1] instanceof Argument) {
-                $args[1] = new Argument($args[1]);
-            }
-
-            return $resolver(...$args);
-        };
     }
 
     private static function isReadable($objectOrArray, $indexOrProperty)

--- a/src/Resources/config/definition_config_processors.yml
+++ b/src/Resources/config/definition_config_processors.yml
@@ -16,6 +16,8 @@ services:
 
     Overblog\GraphQLBundle\Definition\ConfigProcessor\WrapArgumentConfigProcessor:
         class: Overblog\GraphQLBundle\Definition\ConfigProcessor\WrapArgumentConfigProcessor
+        arguments:
+            - '@Overblog\GraphQLBundle\Definition\ArgumentFactory'
         public: false
         tags:
             - { name: overblog_graphql.definition_config_processor }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -113,6 +113,12 @@ services:
 
             - ["setExpressionLanguage", ["@overblog_graphql.expression_language"]]
 
+    Overblog\GraphQLBundle\Definition\ArgumentFactory:
+        arguments:
+            - '%overblog_graphql.argument_class%'
+        tags:
+            - { name: overblog_graphql.global_variable, alias: argumentFactory }
+
     Overblog\GraphQLBundle\EventListener\RequestFilesListener:
         class: Overblog\GraphQLBundle\EventListener\RequestFilesListener
         public: true
@@ -122,7 +128,8 @@ services:
             - { name: kernel.event_listener, event: graphql.executor.context, method: onExecutorContextEvent }
 
     Overblog\GraphQLBundle\EventListener\TypeDecoratorListener:
-        class: Overblog\GraphQLBundle\EventListener\TypeDecoratorListener
+        arguments:
+            - '@Overblog\GraphQLBundle\Definition\ArgumentFactory'
         public: true
         tags:
             - { name: kernel.event_listener, event: graphql.type_loaded, method: onTypeLoaded }

--- a/tests/Definition/ArgumentTest.php
+++ b/tests/Definition/ArgumentTest.php
@@ -52,6 +52,16 @@ class ArgumentTest extends TestCase
 
     public function testGetRawArgs(): void
     {
+        $this->assertSame($this->rawArgs, $this->argument->getArrayCopy());
+    }
+
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecation This "%s" method is deprecated since 0.12 and will be removed in 0.13. You should use "%s::getArrayCopy" instead.
+     */
+    public function testDeprecatedGetRawArgs(): void
+    {
         $this->assertSame($this->rawArgs, $this->argument->getRawArguments());
     }
 }

--- a/tests/EventListener/TypeDecoratorListenerTest.php
+++ b/tests/EventListener/TypeDecoratorListenerTest.php
@@ -11,6 +11,7 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\UnionType;
 use Overblog\GraphQLBundle\Definition\Argument;
+use Overblog\GraphQLBundle\Definition\ArgumentFactory;
 use Overblog\GraphQLBundle\Definition\Type\CustomScalarType;
 use Overblog\GraphQLBundle\EventListener\TypeDecoratorListener;
 use Overblog\GraphQLBundle\Resolver\ResolverMap;
@@ -114,7 +115,7 @@ class TypeDecoratorListenerTest extends TestCase
         /** @var Argument $args */
         $args = $resolveFn(null, $expected);
         $this->assertInstanceOf(Argument::class, $args);
-        $this->assertSame($expected, $args->getRawArguments());
+        $this->assertSame($expected, $args->getArrayCopy());
     }
 
     public function testEnumTypeValuesDecoration(): void
@@ -285,7 +286,7 @@ class TypeDecoratorListenerTest extends TestCase
 
     private function decorate(array $types, array $map): void
     {
-        $typeDecoratorListener = new TypeDecoratorListener();
+        $typeDecoratorListener = new TypeDecoratorListener(new ArgumentFactory(Argument::class));
 
         foreach ($types as $type) {
             $typeDecoratorListener->decorateType($type, $this->createResolverMapMock($map));

--- a/tests/Functional/App/config/argumentWrapper/mapping/query.types.yml
+++ b/tests/Functional/App/config/argumentWrapper/mapping/query.types.yml
@@ -1,13 +1,13 @@
 RootQuery:
     type: object
     config:
-        resolveField: '@="Arguments: " ~ json_encode(args.getRawArguments()) ~ " | InstanceOf: " ~ json_encode(is_a(args, "Overblog\\GraphQLBundle\\Definition\\Argument"))'
+        resolveField: '@="Arguments: " ~ json_encode(args.getArrayCopy()) ~ " | InstanceOf: " ~ json_encode(is_a(args, "Overblog\\GraphQLBundle\\Definition\\Argument"))'
         fields:
             fieldWithResolverAndArgument:
                 type: String!
                 args:
                     name: {type: String!}
-                resolve: '@="Field resolver Arguments: " ~ json_encode(args.getRawArguments()) ~ " | InstanceOf: " ~ json_encode(is_a(args, "Overblog\\GraphQLBundle\\Definition\\Argument"))'
+                resolve: '@="Field resolver Arguments: " ~ json_encode(args.getArrayCopy()) ~ " | InstanceOf: " ~ json_encode(is_a(args, "Overblog\\GraphQLBundle\\Definition\\Argument"))'
             fieldWithDefaultResolverAndArgument:
                 type: String!
                 args:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #326 
| License       | MIT

Allow to customize Argument class using configuration:

```yaml
overblog_graphql:
    definitions:
        argument_class: 'Overblog\GraphQLBundle\Definition\Argument'
```

The argument class must implement `Overblog\GraphQLBundle\Definition\ArgumentInterface`