### PR TITLE
Fix @validator.validator_factory optional service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_install:
     - if [ "${SYMFONY_VERSION}" != "" ]; then perl -pi -e 's#"(symfony/.*)":\s*".*"#"$1":"'"${SYMFONY_VERSION}"'"#' composer.json; fi;
     - if [ "${SYMFONY_VERSION}" = "5.0.*" ]; then composer require "symfony/translation"; fi;
     - if [ "${PHPUNIT_VERSION}" != "" ]; then  composer req "phpunit/phpunit:${PHPUNIT_VERSION}" --dev --no-update; fi;
+    - if [ "${VALIDATOR}" = "0" ]; then  composer remove "symfony/validator" --dev --no-update; fi;
     - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{,.disabled} || echo "xdebug not available"
     - composer selfupdate
     - if [ $GRAPHQLPHP_VERSION ]; then composer require "webonyx/graphql-php:${GRAPHQLPHP_VERSION}" --dev --no-update; fi;
@@ -34,6 +35,8 @@ jobs:
     include:
         - php: 7.2
           env: SYMFONY_VERSION=4.3.* PHPUNIT_VERSION=^7.2 SYMFONY_DEPRECATIONS_HELPER=max[total]=0
+        - php: 7.3
+          env: SYMFONY_VERSION=4.3.* VALIDATOR=0 SYMFONY_DEPRECATIONS_HELPER=max[total]=0
         - php: 7.3
           env: SYMFONY_VERSION=4.3.* USE_EXPERIMENTAL_EXECUTOR=1 SYMFONY_DEPRECATIONS_HELPER=max[total]=0
         - php: 7.3

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -98,12 +98,3 @@ services:
     Overblog\GraphQLBundle\Validator\Formatter:
         tags:
             - { name: kernel.event_listener, event: graphql.error_formatting, method: onErrorFormatting }
-
-    Overblog\GraphQLBundle\Validator\ValidatorFactory:
-        public: false
-        arguments:
-            - '@?validator'
-            - '@validator.validator_factory'
-            - '@?translator.default'
-        tags:
-            - { name: overblog_graphql.global_variable, alias: validatorFactory, public: false }

--- a/src/Validator/ValidatorFactory.php
+++ b/src/Validator/ValidatorFactory.php
@@ -12,13 +12,11 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ValidatorFactory
 {
-    private $defaultValidator;
     private $defaultTranslator;
     private $constraintValidatorFactory;
 
-    public function __construct(?ValidatorInterface $validator, ConstraintValidatorFactoryInterface $constraintValidatorFactory, ?TranslatorInterface $translator)
+    public function __construct(ConstraintValidatorFactoryInterface $constraintValidatorFactory, ?TranslatorInterface $translator)
     {
-        $this->defaultValidator = $validator;
         $this->defaultTranslator = $translator;
         $this->constraintValidatorFactory = $constraintValidatorFactory;
     }
@@ -27,8 +25,7 @@ class ValidatorFactory
     {
         $builder = Validation::createValidatorBuilder()
             ->setMetadataFactory($metadataFactory)
-            ->setConstraintValidatorFactory($this->constraintValidatorFactory)
-        ;
+            ->setConstraintValidatorFactory($this->constraintValidatorFactory);
 
         if (null !== $this->defaultTranslator) {
             $builder

--- a/tests/EventListener/ValidationErrorsListenerTest.php
+++ b/tests/EventListener/ValidationErrorsListenerTest.php
@@ -18,8 +18,11 @@ class ValidationErrorsListenerTest extends TestCase
     /** @var ValidationErrorsListener */
     private $listener;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
+        if (!\class_exists('Symfony\\Component\\Validator\\Validation')) {
+            $this->markTestSkipped('Symfony validator component is not installed');
+        }
         $this->listener = new ValidationErrorsListener();
     }
 

--- a/tests/ExpressionLanguage/ExpressionFunction/GraphQL/ArgumentsTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/GraphQL/ArgumentsTest.php
@@ -19,6 +19,14 @@ class ArgumentsTest extends TestCase
 {
     private $transformer;
 
+    public function setUp(): void
+    {
+        if (!\class_exists('Symfony\\Component\\Validator\\Validation')) {
+            $this->markTestSkipped('Symfony validator component is not installed');
+        }
+        parent::setUp();
+    }
+
     protected function getFunctions()
     {
         $this->transformer = $this->getTransformer([

--- a/tests/Functional/Validator/InputValidatorTest.php
+++ b/tests/Functional/Validator/InputValidatorTest.php
@@ -11,6 +11,9 @@ class InputValidatorTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+        if (!\class_exists('Symfony\\Component\\Validator\\Validation')) {
+            $this->markTestSkipped('Symfony validator component is not installed');
+        }
         static::bootKernel(['test_case' => 'validator']);
     }
 

--- a/tests/Transformer/ArgumentsTransformerTest.php
+++ b/tests/Transformer/ArgumentsTransformerTest.php
@@ -19,6 +19,14 @@ use Symfony\Component\Validator\Validator\RecursiveValidator;
 
 class ArgumentsTransformerTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (!\class_exists('Symfony\\Component\\Validator\\Validation')) {
+            $this->markTestSkipped('Symfony validator component is not installed');
+        }
+    }
+
     private function getTransformer(array $classesMap = null, $validateReturn = null): ArgumentsTransformer
     {
         $validator = $this->createMock(RecursiveValidator::class);

--- a/tests/Validator/InputValidatorTest.php
+++ b/tests/Validator/InputValidatorTest.php
@@ -12,9 +12,17 @@ use Symfony\Component\Validator\ConstraintValidatorFactory;
 
 class InputValidatorTest extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+        if (!\class_exists('Symfony\\Component\\Validator\\Validation')) {
+            $this->markTestSkipped('Symfony validator component is not installed');
+        }
+    }
+
     public function testNoDefaultValidatorException(): void
     {
-        $factory = new ValidatorFactory(null, new ConstraintValidatorFactory(), null);
+        $factory = new ValidatorFactory(new ConstraintValidatorFactory(), null);
 
         $this->expectException(ServiceNotFoundException::class);
 

--- a/tests/Validator/Mapping/MetadataFactoryTest.php
+++ b/tests/Validator/Mapping/MetadataFactoryTest.php
@@ -13,6 +13,14 @@ use Symfony\Component\Validator\Exception\NoSuchMetadataException;
 
 class MetadataFactoryTest extends TestCase
 {
+    public function setUp(): void
+    {
+        if (!\class_exists('Symfony\\Component\\Validator\\Validation')) {
+            $this->markTestSkipped('Symfony validator component is not installed');
+        }
+        parent::setUp();
+    }
+
     public function testMetadataFactoryHasObject(): void
     {
         $metadataFactory = new MetadataFactory();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Documented?   | no
| Fixed tickets | none
| License       | MIT

the service `validator.validator_factory` comes with validator component so should not be required since validator itself is optional

```
The service "Overblog\GraphQLBundle\Definition\Builder\TypeFactory" has a dependency on a non-existent service "validator.validator_factory".
```