### PR TITLE
Add missing alias for ArgumentsTransformer

### DIFF
--- a/src/Resources/config/aliases.yaml
+++ b/src/Resources/config/aliases.yaml
@@ -11,6 +11,7 @@ services:
     overblog_graphql.request_executor: '@Overblog\GraphQLBundle\Request\Executor'
     overblog_graphql.request_parser: '@Overblog\GraphQLBundle\Request\Parser'
     overblog_graphql.request_batch_parser: '@Overblog\GraphQLBundle\Request\BatchParser'
+    overblog_graphql.arguments_transformer: '@Overblog\GraphQLBundle\Transformer\ArgumentsTransformer'
 
     overblog_graphql.schema_builder:
         alias: 'Overblog\GraphQLBundle\Definition\Builder\SchemaBuilder'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | n/a
| License       | MIT

Fix an issue with the service `overblog_graphql.arguments_transformer` not being defined after https://github.com/overblog/GraphQLBundle/commit/9b753dcd57c9063e5fdcce1d35c317add98256dc
