### PR TITLE
Allow fields short syntax

### DIFF
--- a/src/Config/InputObjectTypeDefinition.php
+++ b/src/Config/InputObjectTypeDefinition.php
@@ -17,6 +17,15 @@ class InputObjectTypeDefinition extends TypeDefinition
                 ->arrayNode('fields')
                     ->useAttributeAsKey('name', false)
                     ->prototype('array')
+                        // Allow field type short syntax (Field: Type => Field: {type: Type})
+                        ->beforeNormalization()
+                            ->ifTrue(function ($options) {
+                                return \is_string($options);
+                            })
+                            ->then(function ($options) {
+                                return ['type' => $options];
+                            })
+                        ->end()
                         ->append($this->typeSelection(true))
                         ->append($this->descriptionSection())
                         ->append($this->defaultValueSection())

--- a/src/Config/TypeWithOutputFieldsDefinition.php
+++ b/src/Config/TypeWithOutputFieldsDefinition.php
@@ -23,6 +23,15 @@ abstract class TypeWithOutputFieldsDefinition extends TypeDefinition
         $prototype = $node->useAttributeAsKey('name', false)->prototype('array');
 
         $prototype
+            // Allow field type short syntax (Field: Type => Field: {type: Type})
+            ->beforeNormalization()
+                ->ifTrue(function ($options) {
+                    return \is_string($options);
+                })
+                ->then(function ($options) {
+                    return ['type' => $options];
+                })
+            ->end()
             ->children()
                 ->append($this->typeSelection())
                 ->append($this->validationSection(self::VALIDATION_LEVEL_CLASS))
@@ -48,15 +57,15 @@ abstract class TypeWithOutputFieldsDefinition extends TypeDefinition
                     ->end()
                 ->end()
                 ->variableNode('resolve')
-                    ->info('Value resolver (expression language can be use here)')
+                    ->info('Value resolver (expression language can be used here)')
                 ->end()
                 ->append($this->descriptionSection())
                 ->append($this->deprecationReasonSelection())
                 ->variableNode('access')
-                    ->info('Access control to field (expression language can be use here)')
+                    ->info('Access control to field (expression language can be used here)')
                 ->end()
                 ->variableNode('public')
-                    ->info('Visibility control to field (expression language can be use here)')
+                    ->info('Visibility control to field (expression language can be used here)')
                 ->end()
                 ->variableNode('complexity')
                     ->info('Custom complexity calculator.')

--- a/tests/Functional/App/config/access/mapping/access.types.yml
+++ b/tests/Functional/App/config/access/mapping/access.types.yml
@@ -24,16 +24,14 @@ Human:
     type: interface
     config:
         fields:
-            name:
-                type: String
+            name: String
 
 User:
     type: object
     config:
         fieldsDefaultAccess: "@=isFullyAuthenticated()"
         fields:
-            name:
-                type: String
+            name: String
             roles:
                 type: '[String]'
                 access: "@=hasRole('ROLE_ADMIN')"
@@ -104,7 +102,7 @@ simpleMutationWithThunkFieldsInput:
     type: relay-mutation-input
     config:
         fields:
-            inputData : { type: "Int" }
+            inputData : "Int"
 
 simpleMutationWithThunkFieldsPayload:
     type: relay-mutation-payload

--- a/tests/Functional/App/config/argumentWrapper/mapping/query.types.yml
+++ b/tests/Functional/App/config/argumentWrapper/mapping/query.types.yml
@@ -6,12 +6,12 @@ RootQuery:
             fieldWithResolverAndArgument:
                 type: String!
                 args:
-                    name: {type: String!}
+                    name: String!
                 resolve: '@="Field resolver Arguments: " ~ json_encode(args.getArrayCopy()) ~ " | InstanceOf: " ~ json_encode(is_a(args, "Overblog\\GraphQLBundle\\Definition\\Argument"))'
             fieldWithDefaultResolverAndArgument:
                 type: String!
                 args:
-                    name: {type: String!}
+                    name: String!
             fieldWithAccess:
                 type: String!
                 access: "@=true"

--- a/tests/Functional/App/config/global/mapping/global.types.yml
+++ b/tests/Functional/App/config/global/mapping/global.types.yml
@@ -22,8 +22,7 @@ User:
         fields:
             id:
                 builder: "Relay::GlobalId"
-            name:
-                type: String
+            name: String
         interfaces: [NodeInterface]
 
 Photo:
@@ -35,8 +34,7 @@ Photo:
                 builderConfig:
                     typeName: Photo
                     idFetcher: '@=value["photoId"]'
-            width:
-                type: Int
+            width: Int
         interfaces: [NodeInterface]
 
 Post:
@@ -45,10 +43,8 @@ Post:
         fields:
             id:
                 builder: "Relay::GlobalId"
-            text:
-                type: String
-            status:
-                type: Status
+            text: String
+            status: Status
         interfaces: [NodeInterface]
 
 PhotoAndPost:

--- a/tests/Functional/App/config/inheritance/mapping/Decorators.types.yaml
+++ b/tests/Functional/App/config/inheritance/mapping/Decorators.types.yaml
@@ -4,57 +4,49 @@ QueryBarDecorator:
     config:
         interfaces: [QueryHelloWord]
         fields:
-            bar:
-                type: String
+            bar: String
 
 QueryFooDecorator:
     decorator: true
     config:
         fields:
-            period:
-                type: Period
+            period: Period
 
 A:
     type: interface
     config:
         fields:
-            a:
-                type: String
+            a: String
 
 AA:
     type: interface
     config:
         fields:
-            aa:
-                type: String
+            aa: String
 
 B:
     type: interface
     config:
         fields:
-            b:
-                type: String
+            b: String
 
 C:
     type: interface
     config:
         fields:
-            c:
-                type: String
+            c: String
 
 D:
     type: interface
     config:
         fields:
-            d:
-                type: String
+            d: String
 
 E:
     type: interface
     config:
         fields:
-            e:
-                type: String
+            e: String
 
 DecoratorA:
     type: object
@@ -64,10 +56,8 @@ DecoratorA:
             - A
             - AA
         fields:
-            a:
-                type: String
-            aa:
-                type: String
+            a: String
+            aa: String
 
 DecoratorB:
     type: object
@@ -76,8 +66,7 @@ DecoratorB:
         interfaces:
             - B
         fields:
-            b:
-                type: String
+            b: String
 
 DecoratorC:
     type: object
@@ -86,8 +75,7 @@ DecoratorC:
         interfaces:
             - C
         fields:
-            c:
-                type: String
+            c: String
 
 DecoratorD:
     type: object
@@ -98,8 +86,7 @@ DecoratorD:
         interfaces:
             - D
         fields:
-            d:
-                type: String
+            d: String
 
 ABCDE:
     type: object
@@ -111,5 +98,4 @@ ABCDE:
         interfaces:
             - E
         fields:
-            e:
-                type: String
+            e: String

--- a/tests/Functional/App/config/inheritance/mapping/QueryHelloWord.types.yaml
+++ b/tests/Functional/App/config/inheritance/mapping/QueryHelloWord.types.yaml
@@ -3,6 +3,5 @@ QueryHelloWord:
     heirs: [Query]
     config:
         fields:
-            sayHello:
-                type: String
+            sayHello: String
         resolveType: true

--- a/tests/Functional/App/config/inheritance/mapping/Relay.types.yaml
+++ b/tests/Functional/App/config/inheritance/mapping/Relay.types.yaml
@@ -1,15 +1,13 @@
 AddEventInput:
-  type: relay-mutation-input
-  config:
-    fields:
-      title:
-        type: 'String!'
+    type: relay-mutation-input
+    config:
+        fields:
+            title: 'String!'
 
 ChangeEventInput:
-  type: relay-mutation-input
-  inherits:
-    - AddEventInput
-  config:
-    fields:
-      id:
-        type: 'ID!'
+    type: relay-mutation-input
+    inherits:
+        - AddEventInput
+    config:
+        fields:
+            id: 'ID!'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| License       | MIT

This change allows to use short syntax for field type declarations in following types: 
- `object`
- `input-object`
- `interface`
- `relay-mutation-input`
- `relay-mutation-payload`

#### Example 

before:
```yml
# config/graphql/types/Character.yml
Character:
    type: interface
    config:
        fields:
            id:
                type: String!
            name:
                type: String
            friends:
                type: "[Character]"
            appearsIn:
                type: "[Episode]"
        resolveType: "@=resolver('character_type', [value, typeResolver])"

# config/graphql/types/Human.yml
Human:
    type: object
    config:
        fields:
            id:
                type: String!
            name:
                type: String
            friends:
                type: "[Character]"
            appearsIn:
                type: "[Episode]!"
            primaryFunction:
                type: String
```

after:
```yml
# config/graphql/types/Character.yml
Character:
    type: interface
    config:
        fields:
            id: String!
            name: String
            friends: "[Character]"
            appearsIn: "[Episode]"
        resolveType: "@=resolver('character_type', [value, typeResolver])"

# config/graphql/types/Human.yml
Human:
    type: object
    config:
        fields:
            id: String!
            name: String
            friends: "[Character]"
            appearsIn: "[Episode]!"
            primaryFunction: String
```