### PR TITLE
Always pass arguments from expression function

### DIFF
--- a/src/Transformer/ArgumentsTransformer.php
+++ b/src/Transformer/ArgumentsTransformer.php
@@ -81,6 +81,9 @@ class ArgumentsTransformer
     private function populateObject(Type $type, $data, bool $multiple, ResolveInfo $info)
     {
         if (null === $data) {
+            if ($type instanceof InputObjectType) {
+                return $this->getTypeClassInstance($type->name) ?: null;
+            }
             return $data;
         }
 
@@ -129,9 +132,9 @@ class ArgumentsTransformer
             }
 
             return $instance;
-        } else {
-            return $data;
         }
+
+        return $data;
     }
 
     /**
@@ -170,9 +173,9 @@ class ArgumentsTransformer
 
         if (\count($errors) > 0) {
             throw new InvalidArgumentError($argName, $errors);
-        } else {
-            return $result;
         }
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | none
| License       | MIT

Previously, if I was passing arguments to my resolvers with the expression function, I would get `null` instead of an instance if the query has no arguments (e.g. no parens at all in GQL).

However, this breaks resolvers that require an instance argument. This makes `@arguments` always try to return an instance of an InputObject whenever it is required.