### PR TITLE
Fix body parsing for GET requests

### DIFF
--- a/src/Request/Parser.php
+++ b/src/Request/Parser.php
@@ -35,6 +35,7 @@ class Parser implements ParserInterface
     private function getParsedBody(Request $request): array
     {
         $body = $request->getContent();
+        $method = $request->getMethod();
         $contentType = \explode(';', (string) $request->headers->get('content-type'), 2)[0];
 
         switch ($contentType) {
@@ -46,6 +47,10 @@ class Parser implements ParserInterface
             // JSON object
             case static::CONTENT_TYPE_JSON:
                 if (empty($body)) {
+                    if (Request::METHOD_GET === $method) {
+                        $parsedBody = [];
+                        break;
+                    }
                     throw new BadRequestHttpException('The request content body must not be empty when using json content type request.');
                 }
 

--- a/tests/Functional/Controller/GraphControllerTest.php
+++ b/tests/Functional/Controller/GraphControllerTest.php
@@ -95,11 +95,18 @@ EOF;
      * @expectedException \Symfony\Component\HttpKernel\Exception\BadRequestHttpException
      * @expectedExceptionMessage The request content body must not be empty when using json content type request.
      */
-    public function testEndpointWithEmptyJsonBodyQuery(): void
+    public function testEndpointWithEmptyPostJsonBodyQuery(): void
     {
         $client = static::createClient();
-        $client->request('GET', '/', [], [], ['CONTENT_TYPE' => 'application/json']);
-        $client->getResponse()->getContent();
+        $client->request('POST', '/', [], [], ['CONTENT_TYPE' => 'application/json']);
+    }
+
+    public function testEndpointWithJsonContentTypeAndGetQuery(): void
+    {
+        $client = static::createClient(['test_case' => 'connectionWithCORS']);
+        $client->request('GET', '/', ['query' => $this->friendsQuery], [], ['CONTENT_TYPE' => 'application/json']);
+        $result = $client->getResponse()->getContent();
+        $this->assertSame(['data' => $this->expectedData], \json_decode($result, true), $result);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Documented?   | no
| Fixed tickets | none
| License       | MIT

Hi!

So I was reading the [serving-over-http](https://graphql.org/learn/serving-over-http/) section on graphql.org which states:

> Your GraphQL HTTP server should handle the HTTP GET and POST methods.

So I went ahead and tried using GET requests against a piece of software that uses the GraphQLBundle. For that our code returned `{"message":"The request content body must not be empty when using JSON content type request.","code":400}`.
A colleague and me searched further and ended up at `src/Request/Parser.php:33` and found that `getParsedBody` throws when the body is empty, but does not consider GET requests.

By looking trough the code my colleague found that we could use `$parsedBody = [];` in this case which we tested and confirmed to work on our machines.

I checked the tests and coding style and found that one test is now broken: `testEndpointWithEmptyJsonBodyQuery`. Since the test uses a GET I tried to simply use a POST instead because that is when it *should* break. Alas this turned out to break even more tests.
Sorry, that I haven't fixed this but I have trouble navigating the test structure.

If someone could help with the tests I'd be glad to see this PR going forward.

I hope this is an OK way to address this problem. If not I can happily file an issue instead.

-----

Addendum: I'm also not sure where and how this should be documented, but the initial Q/A table asked for that.