### PR TITLE
Only grant permission when `access` returns true

### DIFF
--- a/src/Resolver/AccessResolver.php
+++ b/src/Resolver/AccessResolver.php
@@ -51,12 +51,12 @@ class AccessResolver
     {
         $promiseOrHasAccess = $this->hasAccess($accessChecker, $resolveArgs);
         $callback = function ($hasAccess) use ($resolveArgs, $resolveCallback) {
-            if (!$hasAccess) {
-                $exceptionClassName = self::isMutationRootField($resolveArgs[3]) ? UserError::class : UserWarning::class;
-                throw new $exceptionClassName('Access denied to this field.');
+            if (true === $hasAccess) {
+                return \call_user_func_array($resolveCallback, $resolveArgs);
             }
 
-            return \call_user_func_array($resolveCallback, $resolveArgs);
+            $exceptionClassName = self::isMutationRootField($resolveArgs[3]) ? UserError::class : UserWarning::class;
+            throw new $exceptionClassName('Access denied to this field.');
         };
 
         if ($this->isThenable($promiseOrHasAccess)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | could be, if people use `"true"` instead of `true`
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| Fixed tickets | #635
| License       | MIT

This fixes #635

When you provide an expression inside the `access` option, it will only work as an expression when you prefix it with `@=`. When you forget to do this, it will be just a string.

Previously, the code would check if the access value is trueish instead of strict true. This granted access to all fields that had mistakenly forgotten to prefix with `@=`.

I also flipped the if statement so that it's much easier to parse as a human :D 


