### PR TITLE
fix auto paginator when argument last is null

### DIFF
--- a/src/Relay/Connection/Paginator.php
+++ b/src/Relay/Connection/Paginator.php
@@ -97,7 +97,7 @@ class Paginator
      */
     public function auto(ArgumentInterface $args, $total, array $callableArgs = [])
     {
-        if (isset($args['last'])) {
+        if (isset($args['last']) && $args['last'] !== null) {
             $connection = $this->backward($args, $total, $callableArgs);
         } else {
             $connection = $this->forward($args);

--- a/tests/Relay/Connection/PaginatorTest.php
+++ b/tests/Relay/Connection/PaginatorTest.php
@@ -249,6 +249,22 @@ class PaginatorTest extends TestCase
         $this->assertTrue($result->getPageInfo()->getHasPreviousPage());
     }
 
+    public function testAutoForwardWithArgumentLastToNull(): void
+    {
+        $paginator = new Paginator(function ($offset, $limit) {
+            $this->assertSame(0, $offset);
+            $this->assertSame(5, $limit);
+
+            return $this->getData($offset);
+        });
+
+        $result = $paginator->auto(new Argument(['first' => 4, 'last' => null]), 5);
+
+        $this->assertCount(4, $result->getEdges());
+        $this->assertSameEdgeNodeValue(['A', 'B', 'C', 'D'], $result);
+        $this->assertTrue($result->getPageInfo()->getHasNextPage());
+    }
+
     public function testTotalCallableWithArguments(): void
     {
         $paginatorBackend = new PaginatorBackend();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | no
| License       | MIT

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
Fix `Paginator.auto()` when `$args['last'] === null` (it try to backward and failed).
