### PR TITLE
Update return typehint for SchemaBuilder

### DIFF
--- a/src/Definition/Builder/SchemaBuilder.php
+++ b/src/Definition/Builder/SchemaBuilder.php
@@ -23,7 +23,7 @@ class SchemaBuilder
         $this->enableValidation = $enableValidation;
     }
 
-    public function getBuilder(string $name, ?string $queryAlias, ?string $mutationAlias = null, ?string $subscriptionAlias = null, array $types = []): callable
+    public function getBuilder(string $name, ?string $queryAlias, ?string $mutationAlias = null, ?string $subscriptionAlias = null, array $types = []): \Closure
     {
         return function () use ($name, $queryAlias, $mutationAlias, $subscriptionAlias, $types): ExtensibleSchema {
             static $schema = null;

--- a/src/Request/Executor.php
+++ b/src/Request/Executor.php
@@ -57,7 +57,7 @@ class Executor
         return $this;
     }
 
-    public function addSchemaBuilder(string $name, callable $builder): self
+    public function addSchemaBuilder(string $name, \Closure $builder): self
     {
         $this->schemas[$name] = $builder;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | nothing to document
| Fixed tickets | none
| License       | MIT

Previously, running `bin/console lint:container` with this bundle installed lead to this error output:

```
  Invalid definition for service "overblog_graphql.request_executor": argument 2 of "Overblog\GraphQLBundle\Request\Executor::addSchemaBuilder" accepts "callable", "Closure" passed.
```

This fixes this error by passing `\Closure` from `\Overblog\GraphQLBundle\Definition\Builder\SchemaBuilder::getBuilder` to `Executor::addSchemaBuilder`.