### PR TITLE
Add targetType property to Mutation

### DIFF
--- a/docs/annotations/annotations-reference.md
+++ b/docs/annotations/annotations-reference.md
@@ -384,6 +384,10 @@ This annotation applies on methods for classes tagged with the `@Provider` annot
 The resulting field is added to the root Mutation type (defined in configuration at key `overblog_graphql.definitions.schema.mutation`).  
 The class exposing the mutation(s) must be declared as a [service](https://symfony.com/doc/current/service_container.html).
 
+Optional attributes:
+
+-   **targetType** : The GraphQL type to attach the field to (by default, it'll be the root Mutation type).
+
 Example:
 
 This will add an `updateUserEmail` mutation, with as resolver `@=service('App\Graphql\MutationProvider').updateUserEmail(...)`.

--- a/src/Annotation/Mutation.php
+++ b/src/Annotation/Mutation.php
@@ -12,4 +12,10 @@ namespace Overblog\GraphQLBundle\Annotation;
  */
 final class Mutation extends Field
 {
+    /**
+     * The target type to attach this mutation to.
+     *
+     * @var string
+     */
+    public $targetType;
 }

--- a/tests/Config/Parser/AnnotationParserTest.php
+++ b/tests/Config/Parser/AnnotationParserTest.php
@@ -14,6 +14,7 @@ class AnnotationParserTest extends TestCase
         'definitions' => [
             'schema' => [
                 'default' => ['query' => 'RootQuery', 'mutation' => 'RootMutation'],
+                'alternative' => ['query' => 'AlternativeQuery', 'mutation' => 'AlternativeMutation'],
             ],
         ],
         'doctrine' => [
@@ -224,6 +225,30 @@ class AnnotationParserTest extends TestCase
                     'type' => 'Planet',
                     'args' => ['planetInput' => ['type' => 'PlanetInput!']],
                     'resolve' => "@=call(service('Overblog\\\\GraphQLBundle\\\\Tests\\\\Config\\\\Parser\\\\fixtures\\\\annotations\\\\Repository\\\\PlanetRepository').createPlanet, arguments({planetInput: \"PlanetInput!\"}, args))",
+                    'access' => '@=default_access',
+                    'public' => '@=override_public',
+                ],
+            ],
+        ]);
+
+        $this->expect('AlternativeQuery', 'object', [
+            'fields' => [
+                'planet_sortPlanets' => [
+                    'type' => '[Planet]',
+                    'args' => ['direction' => ['type' => 'String!']],
+                    'resolve' => "@=call(service('Overblog\\\\GraphQLBundle\\\\Tests\\\\Config\\\\Parser\\\\fixtures\\\\annotations\\\\Repository\\\\PlanetRepository').sortPlanets, arguments({direction: \"String!\"}, args))",
+                    'access' => '@=default_access',
+                    'public' => '@=default_public',
+                ],
+            ],
+        ]);
+
+        $this->expect('AlternativeMutation', 'object', [
+            'fields' => [
+                'planet_destroyPlanet' => [
+                    'type' => 'Planet',
+                    'args' => ['planetInput' => ['type' => 'PlanetInput!']],
+                    'resolve' => "@=call(service('Overblog\\\\GraphQLBundle\\\\Tests\\\\Config\\\\Parser\\\\fixtures\\\\annotations\\\\Repository\\\\PlanetRepository').destroyPlanet, arguments({planetInput: \"PlanetInput!\"}, args))",
                     'access' => '@=default_access',
                     'public' => '@=override_public',
                 ],

--- a/tests/Config/Parser/fixtures/annotations/Repository/PlanetRepository.php
+++ b/tests/Config/Parser/fixtures/annotations/Repository/PlanetRepository.php
@@ -24,12 +24,33 @@ class PlanetRepository
     }
 
     /**
+     * @GQL\Query(type="[Planet]", targetType="AlternativeQuery", args={
+     *    @GQL\Arg(type="String!", name="direction")
+     * })
+     */
+    public function sortPlanets(string $direction)
+    {
+        return [];
+    }
+
+    /**
      * @GQL\Mutation(type="Planet", args={
      *    @GQL\Arg(type="PlanetInput!", name="planetInput")
      * })
      * @GQL\IsPublic("override_public")
      */
     public function createPlanet(array $planetInput)
+    {
+        return [];
+    }
+
+    /**
+     * @GQL\Mutation(type="Planet", targetType="AlternativeMutation", args={
+     *    @GQL\Arg(type="PlanetInput!", name="planetInput")
+     * })
+     * @GQL\IsPublic("override_public")
+     */
+    public function destroyPlanet(array $planetInput)
     {
         return [];
     }

--- a/tests/Config/Parser/fixtures/annotations/Type/AlternativeMutation.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/AlternativeMutation.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Type;
+
+use Overblog\GraphQLBundle\Annotation as GQL;
+
+/**
+ * @GQL\Type
+ */
+class AlternativeMutation
+{
+}

--- a/tests/Config/Parser/fixtures/annotations/Type/AlternativeQuery.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/AlternativeQuery.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Type;
+
+use Overblog\GraphQLBundle\Annotation as GQL;
+
+/**
+ * @GQL\Type
+ */
+class AlternativeQuery
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| Fixed tickets | #526 
| License       | MIT

Added targetType property to the Mutation type so that different schemas can be created and mutations can be attached to them. 