### PR TITLE
Make resolution error message clearer

### DIFF
--- a/src/Definition/Builder/SchemaBuilder.php
+++ b/src/Definition/Builder/SchemaBuilder.php
@@ -64,7 +64,7 @@ class SchemaBuilder
             'types' => function () use ($types, $schemaName) {
                 $this->typeResolver->setCurrentSchemaName($schemaName);
 
-                return \array_map([$this->typeResolver, 'getSolution'], $types);
+                return \array_map([$this->typeResolver, 'resolve'], $types);
             },
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | dunno
| Documented?   | no
| Fixed tickets | N/A
| License       | MIT

I had a few types listed as follow:

```yaml
overblog_graphql:
    definitions:
        schema:
            #...
            types:
                - Foo
                # ...
```

But after some refactoring `Foo` has been changed to `Bar`. As a result the type `Foo` no longer existed and could not be loaded. Dumping the schema was resulting in a failure with the obscure error:

```
GraphQL\Error\InvariantViolation: Each entry of schema types must be instance of GraphQL\Type\Definition\Type but entry at 3 is null
```

And the trace was not much more helpful. With the following patch, the error is changed to:

```
LogicException: Could not load the type "Foo"
```