### PR TITLE
Fix typo on access control docs

### DIFF
--- a/docs/security/fields-access-control.md
+++ b/docs/security/fields-access-control.md
@@ -1,6 +1,6 @@
 # Fields access Control
 
-## With Annotations
+## With YAML
 
 An access control can be added on each field using `config.fields.*.access` or globally with `config.fieldsDefaultAccess`.
 If `config.fields.*.access` value is true field will be normally resolved but will be `null` otherwise.


### PR DESCRIPTION
Since it refers to YAML instead of annotation.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| License       | MIT
