### PR TITLE
Move config parser to compiler pass

### DIFF
--- a/src/DependencyInjection/Compiler/TypeGeneratorPass.php
+++ b/src/DependencyInjection/Compiler/TypeGeneratorPass.php
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
-class ConfigTypesPass implements CompilerPassInterface
+class TypeGeneratorPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -8,6 +8,7 @@ use GraphQL\Executor\Promise\Adapter\SyncPromiseAdapter;
 use GraphQL\Validator\Rules\QueryComplexity;
 use GraphQL\Validator\Rules\QueryDepth;
 use Overblog\GraphQLBundle\Definition\Argument;
+use Overblog\GraphQLBundle\DependencyInjection\Compiler\ConfigParserPass;
 use Overblog\GraphQLBundle\Error\ErrorHandler;
 use Overblog\GraphQLBundle\EventListener\ErrorLoggerListener;
 use Overblog\GraphQLBundle\Executor\Executor;
@@ -257,10 +258,10 @@ class Configuration implements ConfigurationInterface
                         ->end()
                         ->children()
                             ->arrayNode('types')
-                                ->prototype('enum')->values(\array_keys(OverblogGraphQLTypesExtension::SUPPORTED_TYPES_EXTENSIONS))->isRequired()->end()
+                                ->prototype('enum')->values(\array_keys(ConfigParserPass::SUPPORTED_TYPES_EXTENSIONS))->isRequired()->end()
                             ->end()
                             ->scalarNode('dir')->defaultNull()->end()
-                            ->scalarNode('suffix')->defaultValue(OverblogGraphQLTypesExtension::DEFAULT_TYPES_SUFFIX)->end()
+                            ->scalarNode('suffix')->defaultValue(ConfigParserPass::DEFAULT_TYPES_SUFFIX)->end()
                         ->end()
                     ->end()
                 ->end()

--- a/src/OverblogGraphQLBundle.php
+++ b/src/OverblogGraphQLBundle.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle;
 
 use Overblog\GraphQLBundle\DependencyInjection\Compiler\AliasedPass;
-use Overblog\GraphQLBundle\DependencyInjection\Compiler\ConfigTypesPass;
+use Overblog\GraphQLBundle\DependencyInjection\Compiler\ConfigParserPass;
 use Overblog\GraphQLBundle\DependencyInjection\Compiler\ExpressionFunctionPass;
 use Overblog\GraphQLBundle\DependencyInjection\Compiler\GlobalVariablesPass;
 use Overblog\GraphQLBundle\DependencyInjection\Compiler\MutationTaggedServiceMappingTaggedPass;
 use Overblog\GraphQLBundle\DependencyInjection\Compiler\ResolverTaggedServiceMappingPass;
+use Overblog\GraphQLBundle\DependencyInjection\Compiler\TypeGeneratorPass;
 use Overblog\GraphQLBundle\DependencyInjection\Compiler\TypeTaggedServiceMappingPass;
 use Overblog\GraphQLBundle\DependencyInjection\OverblogGraphQLExtension;
-use Overblog\GraphQLBundle\DependencyInjection\OverblogGraphQLTypesExtension;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
@@ -27,16 +27,15 @@ class OverblogGraphQLBundle extends Bundle
     {
         parent::build($container);
 
-        //ConfigTypesPass must be before TypeTaggedServiceMappingPass
+        //TypeGeneratorPass must be before TypeTaggedServiceMappingPass
+        $container->addCompilerPass(new ConfigParserPass());
         $container->addCompilerPass(new GlobalVariablesPass());
         $container->addCompilerPass(new ExpressionFunctionPass());
         $container->addCompilerPass(new AliasedPass());
-        $container->addCompilerPass(new ConfigTypesPass(), PassConfig::TYPE_BEFORE_REMOVING);
+        $container->addCompilerPass(new TypeGeneratorPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $container->addCompilerPass(new TypeTaggedServiceMappingPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $container->addCompilerPass(new ResolverTaggedServiceMappingPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $container->addCompilerPass(new MutationTaggedServiceMappingTaggedPass(), PassConfig::TYPE_BEFORE_REMOVING);
-
-        $container->registerExtension(new OverblogGraphQLTypesExtension());
     }
 
     public function getContainerExtension()

--- a/tests/DependencyInjection/Compiler/ConfigParserPassTest.php
+++ b/tests/DependencyInjection/Compiler/ConfigParserPassTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Overblog\GraphQLBundle\Tests\DependencyInjection;
+namespace Overblog\GraphQLBundle\Tests\DependencyInjection\Compiler;
 
 use GraphQL\Error\UserError;
 use Overblog\GraphQLBundle\Config\Processor\InheritanceProcessor;
+use Overblog\GraphQLBundle\DependencyInjection\Compiler\ConfigParserPass;
 use Overblog\GraphQLBundle\DependencyInjection\OverblogGraphQLExtension;
-use Overblog\GraphQLBundle\DependencyInjection\OverblogGraphQLTypesExtension;
 use Overblog\GraphQLBundle\Error\UserWarning;
 use Overblog\GraphQLBundle\Tests\DependencyInjection\Builder\BoxFields;
 use Overblog\GraphQLBundle\Tests\DependencyInjection\Builder\MutationField;
@@ -20,60 +20,46 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 
-class OverblogGraphQLTypesExtensionTest extends TestCase
+class ConfigParserPassTest extends TestCase
 {
     /** @var ContainerBuilder */
     private $container;
 
-    /** @var OverblogGraphQLTypesExtension */
-    private $extension;
+    /** @var ConfigParserPass */
+    private $compilerPass;
 
     public function setUp(): void
     {
         $this->container = new ContainerBuilder();
         $this->container->setParameter('kernel.bundles', []);
         $this->container->setParameter('kernel.debug', false);
-        $this->extension = new OverblogGraphQLTypesExtension();
+        $this->compilerPass = new ConfigParserPass();
     }
 
     public function tearDown(): void
     {
-        unset($this->container, $this->extension);
-    }
-
-    public function testMultipleConfigNotAllowed(): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Configs type should never contain more than one config to deal with inheritance.');
-        $configs = [['foo' => []], ['bar' => []]];
-        $this->extension->load($configs, $this->container);
+        unset($this->container, $this->compilerPass);
     }
 
     public function testBrokenYmlOnPrepend(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageRegExp('#The file "(.*)/broken.types.yml" does not contain valid YAML\.#');
-        $this->extension->containerPrependExtensionConfig($this->getMappingConfig('yaml'), $this->container);
+        $this->processCompilerPass($this->getMappingConfig('yaml'));
     }
 
     public function testBrokenXmlOnPrepend(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessageRegExp('#Unable to parse file "(.*)/broken.types.xml"\.#');
-        $this->extension->containerPrependExtensionConfig($this->getMappingConfig('xml'), $this->container);
+        $this->processCompilerPass($this->getMappingConfig('xml'));
     }
 
     public function testPreparseOnPrepend(): void
     {
-        $this->extension->containerPrependExtensionConfig($this->getMappingConfig('annotation'), $this->container);
-        $expected = [0 => [
-            'Type' => [
-                'type' => 'object',
-                'config' => ['fields' => []],
-            ],
-        ]];
-
-        $this->assertEquals($this->container->getExtensionConfig('overblog_graphql_types'), $expected);
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The path "overblog_graphql_types.Type._object_config.fields" should have at least 1 element(s) defined.');
+        $this->processCompilerPass($this->getMappingConfig('annotation'));
     }
 
     /**
@@ -88,7 +74,7 @@ class OverblogGraphQLTypesExtensionTest extends TestCase
             ['bar' => [$internalConfigKey => []]],
         ];
 
-        $this->extension->load($configs, $this->container);
+        $this->compilerPass->processConfiguration($configs);
     }
 
     /**
@@ -113,7 +99,7 @@ class OverblogGraphQLTypesExtensionTest extends TestCase
         $this->expectException($exceptionClass);
         $this->expectExceptionMessage($exceptionMessage);
 
-        $this->extension->load([$configs], $this->container);
+        $this->compilerPass->processConfiguration([$configs]);
     }
 
     /**
@@ -181,7 +167,7 @@ class OverblogGraphQLTypesExtensionTest extends TestCase
             $this->container
         );
 
-        $this->extension->load(
+        $config = $this->compilerPass->processConfiguration(
             [
                 [
                     'foo' => [
@@ -249,8 +235,7 @@ class OverblogGraphQLTypesExtensionTest extends TestCase
                         ],
                     ],
                 ],
-            ],
-            $this->container
+            ]
         );
 
         $this->assertSame(
@@ -449,7 +434,7 @@ class OverblogGraphQLTypesExtensionTest extends TestCase
                     ],
                 ],
             ],
-            $this->container->getParameter('overblog_graphql_types.config')
+            $config
         );
     }
 
@@ -464,7 +449,7 @@ class OverblogGraphQLTypesExtensionTest extends TestCase
         ];
     }
 
-    private function getMappingConfig($type)
+    private function getMappingConfig($type): array
     {
         $config = [
             'definitions' => [
@@ -472,7 +457,7 @@ class OverblogGraphQLTypesExtensionTest extends TestCase
                     'types' => [
                         [
                             'types' => [$type],
-                            'dir' => __DIR__.'/mapping/'.$type,
+                            'dir' => __DIR__.'/../mapping/'.$type,
                         ],
                     ],
                 ],
@@ -587,5 +572,13 @@ class OverblogGraphQLTypesExtensionTest extends TestCase
                 \sprintf($expectedMessage, 'FooBox', BoxFields::class, BoxFields::class),
             ],
         ];
+    }
+
+    private function processCompilerPass(array $configs, ?ConfigParserPass $compilerPass = null, ?ContainerBuilder $container = null): void
+    {
+        $container = $container ?? $this->container;
+        $compilerPass = $compilerPass ?? $this->compilerPass;
+        $container->setParameter('overblog_graphql.config', $configs);
+        $compilerPass->process($container);
     }
 }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | possible
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | none
| License       | MIT

This change leaves more flexibility to developers to prepend the config of the bundle without conflicting with config parsing
