### PR TITLE
Make expression function evaluator optional

### DIFF
--- a/src/ExpressionLanguage/ExpressionFunction.php
+++ b/src/ExpressionLanguage/ExpressionFunction.php
@@ -4,8 +4,17 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\ExpressionLanguage;
 
+use Overblog\GraphQLBundle\ExpressionLanguage\Exception\EvaluatorIsNotAllowedException;
 use Symfony\Component\ExpressionLanguage\ExpressionFunction as BaseExpressionFunction;
 
 class ExpressionFunction extends BaseExpressionFunction
 {
+    public function __construct(string $name, callable $compiler, ?callable $evaluator = null)
+    {
+        if (null === $evaluator) {
+            $evaluator = new EvaluatorIsNotAllowedException($name);
+        }
+
+        parent::__construct($name, $compiler, $evaluator);
+    }
 }

--- a/src/ExpressionLanguage/ExpressionFunction/GraphQL/Mutation.php
+++ b/src/ExpressionLanguage/ExpressionFunction/GraphQL/Mutation.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\GraphQL;
 
-use Overblog\GraphQLBundle\ExpressionLanguage\Exception\EvaluatorIsNotAllowedException;
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction;
 
 final class Mutation extends ExpressionFunction
@@ -15,9 +14,7 @@ final class Mutation extends ExpressionFunction
             $name,
             function ($alias, $args = '[]') {
                 return "\$globalVariable->get('mutationResolver')->resolve([$alias, $args])";
-            },
-            // This expression function is not designed to be used by it's evaluator
-            new EvaluatorIsNotAllowedException($name)
+            }
         );
     }
 }

--- a/src/ExpressionLanguage/ExpressionFunction/GraphQL/Relay/IdFetcherCallback.php
+++ b/src/ExpressionLanguage/ExpressionFunction/GraphQL/Relay/IdFetcherCallback.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\GraphQL\Relay;
 
-use Overblog\GraphQLBundle\ExpressionLanguage\Exception\EvaluatorIsNotAllowedException;
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction;
 use Overblog\GraphQLBundle\Generator\TypeGenerator;
 
@@ -12,18 +11,14 @@ final class IdFetcherCallback extends ExpressionFunction
 {
     public function __construct()
     {
-        $name = 'idFetcherCallback';
-
         parent::__construct(
-            $name,
+            'idFetcherCallback',
             function ($idFetcher) {
                 $code = 'function ($value) use ('.TypeGenerator::USE_FOR_CLOSURES.', $args, $context, $info) { ';
                 $code .= 'return '.$idFetcher.'; }';
 
                 return $code;
-            },
-            // This expression function is not designed to be used by it's evaluator
-            new EvaluatorIsNotAllowedException($name)
+            }
         );
     }
 }

--- a/src/ExpressionLanguage/ExpressionFunction/GraphQL/Relay/MutateAndGetPayloadCallback.php
+++ b/src/ExpressionLanguage/ExpressionFunction/GraphQL/Relay/MutateAndGetPayloadCallback.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\GraphQL\Relay;
 
-use Overblog\GraphQLBundle\ExpressionLanguage\Exception\EvaluatorIsNotAllowedException;
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction;
 use Overblog\GraphQLBundle\Generator\TypeGenerator;
 
@@ -12,18 +11,14 @@ final class MutateAndGetPayloadCallback extends ExpressionFunction
 {
     public function __construct()
     {
-        $name = 'mutateAndGetPayloadCallback';
-
         parent::__construct(
-            $name,
+            'mutateAndGetPayloadCallback',
             function ($mutateAndGetPayload) {
                 $code = 'function ($value) use ('.TypeGenerator::USE_FOR_CLOSURES.', $args, $context, $info) { ';
                 $code .= 'return '.$mutateAndGetPayload.'; }';
 
                 return $code;
-            },
-            // This expression function is not designed to be used by it's evaluator
-            new EvaluatorIsNotAllowedException($name)
+            }
         );
     }
 }

--- a/src/ExpressionLanguage/ExpressionFunction/GraphQL/Relay/ResolveSingleInputCallback.php
+++ b/src/ExpressionLanguage/ExpressionFunction/GraphQL/Relay/ResolveSingleInputCallback.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\GraphQL\Relay;
 
-use Overblog\GraphQLBundle\ExpressionLanguage\Exception\EvaluatorIsNotAllowedException;
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction;
 use Overblog\GraphQLBundle\Generator\TypeGenerator;
 
@@ -12,18 +11,14 @@ final class ResolveSingleInputCallback extends ExpressionFunction
 {
     public function __construct()
     {
-        $name = 'resolveSingleInputCallback';
-
         parent::__construct(
-            $name,
+            'resolveSingleInputCallback',
             function ($resolveSingleInput) {
                 $code = 'function ($value) use ('.TypeGenerator::USE_FOR_CLOSURES.', $args, $context, $info) { ';
                 $code .= 'return '.$resolveSingleInput.'; }';
 
                 return $code;
-            },
-            // This expression function is not designed to be used by it's evaluator
-            new EvaluatorIsNotAllowedException($name)
+            }
         );
     }
 }

--- a/src/ExpressionLanguage/ExpressionFunction/GraphQL/Resolver.php
+++ b/src/ExpressionLanguage/ExpressionFunction/GraphQL/Resolver.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\GraphQL;
 
-use Overblog\GraphQLBundle\ExpressionLanguage\Exception\EvaluatorIsNotAllowedException;
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction;
 
 final class Resolver extends ExpressionFunction
@@ -15,9 +14,7 @@ final class Resolver extends ExpressionFunction
             $name,
             function (string $alias, string $args = '[]'): string {
                 return "\$globalVariable->get('resolverResolver')->resolve([$alias, $args])";
-            },
-            // This expression function is not designed to be used by it's evaluator
-            new EvaluatorIsNotAllowedException($name)
+            }
         );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | none
| License       | MIT

this remove BC on expression function in 0.13@dev 
