### PR TITLE
Fix args transformer populating nonNull-listOf inputs

### DIFF
--- a/src/Transformer/ArgumentsTransformer.php
+++ b/src/Transformer/ArgumentsTransformer.php
@@ -113,11 +113,16 @@ class ArgumentsTransformer
 
             foreach ($fields as $name => $field) {
                 $fieldData = $this->accessor->getValue($data, \sprintf('[%s]', $name));
+                $fieldType = $field->getType();
 
-                if ($field->getType() instanceof ListOfType) {
-                    $fieldValue = $this->populateObject($field->getType()->getWrappedType(), $fieldData, true, $info);
+                if ($fieldType instanceof NonNull) {
+                    $fieldType = $fieldType->getWrappedType();
+                }
+
+                if ($fieldType instanceof ListOfType) {
+                    $fieldValue = $this->populateObject($fieldType->getWrappedType(), $fieldData, true, $info);
                 } else {
-                    $fieldValue = $this->populateObject($field->getType(), $fieldData, false, $info);
+                    $fieldValue = $this->populateObject($fieldType, $fieldData, false, $info);
                 }
 
                 $this->accessor->setValue($instance, $name, $fieldValue);

--- a/tests/Transformer/ArgumentsTransformerTest.php
+++ b/tests/Transformer/ArgumentsTransformerTest.php
@@ -63,7 +63,6 @@ class ArgumentsTransformerTest extends TestCase
             'name' => 'InputType3',
             'fields' => [
                 'field1' => Type::nonNull(Type::listOf($t1)),
-                'field2' => Type::nonNull(Type::listOf(Type::string())),
             ],
         ]);
 

--- a/tests/Transformer/InputType3.php
+++ b/tests/Transformer/InputType3.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Tests\Transformer;
 
-class InputType2
+class InputType3
 {
     public $field1;
     public $field2;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| Fixed tickets | none
| License       | MIT

Fixes issue `nonNull` & `listOf` inputs not populated by `ArgumentsTransformer`

Example what did not work:
```php
/**
 * @GQL\Input()
 */
final class ChangeUser
{
    /**
     * @GQL\Field(type="Id!")
     *
     * @var UuidInterface
     */
    public $userId;

    /**
     * @GQL\Field(type="[ChangeUserOperationInput!]!")
     *
     * @var ChangeUserOperation[]
     */
    public $operations;
}
```
Hereby `ChangeUserOperationInput` was not populated.

@Vincz 
You think **new** error raised error tests needed for this case?
With all those `field1`, `field2`, etc. its a bit hard to wrap the heard around :D. 

As an aside maybe need to improve the test here so it can scale better. For example split in parts, or something, so the intent of the test is clear. Just did not want to press it all in this PR. Had to hold my hands back multiple times not starting rearrange stuff :) 