### PR TITLE
Auto-register the resolver maps using service tags

### DIFF
--- a/UPGRADE-0.13.md
+++ b/UPGRADE-0.13.md
@@ -5,6 +5,7 @@ UPGRADE FROM 0.12 to 0.13
 
 - [Rename default_field config](#rename-default_field-config)
 - [Improve default field resolver](#improve-default-field-resolver)
+- [Use service tags to register resolver maps](#use-service-tags-to-register-resolver-maps)
 
 ### Rename default_field config
 
@@ -50,3 +51,27 @@ MyType:
 ```
 
 [see default Field Resolver per type for more details](https://webonyx.github.io/graphql-php/data-fetching/#default-field-resolver-per-type)
+
+### Use service tags to register resolver maps
+
+The resolver maps used to be configured using the `overblog_graphql.definitions.schema.resolver_maps`
+option. This has been deprecated in favour of using service tags to register them.
+
+```diff
+# config/graphql.yaml
+overblog_graphql:
+    definitions:
+        schema:
+             # ...
+-            resolver_maps:
+-                - 'App\GraphQL\MyResolverMap'
+```
+
+```diff
+# services/graphql.yaml
+services:
+-    App\GraphQL\MyResolverMap: ~
++    App\GraphQL\MyResolverMap:
++        tags:
++            - { name: overblog_graphql.resolver_map, schema: default }
+```

--- a/docs/definitions/quick-start.md
+++ b/docs/definitions/quick-start.md
@@ -30,16 +30,6 @@ in files `config/graphql/types/*.graphql`
 
 4. Define schema Resolvers ([more details](resolver-map.md))
 
-```yaml
-# config/packages/graphql.yaml
-overblog_graphql:
-    definitions:
-        schema:
-            # ...
-            resolver_maps:
-                - App\Resolver\MyResolverMap
-```
-
 ```php
 <?php
 

--- a/docs/definitions/resolver-map.md
+++ b/docs/definitions/resolver-map.md
@@ -118,19 +118,21 @@ class MyResolverMap extends ResolverMap
 }
 ```
 
-Declare resolverMap to current schema
+Each resolver map must be tagged with the `overblog_graphql.resolver_map` tag
+that defines at which priority it should run for the given schema. The priority
+is an optional attribute and it has a default value of 0. The higher the number,
+the earlier the resolver map is executed.
 
 ```yaml
-overblog_graphql:
-    definitions:
-        schema:
-            # ...
-            # resolver maps services IDs
-            resolver_maps:
-                - App\Resolver\MyResolverMap
-
+# config/services.yaml
 services:
-    App\Resolver\MyResolverMap: ~
+    App\Resolver\MyResolverMap1:
+        tags:
+            - { name: overblog_graphql.resolver_map, schema: default }
+    
+    App\Resolver\MyResolverMap2:
+        tags:
+            - { name: overblog_graphql.resolver_map, schema: default, priority: 10 }
 ```
 
 **Notes:**

--- a/src/DependencyInjection/Compiler/ResolverMapTaggedServiceMappingPass.php
+++ b/src/DependencyInjection/Compiler/ResolverMapTaggedServiceMappingPass.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\DependencyInjection\Compiler;
+
+use Overblog\GraphQLBundle\EventListener\TypeDecoratorListener;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class ResolverMapTaggedServiceMappingPass implements CompilerPassInterface
+{
+    private const SERVICE_TAG = 'overblog_graphql.resolver_map';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container): void
+    {
+        $resolverMapsSortedBySchema = [];
+        $resolverMapsBySchemas = $container->getParameter('overblog_graphql.resolver_maps');
+        $typeDecoratorListenerDefinition = $container->getDefinition(TypeDecoratorListener::class);
+
+        foreach ($container->findTaggedServiceIds(self::SERVICE_TAG, true) as $serviceId => $tags) {
+            foreach ($tags as $tag) {
+                if (!isset($tag['schema'])) {
+                    throw new RuntimeException(\sprintf('The "schema" attribute on the "overblog_graphql.resolver_map" tag of the "%s" service is required.', $serviceId));
+                }
+
+                if (!isset($resolverMapsBySchemas[$tag['schema']])) {
+                    throw new RuntimeException(\sprintf('Service "%s" is invalid: schema "%s" specified on the tag "%s" does not exist (known ones are: "%s").', $serviceId, $tag['schema'], self::SERVICE_TAG, \implode('", "', \array_keys($resolverMapsBySchemas))));
+                }
+
+                $resolverMapsBySchemas[$tag['schema']][$serviceId] = $tag['priority'] ?? ($resolverMapsBySchemas[$tag['schema']][$serviceId] ?? 0);
+            }
+        }
+
+        foreach ($resolverMapsBySchemas as $schema => $resolverMaps) {
+            foreach ($resolverMaps as $resolverMap => $priority) {
+                $resolverMapsSortedBySchema[$schema][$priority][] = $resolverMap;
+            }
+        }
+
+        foreach ($resolverMapsSortedBySchema as $schema => $resolverMaps) {
+            \krsort($resolverMaps);
+
+            $resolverMaps = \array_merge(...$resolverMaps);
+
+            foreach ($resolverMaps as $index => $resolverMap) {
+                $resolverMaps[$index] = new Reference($resolverMap);
+            }
+
+            $typeDecoratorListenerDefinition->addMethodCall('addSchemaResolverMaps', [
+                $schema,
+                $resolverMaps,
+            ]);
+        }
+
+        $container->getParameterBag()->remove('overblog_graphql.resolver_maps');
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -210,6 +210,7 @@ class Configuration implements ConfigurationInterface
                     ->arrayNode('resolver_maps')
                         ->defaultValue([])
                         ->prototype('scalar')->end()
+                        ->setDeprecated('The "%path%.%node%" configuration is deprecated since version 0.13 and will be removed in 0.14. Add the "overblog_graphql.resolver_map" tag to the services instead.')
                     ->end()
                     ->arrayNode('types')
                         ->defaultValue([])

--- a/src/OverblogGraphQLBundle.php
+++ b/src/OverblogGraphQLBundle.php
@@ -10,6 +10,7 @@ use Overblog\GraphQLBundle\DependencyInjection\Compiler\ConfigProcessorPass;
 use Overblog\GraphQLBundle\DependencyInjection\Compiler\ExpressionFunctionPass;
 use Overblog\GraphQLBundle\DependencyInjection\Compiler\GlobalVariablesPass;
 use Overblog\GraphQLBundle\DependencyInjection\Compiler\MutationTaggedServiceMappingTaggedPass;
+use Overblog\GraphQLBundle\DependencyInjection\Compiler\ResolverMapTaggedServiceMappingPass;
 use Overblog\GraphQLBundle\DependencyInjection\Compiler\ResolverMethodAliasesPass;
 use Overblog\GraphQLBundle\DependencyInjection\Compiler\ResolverTaggedServiceMappingPass;
 use Overblog\GraphQLBundle\DependencyInjection\Compiler\TypeGeneratorPass;
@@ -43,6 +44,7 @@ class OverblogGraphQLBundle extends Bundle
         $container->addCompilerPass(new ExpressionFunctionPass());
         $container->addCompilerPass(new ResolverMethodAliasesPass());
         $container->addCompilerPass(new AliasedPass());
+        $container->addCompilerPass(new ResolverMapTaggedServiceMappingPass());
         $container->addCompilerPass(new TypeGeneratorPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $container->addCompilerPass(new TypeTaggedServiceMappingPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $container->addCompilerPass(new ResolverTaggedServiceMappingPass(), PassConfig::TYPE_BEFORE_REMOVING);

--- a/tests/DependencyInjection/Compiler/ResolverMapTaggedServiceMappingPassTest.php
+++ b/tests/DependencyInjection/Compiler/ResolverMapTaggedServiceMappingPassTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\DependencyInjection\Compiler;
+
+use Overblog\GraphQLBundle\DependencyInjection\Compiler\ResolverMapTaggedServiceMappingPass;
+use Overblog\GraphQLBundle\EventListener\TypeDecoratorListener;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class ResolverMapTaggedServiceMappingPassTest extends TestCase
+{
+    public function testProcess(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('overblog_graphql.resolver_maps', [
+            'foo' => [],
+            'bar' => [],
+        ]);
+
+        $container->register(TypeDecoratorListener::class);
+        $container->register('App\\GraphQl\\Resolver\\ResolverMap1')
+            ->addTag('overblog_graphql.resolver_map', ['schema' => 'foo']);
+
+        $container->register('App\\GraphQl\\Resolver\\ResolverMap2')
+            ->addTag('overblog_graphql.resolver_map', ['schema' => 'foo', 'priority' => 10])
+            ->addTag('overblog_graphql.resolver_map', ['schema' => 'bar', 'priority' => -10]);
+
+        $container->register('App\\GraphQl\\Resolver\\ResolverMap3')
+            ->addTag('overblog_graphql.resolver_map', ['schema' => 'foo', 'priority' => -10])
+            ->addTag('overblog_graphql.resolver_map', ['schema' => 'bar', 'priority' => 10]);
+
+        $container->register('App\\GraphQl\\Resolver\\ResolverMap4')
+            ->addTag('overblog_graphql.resolver_map', ['schema' => 'bar']);
+
+        (new ResolverMapTaggedServiceMappingPass())->process($container);
+
+        $typeDecoratorListenerDefinition = $container->getDefinition(TypeDecoratorListener::class);
+
+        $methodCalls = $typeDecoratorListenerDefinition->getMethodCalls();
+
+        $this->assertCount(2, $methodCalls);
+
+        $this->assertSame('addSchemaResolverMaps', $methodCalls[0][0]);
+        $this->assertSame('foo', $methodCalls[0][1][0]);
+        $this->assertEquals([
+            new Reference('App\\GraphQl\\Resolver\\ResolverMap2'),
+            new Reference('App\\GraphQl\\Resolver\\ResolverMap1'),
+            new Reference('App\\GraphQl\\Resolver\\ResolverMap3'),
+        ], $methodCalls[0][1][1]);
+
+        $this->assertSame('addSchemaResolverMaps', $methodCalls[1][0]);
+        $this->assertSame('bar', $methodCalls[1][1][0]);
+        $this->assertEquals([
+            new Reference('App\\GraphQl\\Resolver\\ResolverMap3'),
+            new Reference('App\\GraphQl\\Resolver\\ResolverMap4'),
+            new Reference('App\\GraphQl\\Resolver\\ResolverMap2'),
+        ], $methodCalls[1][1][1]);
+    }
+
+    public function testProcessThrowsIfSchemaAttributeIsNotDefinedOnTag(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('overblog_graphql.resolver_maps', []);
+
+        $container->register(TypeDecoratorListener::class);
+        $container->register('App\\GraphQl\\Resolver\\ResolverMap')
+            ->addTag('overblog_graphql.resolver_map');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The "schema" attribute on the "overblog_graphql.resolver_map" tag of the "App\\GraphQl\\Resolver\\ResolverMap" service is required.');
+
+        (new ResolverMapTaggedServiceMappingPass())->process($container);
+    }
+
+    public function testProcessWithResolverMapBothTaggedAndInConfigDoesNotAddItTwice(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('overblog_graphql.resolver_maps', [
+            'foo' => [
+                'App\\GraphQl\\Resolver\\ResolverMap1' => -10,
+                'App\\GraphQl\\Resolver\\ResolverMap2' => 0,
+            ],
+        ]);
+
+        $container->register(TypeDecoratorListener::class);
+        $container->register('App\\GraphQl\\Resolver\\ResolverMap1')
+            ->addTag('overblog_graphql.resolver_map', ['schema' => 'foo', 'priority' => 10]);
+
+        $container->register('App\\GraphQl\\Resolver\\ResolverMap2');
+
+        (new ResolverMapTaggedServiceMappingPass())->process($container);
+
+        $typeDecoratorListenerDefinition = $container->getDefinition(TypeDecoratorListener::class);
+
+        $methodCalls = $typeDecoratorListenerDefinition->getMethodCalls();
+
+        $this->assertCount(1, $methodCalls);
+        $this->assertSame('foo', $methodCalls[0][1][0]);
+        $this->assertEquals([
+            new Reference('App\\GraphQl\\Resolver\\ResolverMap1'),
+            new Reference('App\\GraphQl\\Resolver\\ResolverMap2'),
+        ], $methodCalls[0][1][1]);
+    }
+
+    public function testProcessThrowsIfTagReferencesUnknownSchema(): void
+    {
+        $container = new ContainerBuilder();
+        $container->register(TypeDecoratorListener::class);
+        $container->setParameter('overblog_graphql.resolver_maps', [
+            'foo' => [],
+            'bar' => [],
+        ]);
+
+        $container->register('App\\GraphQl\\Resolver\\ResolverMap')
+            ->addTag('overblog_graphql.resolver_map', ['schema' => 'baz']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Service "App\\GraphQl\\Resolver\\ResolverMap" is invalid: schema "baz" specified on the tag "overblog_graphql.resolver_map" does not exist (known ones are: "foo", "bar").');
+
+        (new ResolverMapTaggedServiceMappingPass())->process($container);
+    }
+}

--- a/tests/Functional/App/config/schemaLanguage/config.yml
+++ b/tests/Functional/App/config/schemaLanguage/config.yml
@@ -8,13 +8,8 @@ overblog_graphql:
             main:
                 query: Query
                 mutation: Mutation
-                resolver_maps:
-                    - Overblog\GraphQLBundle\Tests\Functional\App\Resolver\SchemaLanguageQueryResolverMap
-                    - Overblog\GraphQLBundle\Tests\Functional\App\Resolver\SchemaLanguageMutationResolverMap
             empty:
                 query: Query
-                resolver_maps:
-                    - Overblog\GraphQLBundle\Tests\Functional\App\Resolver\NullResolverMap
         mappings:
             types:
                 -
@@ -23,6 +18,14 @@ overblog_graphql:
                     suffix: ~
 
 services:
-    Overblog\GraphQLBundle\Tests\Functional\App\Resolver\NullResolverMap: ~
-    Overblog\GraphQLBundle\Tests\Functional\App\Resolver\SchemaLanguageQueryResolverMap: ~
-    Overblog\GraphQLBundle\Tests\Functional\App\Resolver\SchemaLanguageMutationResolverMap: ~
+    Overblog\GraphQLBundle\Tests\Functional\App\Resolver\NullResolverMap:
+        tags:
+            - { name: overblog_graphql.resolver_map, schema: empty }
+
+    Overblog\GraphQLBundle\Tests\Functional\App\Resolver\SchemaLanguageQueryResolverMap:
+        tags:
+            - { name: overblog_graphql.resolver_map, schema: main, priority: 10 }
+
+    Overblog\GraphQLBundle\Tests\Functional\App\Resolver\SchemaLanguageMutationResolverMap:
+        tags:
+            - { name: overblog_graphql.resolver_map, schema: main }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | maybe, see below
| Deprecations? | yes
| Tests pass?   | yes
| Documented?   | yes
| Fixed tickets | #592
| License       | MIT

With this PR I'm going to deprecate the `overblog_graphql.definitions.schema.[...].resolver_maps` option and instead we are going to promote the use of the service tag `overblog_graphql.resolver_map`. The tag supports an optional attribute `priority` that allows specifying the priority per-schema of the resolver map