### PR TITLE
Added support for getters with no prefix on FieldResolver

### DIFF
--- a/src/Resolver/FieldResolver.php
+++ b/src/Resolver/FieldResolver.php
@@ -24,6 +24,8 @@ class FieldResolver
         } elseif (\is_object($objectOrArray)) {
             if (null !== $getter = self::guessObjectMethod($objectOrArray, $fieldName, 'get')) {
                 $value = $objectOrArray->$getter();
+            } elseif (null !== $getter = self::guessObjectMethod($objectOrArray, $fieldName, '')) {
+                $value = $objectOrArray->$getter();
             } elseif (isset($objectOrArray->$fieldName)) {
                 $value = $objectOrArray->$fieldName;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| License       | MIT

When upgrading to 13.1 my API broke: all of a sudden, some fields were `null` instead of their actual value.

The problem is inside the FieldResolver, it does not handles methods with no leading `get` prefix. In my case my entity looks like this:

```php
class Entity
{
    public function hasSomething() {
        //...
    }
}
```

And the schema:

```yaml
Entity:
    type: object
    config:
        fields:
            hasSomething:
                type: "Boolean"
            # ...
```

We want to call `$entity->hasSomething()` during resolution, not only `$entity->getHasSomething()`.