### PR TITLE
Compiler pass instead of !tagged expression, SF 5 tests run fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ cache:
 before_install:
     - if [ "${STABILITY}" != "" ]; then perl -pi -e 's/^}$/,"minimum-stability":"'"${STABILITY}"'"}/' composer.json; fi;
     - if [ "${SYMFONY_VERSION}" != "" ]; then perl -pi -e 's#"(symfony/.*)":\s*".*"#"$1":"'"${SYMFONY_VERSION}"'"#' composer.json; fi;
+    - if [ "${SYMFONY_VERSION}" = "5.0.*" ]; then composer require "symfony/translation"; fi;
     - if [ "${PHPUNIT_VERSION}" != "" ]; then  composer req "phpunit/phpunit:${PHPUNIT_VERSION}" --dev --no-update; fi;
     - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{,.disabled} || echo "xdebug not available"
     - composer selfupdate

--- a/src/DependencyInjection/Compiler/ConfigProcessorPass.php
+++ b/src/DependencyInjection/Compiler/ConfigProcessorPass.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\DependencyInjection\Compiler;
+
+use Overblog\GraphQLBundle\Definition\ConfigProcessor;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class ConfigProcessorPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->has(ConfigProcessor::class)) {
+            return;
+        }
+
+        $definition = $container->findDefinition(ConfigProcessor::class);
+
+        $taggedServices = $container->findTaggedServiceIds('overblog_graphql.definition_config_processor');
+
+        $arguments = [];
+        foreach ($taggedServices as $id => $tags) {
+            $arguments[] = new Reference($id);
+        }
+
+        $definition->setArgument('$processors', $arguments);
+    }
+}

--- a/src/DependencyInjection/Compiler/ConfigProcessorPass.php
+++ b/src/DependencyInjection/Compiler/ConfigProcessorPass.php
@@ -13,10 +13,6 @@ class ConfigProcessorPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
-        if (!$container->has(ConfigProcessor::class)) {
-            return;
-        }
-
         $definition = $container->findDefinition(ConfigProcessor::class);
 
         $taggedServices = $container->findTaggedServiceIds('overblog_graphql.definition_config_processor');

--- a/src/OverblogGraphQLBundle.php
+++ b/src/OverblogGraphQLBundle.php
@@ -6,6 +6,7 @@ namespace Overblog\GraphQLBundle;
 
 use Overblog\GraphQLBundle\DependencyInjection\Compiler\AliasedPass;
 use Overblog\GraphQLBundle\DependencyInjection\Compiler\ConfigParserPass;
+use Overblog\GraphQLBundle\DependencyInjection\Compiler\ConfigProcessorPass;
 use Overblog\GraphQLBundle\DependencyInjection\Compiler\ExpressionFunctionPass;
 use Overblog\GraphQLBundle\DependencyInjection\Compiler\GlobalVariablesPass;
 use Overblog\GraphQLBundle\DependencyInjection\Compiler\MutationTaggedServiceMappingTaggedPass;
@@ -29,6 +30,7 @@ class OverblogGraphQLBundle extends Bundle
 
         //TypeGeneratorPass must be before TypeTaggedServiceMappingPass
         $container->addCompilerPass(new ConfigParserPass());
+        $container->addCompilerPass(new ConfigProcessorPass());
         $container->addCompilerPass(new GlobalVariablesPass());
         $container->addCompilerPass(new ExpressionFunctionPass());
         $container->addCompilerPass(new AliasedPass());

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -90,7 +90,6 @@ services:
             - "%overblog_graphql.handle_cors%"
             - "%overblog_graphql.batching_method%"
 
-    Overblog\GraphQLBundle\Definition\ConfigProcessor:
-        arguments: [!tagged overblog_graphql.definition_config_processor]
+    Overblog\GraphQLBundle\Definition\ConfigProcessor: ~
 
     GraphQL\Executor\Promise\PromiseAdapter: "@overblog_graphql.promise_adapter"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | no
| Documented?   | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Because since SF 4.4 !tagged expression should be renamed to !tagged_iterator the only way to keep bundle compatible is not to use both of these keywords.

Also fixed tests run for SF 5.0.* - where Translator component is not included by default.

I propose to not to test with php nightly builds. Because even if we can adopt this repo for php8 - Symfony code causes unit-tests errors. Because .travis matrix in Symfony does not include php nightly yet. I really doubt that Symfony community will approve my fix for php that even not included in .travis.
