### PR TITLE
Fix Appveyor build

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
     },
     "require-dev": {
         "doctrine/orm": "^2.5",
-        "phpunit/phpunit": "^7.2 || ^8.2",
+        "phpunit/phpunit": "<8.3",
         "react/promise": "^2.5",
         "symfony/asset": "^3.4 || ^4.0",
         "symfony/browser-kit": "^3.4 || ^4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Documented?   | no
| Fixed tickets | none
| License       | MIT

PHPunit 8.3 is not compatible with symfony/phpunit-bridge <=4.3.3