### PR TITLE
Added a paragraph about using only Annotations as mapping type

### DIFF
--- a/docs/annotations/index.md
+++ b/docs/annotations/index.md
@@ -14,7 +14,7 @@ overblog_graphql:
 
 This will load all annotated classes in `%kernel.project_dir%/src/GraphQL` into the schema.
 
-## Use Annotations as your only Mapping
+## Using Annotations as your only Mapping
 
 If you only use annotations as mappings you need to add an empty `RootQuery` type.
 Your config should look like this:

--- a/docs/annotations/index.md
+++ b/docs/annotations/index.md
@@ -16,7 +16,7 @@ This will load all annotated classes in `%kernel.project_dir%/src/GraphQL` into 
 
 ## Use Annotations as your only Mapping
 
-If you only use annotations as mappings you need to add an empty RootQuery type.
+If you only use annotations as mappings you need to add an empty `RootQuery` type.
 Your config should look like this:
 ```yaml
 # config/packages/graphql.yaml
@@ -30,7 +30,7 @@ overblog_graphql:
           dir: "%kernel.project_dir%/src/GraphQL"
           suffix: ~
 ```
-Your RootQuery class should look like this:
+Your `RootQuery` class should look like this:
 ```php
 namespace App\GraphQL\Query;
 
@@ -41,7 +41,7 @@ class RootQuery
 {
 }
 ```
-If you use mutations, you need a RootMutation aswell.
+If you use mutations, you need a `RootMutation` type as well.
 ## Annotations reference
 - [Annotations reference](annotations-reference.md)
 

--- a/docs/annotations/index.md
+++ b/docs/annotations/index.md
@@ -14,6 +14,34 @@ overblog_graphql:
 
 This will load all annotated classes in `%kernel.project_dir%/src/GraphQL` into the schema.
 
+## Use Annotations as your only Mapping
+
+If you only use annotations as mappings you need to add an empty RootQuery type.
+Your config should look like this:
+```yaml
+# config/packages/graphql.yaml
+overblog_graphql:
+  definitions:
+    schema:
+      query: RootQuery
+    mappings:
+      types:
+        - type: annotation
+          dir: "%kernel.project_dir%/src/GraphQL"
+          suffix: ~
+```
+Your RootQuery class should look like this:
+```php
+namespace App\GraphQL\Query;
+
+/**
+ * @GQL\Type
+ */
+class RootQuery
+{
+}
+```
+If you use mutations, you need a RootMutation aswell.
 ## Annotations reference
 - [Annotations reference](annotations-reference.md)
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| License       | MIT

I had some issues figuring out how the Annotations work without using any other type of mapping. It says nowhere that you would need an empty RootQuery/RootMutation.
This should clear things up.
