### PR TITLE
fixed example of Enum. Added public $value.

### DIFF
--- a/docs/definitions/type-system/enum.md
+++ b/docs/definitions/type-system/enum.md
@@ -51,5 +51,7 @@ class Episode
     const EMPIRE = 'constant("App\\StarWars\\Movies::MOVIE_EMPIRE")';
     const JEDI = 6;
     const FORCEAWAKENS = 'FORCEAWAKENS';
+    
+    public $value;
 }
 ```


### PR DESCRIPTION
Fixed example of Enum. 
Added public $value.
Without class attribute `$value` the Enum doesn't work.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT


