### PR TITLE
Fix parsing of the descriptions of the enum values when using GraphQL schema file

### DIFF
--- a/src/Config/Parser/GraphQL/ASTConverter/EnumNode.php
+++ b/src/Config/Parser/GraphQL/ASTConverter/EnumNode.php
@@ -8,27 +8,27 @@ class EnumNode implements NodeInterface
 {
     public static function toConfig(Node $node)
     {
-        $config = [
-            'description' => DescriptionNode::toConfig($node),
-        ];
-
         $values = [];
+
         foreach ($node->values as $value) {
             $values[$value->name->value] = [
-                'description' => DescriptionNode::toConfig($node),
+                'description' => DescriptionNode::toConfig($value),
                 'value' => $value->name->value,
             ];
 
             $directiveConfig = DirectiveNode::toConfig($value);
+
             if (isset($directiveConfig['deprecationReason'])) {
                 $values[$value->name->value]['deprecationReason'] = $directiveConfig['deprecationReason'];
             }
         }
-        $config['values'] = $values;
 
         return [
             'type' => 'enum',
-            'config' => $config,
+            'config' => [
+                'description' => DescriptionNode::toConfig($node),
+                'values' => $values,
+            ],
         ];
     }
 }

--- a/tests/Config/Parser/fixtures/graphql/schema-0.11.graphql
+++ b/tests/Config/Parser/fixtures/graphql/schema-0.11.graphql
@@ -16,6 +16,7 @@ type Starship {
 
 enum Episode {
   NEWHOPE
+  # Star Wars: Episode V – The Empire Strikes Back
   EMPIRE
   JEDI @deprecated
 }

--- a/tests/Config/Parser/fixtures/graphql/schema.graphql
+++ b/tests/Config/Parser/fixtures/graphql/schema.graphql
@@ -16,6 +16,7 @@ type Starship {
 
 enum Episode {
   NEWHOPE
+  """Star Wars: Episode V – The Empire Strikes Back"""
   EMPIRE
   JEDI @deprecated
 }

--- a/tests/Config/Parser/fixtures/graphql/schema.php
+++ b/tests/Config/Parser/fixtures/graphql/schema.php
@@ -56,8 +56,14 @@ return [
         'config' => [
             'description' => null,
             'values' => [
-                'NEWHOPE' => ['description' => null, 'value' => 'NEWHOPE'],
-                'EMPIRE' => ['description' => null, 'value' => 'EMPIRE'],
+                'NEWHOPE' => [
+                    'description' => null,
+                    'value' => 'NEWHOPE',
+                ],
+                'EMPIRE' => [
+                    'description' => 'Star Wars: Episode V – The Empire Strikes Back',
+                    'value' => 'EMPIRE',
+                ],
                 'JEDI' => [
                     'description' => null,
                     'value' => 'JEDI',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #612
| License       | MIT

This PR fixes a bug that was causing the description of the enum values to be taken from the node of the enum instead of from the node of the value itself.