### PR TITLE
update phpstan, phpstan-phpunit and added phpstan/extension-installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,9 +70,9 @@
     "scripts": {
         "test": "bin/phpunit --color=always -v --debug",
         "static-analysis": [
-            "@composer req --ansi --dev 'phpstan/phpstan:^0.10.3' 'phpstan/phpstan-phpunit:^0.10.0'",
+            "@composer req --ansi --dev 'phpstan/phpstan:^0.11.16' 'phpstan/phpstan-phpunit:^0.11.2' 'phpstan/extension-installer:^1.0.2'",
             "phpstan analyse --ansi",
-            "@composer rem --ansi --dev phpstan/phpstan phpstan/phpstan-phpunit"
+            "@composer rem --ansi --dev phpstan/phpstan phpstan/phpstan-phpunit phpstan/extension-installer"
         ],
         "bench": [
             "test -f phpbench.phar || wget https://phpbench.github.io/phpbench/phpbench.phar https://phpbench.github.io/phpbench/phpbench.phar.pubkey",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,7 +5,3 @@ parameters:
     - %currentWorkingDirectory%/lib/generator/tests
     - %currentWorkingDirectory%/src
     - %currentWorkingDirectory%/tests
-
-includes:
-	- vendor/phpstan/phpstan-phpunit/extension.neon
-	- vendor/phpstan/phpstan-phpunit/rules.neon


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| License       | MIT

 - Update phpstan/phpstan
 - Update phpstan/phpstan-phpunit
 - Add phpstan/extension-installer to auto-register extensions

I have only one question, why do you chose to add the package during the composer step instead of adding it on required-dev? There are some blockers or moving in it should be accepted?