### PR TITLE
Extract the code that maps exceptions to GraphQL error classes to its own class

### DIFF
--- a/docs/error-handling/index.md
+++ b/docs/error-handling/index.md
@@ -107,7 +107,7 @@ overblog_graphql:
                 - "InvalidArgumentException"
 ```
 
-The mapping is handled inside the ``Overblog\GraphQLBundle\Error\ErrorHandler`
+The mapping is handled inside the `Overblog\GraphQLBundle\Error\ErrorHandler`
 class using an instance of the `Overblog\GraphQLBundle\Error\ExceptionConverter`
 class. Since this class implements an interface and is registered as a service
 in the dependency container, you can easily swap it and customize the logic.

--- a/docs/error-handling/index.md
+++ b/docs/error-handling/index.md
@@ -107,6 +107,33 @@ overblog_graphql:
                 - "InvalidArgumentException"
 ```
 
+The mapping is handled inside the ``Overblog\GraphQLBundle\Error\ErrorHandler`
+class using an instance of the `Overblog\GraphQLBundle\Error\ExceptionConverter`
+class. Since this class implements an interface and is registered as a service
+in the dependency container, you can easily swap it and customize the logic.
+
+```php
+namespace App\Error;
+
+use Overblog\GraphQLBundle\Error\ExceptionConverterInterface;
+use Overblog\GraphQLBundle\Error\UserError;
+
+final class ExceptionConverter implements ExceptionConverterInterface
+{
+    public function convertException(\Throwable $exception): \Throwable
+    {
+        return new UserError($exception->getMessage(), $exception->getCode(), $exception->getPrevious());
+    }
+}
+```
+
+```yaml
+App\Error\ExceptionConverter: ~
+
+Overblog\GraphQLBundle\Error\ExceptionConverterInterface:
+    alias: '@App\Error\ExceptionConverter'
+```
+
 You can custom the default errors handler using configuration:
 
 ```yaml

--- a/src/Error/ErrorHandler.php
+++ b/src/Error/ErrorHandler.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Error;
 
-use GraphQL\Error\ClientAware;
 use GraphQL\Error\Debug;
 use GraphQL\Error\Error as GraphQLError;
 use GraphQL\Error\FormattedError;
@@ -21,50 +20,47 @@ class ErrorHandler
     /** @var EventDispatcherInterface */
     private $dispatcher;
 
+    /** @var ExceptionConverterInterface */
+    private $exceptionConverter;
+
     /** @var string */
     private $internalErrorMessage;
 
-    /** @var array */
-    private $exceptionMap;
-
-    /** @var bool */
-    private $mapExceptionsToParent;
-
     public function __construct(
         EventDispatcherInterface $dispatcher,
-        $internalErrorMessage = null,
-        array $exceptionMap = [],
-        $mapExceptionsToParent = false
+        ExceptionConverterInterface $exceptionConverter,
+        string $internalErrorMessage = self::DEFAULT_ERROR_MESSAGE
     ) {
         $this->dispatcher = $dispatcher;
-        if (empty($internalErrorMessage)) {
-            $internalErrorMessage = self::DEFAULT_ERROR_MESSAGE;
-        }
+        $this->exceptionConverter = $exceptionConverter;
         $this->internalErrorMessage = $internalErrorMessage;
-        $this->exceptionMap = $exceptionMap;
-        $this->mapExceptionsToParent = $mapExceptionsToParent;
     }
 
-    public function handleErrors(ExecutionResult $executionResult, $throwRawException = false, $debug = false): void
+    public function handleErrors(ExecutionResult $executionResult, bool $throwRawException = false, bool $debug = false): void
     {
         $errorFormatter = $this->createErrorFormatter($debug);
+
         $executionResult->setErrorFormatter($errorFormatter);
+
         $exceptions = $this->treatExceptions($executionResult->errors, $throwRawException);
         $executionResult->errors = $exceptions['errors'];
+
         if (!empty($exceptions['extensions']['warnings'])) {
             $executionResult->extensions['warnings'] = \array_map($errorFormatter, $exceptions['extensions']['warnings']);
         }
     }
 
-    private function createErrorFormatter($debug = false)
+    private function createErrorFormatter(bool $debug): \Closure
     {
         $debugMode = false;
+
         if ($debug) {
             $debugMode = Debug::INCLUDE_TRACE | Debug::INCLUDE_DEBUG_MESSAGE;
         }
 
-        return function (GraphQLError $error) use ($debugMode) {
+        return function (GraphQLError $error) use ($debugMode): array {
             $event = new ErrorFormattingEvent($error, FormattedError::createFromException($error, $debugMode, $this->internalErrorMessage));
+
             $this->dispatcher->dispatch($event, Events::ERROR_FORMATTING);
 
             return $event->getFormattedError()->getArrayCopy();
@@ -90,11 +86,16 @@ class ErrorHandler
 
         /** @var GraphQLError $error */
         foreach ($this->flattenErrors($errors) as $error) {
-            $rawException = $this->convertException($error->getPrevious());
+            $rawException = $error->getPrevious();
+
+            if (null !== $rawException) {
+                $rawException = $this->exceptionConverter->convertException($error->getPrevious());
+            }
 
             // raw GraphQL Error or InvariantViolation exception
             if (null === $rawException) {
                 $treatedExceptions['errors'][] = $error;
+
                 continue;
             }
 
@@ -111,12 +112,14 @@ class ErrorHandler
             // user error
             if ($rawException instanceof GraphQLUserError) {
                 $treatedExceptions['errors'][] = $errorWithConvertedException;
+
                 continue;
             }
 
             // user warning
             if ($rawException instanceof UserWarning) {
                 $treatedExceptions['extensions']['warnings'][] = $errorWithConvertedException;
+
                 continue;
             }
 
@@ -142,9 +145,11 @@ class ErrorHandler
 
         foreach ($errors as $error) {
             $rawException = $error->getPrevious();
+
             // multiple errors
             if ($rawException instanceof UserErrors) {
                 $rawExceptions = $rawException;
+
                 foreach ($rawExceptions->getErrors() as $rawException) {
                     $flattenErrors[] = GraphQLError::createLocatedError($rawException, $error->nodes, $error->path);
                 }
@@ -154,62 +159,5 @@ class ErrorHandler
         }
 
         return $flattenErrors;
-    }
-
-    /**
-     * Tries to convert a raw exception into a user warning or error
-     * that is displayed to the user.
-     *
-     * @param \Exception|\Error $rawException
-     *
-     * @return \Exception|\Error
-     */
-    private function convertException($rawException = null)
-    {
-        if (null === $rawException || $rawException instanceof ClientAware) {
-            return $rawException;
-        }
-
-        $errorClass = $this->findErrorClass($rawException);
-        if (null !== $errorClass) {
-            return new $errorClass($rawException->getMessage(), $rawException->getCode(), $rawException);
-        }
-
-        return $rawException;
-    }
-
-    /**
-     * @param \Exception|\Error $rawException
-     *
-     * @return string|null
-     */
-    private function findErrorClass($rawException)
-    {
-        $rawExceptionClass = \get_class($rawException);
-        if (isset($this->exceptionMap[$rawExceptionClass])) {
-            return $this->exceptionMap[$rawExceptionClass];
-        }
-
-        if ($this->mapExceptionsToParent) {
-            return $this->findErrorClassUsingParentException($rawException);
-        }
-
-        return null;
-    }
-
-    /**
-     * @param \Exception|\Error $rawException
-     *
-     * @return string|null
-     */
-    private function findErrorClassUsingParentException($rawException)
-    {
-        foreach ($this->exceptionMap as $rawExceptionClass => $errorClass) {
-            if ($rawException instanceof $rawExceptionClass) {
-                return $errorClass;
-            }
-        }
-
-        return null;
     }
 }

--- a/src/Error/ExceptionConverter.php
+++ b/src/Error/ExceptionConverter.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Error;
+
+use GraphQL\Error\ClientAware as ClientAwareInterface;
+
+final class ExceptionConverter implements ExceptionConverterInterface
+{
+    /**
+     * @var array<string, string>
+     */
+    private $exceptionMap;
+
+    /**
+     * @var bool
+     */
+    private $mapExceptionsToParent;
+
+    /**
+     * @param array<string, string> $exceptionMap
+     */
+    public function __construct(array $exceptionMap, bool $mapExceptionsToParent = false)
+    {
+        $this->exceptionMap = $exceptionMap;
+        $this->mapExceptionsToParent = $mapExceptionsToParent;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertException(\Throwable $exception): \Throwable
+    {
+        if ($exception instanceof ClientAwareInterface) {
+            return $exception;
+        }
+
+        $errorClass = $this->findErrorClass($exception);
+
+        if (null !== $errorClass) {
+            return new $errorClass($exception->getMessage(), $exception->getCode(), $exception);
+        }
+
+        return $exception;
+    }
+
+    private function findErrorClass(\Throwable $exception): ?string
+    {
+        $exceptionClass = \get_class($exception);
+
+        if (isset($this->exceptionMap[$exceptionClass])) {
+            return $this->exceptionMap[$exceptionClass];
+        }
+
+        if ($this->mapExceptionsToParent) {
+            return $this->findErrorClassUsingParentException($exception);
+        }
+
+        return null;
+    }
+
+    private function findErrorClassUsingParentException(\Throwable $exception): ?string
+    {
+        foreach ($this->exceptionMap as $exceptionClass => $errorExceptionClass) {
+            if ($exception instanceof $exceptionClass) {
+                return $errorExceptionClass;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Error/ExceptionConverterInterface.php
+++ b/src/Error/ExceptionConverterInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Error;
+
+interface ExceptionConverterInterface
+{
+    /**
+     * Tries to convert a raw exception into a user warning or error
+     * that is displayed to the user.
+     *
+     * @param \Throwable $exception
+     *
+     * @return \Throwable
+     */
+    public function convertException(\Throwable $exception): \Throwable;
+}

--- a/src/EventListener/ErrorHandlerListener.php
+++ b/src/EventListener/ErrorHandlerListener.php
@@ -28,6 +28,7 @@ final class ErrorHandlerListener
     public function onPostExecutor(ExecutorResultEvent $executorResultEvent): void
     {
         $result = $executorResultEvent->getResult();
+
         $this->errorHandler->handleErrors($result, $this->throwException, $this->debug);
     }
 }

--- a/tests/DependencyInjection/Compiler/ConfigParserPassTest.php
+++ b/tests/DependencyInjection/Compiler/ConfigParserPassTest.php
@@ -8,6 +8,7 @@ use GraphQL\Error\UserError;
 use Overblog\GraphQLBundle\Config\Processor\InheritanceProcessor;
 use Overblog\GraphQLBundle\DependencyInjection\Compiler\ConfigParserPass;
 use Overblog\GraphQLBundle\DependencyInjection\OverblogGraphQLExtension;
+use Overblog\GraphQLBundle\Error\ExceptionConverter;
 use Overblog\GraphQLBundle\Error\UserWarning;
 use Overblog\GraphQLBundle\Tests\DependencyInjection\Builder\BoxFields;
 use Overblog\GraphQLBundle\Tests\DependencyInjection\Builder\MutationField;
@@ -131,8 +132,9 @@ class ConfigParserPassTest extends TestCase
             \InvalidArgumentException::class => UserError::class,
         ];
 
-        $definition = $this->container->getDefinition('overblog_graphql.error_handler');
-        $this->assertSame($expectedExceptionMap, $definition->getArgument(2));
+        $definition = $this->container->getDefinition(ExceptionConverter::class);
+
+        $this->assertSame($expectedExceptionMap, $definition->getArgument(0));
     }
 
     /**

--- a/tests/Error/ExceptionConverterTest.php
+++ b/tests/Error/ExceptionConverterTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Error;
+
+use Overblog\GraphQLBundle\Error\ExceptionConverter;
+use Overblog\GraphQLBundle\Error\UserError;
+use PHPUnit\Framework\TestCase;
+
+final class ExceptionConverterTest extends TestCase
+{
+    /**
+     * @param array<string, string[]> $exceptionMap
+     *
+     * @dataProvider convertExceptionDataProvider
+     */
+    public function testConvertException(array $exceptionMap, bool $mapExceptionsToParent, \Throwable $exception, \Throwable $expectedException): void
+    {
+        $exceptionConverter = new ExceptionConverter($exceptionMap, $mapExceptionsToParent);
+        $convertedException = $exceptionConverter->convertException($exception);
+
+        $this->assertSame(
+            $expectedException->getMessage(),
+            $convertedException->getMessage()
+        );
+
+        $this->assertSame(
+            $expectedException->getPrevious(),
+            $convertedException->getPrevious()
+        );
+    }
+
+    public function convertExceptionDataProvider(): \Generator
+    {
+        yield [
+            [],
+            false,
+            new \Exception('foo'),
+            new \Exception('foo'),
+        ];
+
+        yield [
+            [],
+            true,
+            new \Exception('foo'),
+            new \Exception('foo'),
+        ];
+
+        yield [
+            [],
+            false,
+            new UserError('foo'),
+            new UserError('foo'),
+        ];
+
+        $exception = new class() extends \Exception {
+            public function __construct()
+            {
+                parent::__construct('foo');
+            }
+        };
+
+        yield [
+            [
+                \Exception::class => UserError::class,
+            ],
+            false,
+            $exception,
+            $exception,
+        ];
+
+        $exception = new class() extends \Exception {
+            public function __construct()
+            {
+                parent::__construct('foo');
+            }
+        };
+
+        yield [
+            [
+                \get_class($exception) => UserError::class,
+            ],
+            false,
+            $exception,
+            new UserError('foo', 0, $exception),
+        ];
+
+        $exception = new class() extends \Exception {
+            public function __construct()
+            {
+                parent::__construct('foo');
+            }
+        };
+
+        yield [
+            [
+                \Exception::class => UserError::class,
+            ],
+            true,
+            $exception,
+            new UserError('foo', 0, $exception),
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| Fixed tickets | #583
| License       | MIT

With the changes of this PR I extracted from the `ErrorHandler` class the code that maps the user exceptions to the GraphQL exception classes. This way, it's possible to map an exception to a certain other exception. Since this is an advanced use case I decided to not modify the configuration to expose this possibility, thus through it it's only possible to convert exceptions to the `UserError` or `UserWarning` classes like now