### PR TITLE
Add missing totalCount on RelayConnectionFieldsBuilder

### DIFF
--- a/src/Relay/Builder/RelayConnectionFieldsBuilder.php
+++ b/src/Relay/Builder/RelayConnectionFieldsBuilder.php
@@ -20,6 +20,8 @@ class RelayConnectionFieldsBuilder implements MappingInterface
         $pageInfoType = $config['pageInfoType'] ?? 'PageInfo';
         $pageInfoDescription = $config['pageInfoDescription'] ?? 'Page info of the connection';
 
+        $totalCountDescription = $config['totalCountDescription'] ?? 'Total count of items in the connection.';
+
         return [
             'edges' => [
                 'description' => $edgeDescription,
@@ -28,6 +30,10 @@ class RelayConnectionFieldsBuilder implements MappingInterface
             'pageInfo' => [
                 'description' => $pageInfoDescription,
                 'type' => $pageInfoType,
+            ],
+            'totalCount' => [
+                'description' => $totalCountDescription,
+                'type' => 'Int',
             ],
         ];
     }

--- a/tests/Relay/Builder/RelayConnectionFieldsBuilderTest.php
+++ b/tests/Relay/Builder/RelayConnectionFieldsBuilderTest.php
@@ -41,6 +41,7 @@ class RelayConnectionFieldsBuilderTest extends TestCase
             'edgeDescription' => 'Custom edge description',
             'pageInfoType' => 'CustomPageInfo',
             'pageInfoDescription' => 'Custom page info description',
+            'totalCountDescription' => 'Custom total count description',
         ];
         $expected = [
             'edges' => [
@@ -50,6 +51,10 @@ class RelayConnectionFieldsBuilderTest extends TestCase
             'pageInfo' => [
                 'description' => $config['pageInfoDescription'],
                 'type' => 'CustomPageInfo',
+            ],
+            'totalCount' => [
+                'description' => $config['totalCountDescription'],
+                'type' => 'Int',
             ],
         ];
         $this->assertSame($this->doMapping($config), $expected);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| Fixed tickets | N/A
| License       | MIT

This PR add the missing `totalCount` mapping definition in RelayConnectionFieldsBuilder.php as discussed in https://github.com/overblog/GraphQLBundle/pull/445
