### PR TITLE
Use the exception key in the context of the logger

### DIFF
--- a/src/EventListener/ErrorLoggerListener.php
+++ b/src/EventListener/ErrorLoggerListener.php
@@ -15,65 +15,55 @@ final class ErrorLoggerListener
 {
     public const DEFAULT_LOGGER_SERVICE = 'logger';
 
-    /** @var LoggerInterface */
+    /**
+     * @var LoggerInterface
+     */
     private $logger;
 
-    public function __construct(
-        LoggerInterface $logger = null
-    ) {
-        $this->logger = null === $logger ? new NullLogger() : $logger;
+    public function __construct(?LoggerInterface $logger = null)
+    {
+        $this->logger = $logger ?? new NullLogger();
     }
 
     public function onErrorFormatting(ErrorFormattingEvent $event): void
     {
         $error = $event->getError();
+        $exception = $error->getPrevious();
 
-        if ($error->getPrevious()) {
-            $exception = $error->getPrevious();
-            if ($exception instanceof UserError) {
-                if ($exception->getPrevious()) {
-                    $this->log($exception->getPrevious());
-                }
-
-                return;
-            }
-
-            if ($exception instanceof UserWarning) {
-                if ($exception->getPrevious()) {
-                    $this->log($exception->getPrevious(), LogLevel::WARNING);
-                }
-
-                return;
-            }
-            $this->log($error->getPrevious(), LogLevel::CRITICAL);
+        if (null === $exception) {
+            return;
         }
+
+        if ($exception instanceof UserError) {
+            if ($exception->getPrevious()) {
+                $this->log($exception->getPrevious());
+            }
+
+            return;
+        }
+
+        if ($exception instanceof UserWarning) {
+            if ($exception->getPrevious()) {
+                $this->log($exception->getPrevious(), LogLevel::WARNING);
+            }
+
+            return;
+        }
+
+        $this->log($exception, LogLevel::CRITICAL);
     }
 
-    /**
-     * @param \Throwable $throwable
-     * @param string     $errorLevel
-     */
-    public function log(\Throwable $throwable, string $errorLevel = LogLevel::ERROR): void
-    {
-        $this->logger->$errorLevel(self::serializeThrowableObject($throwable), ['throwable' => $throwable]);
-    }
-
-    /**
-     * @param \Throwable $throwable
-     *
-     * @return string
-     */
-    private static function serializeThrowableObject($throwable): string
+    public function log(\Throwable $exception, string $errorLevel = LogLevel::ERROR): void
     {
         $message = \sprintf(
             '[GraphQL] %s: %s[%d] (caught throwable) at %s line %s.',
-            \get_class($throwable),
-            $throwable->getMessage(),
-            $throwable->getCode(),
-            $throwable->getFile(),
-            $throwable->getLine()
+            \get_class($exception),
+            $exception->getMessage(),
+            $exception->getCode(),
+            $exception->getFile(),
+            $exception->getLine()
         );
 
-        return $message;
+        $this->logger->log($errorLevel, $message, ['exception' => $exception]);
     }
 }

--- a/tests/EventListener/ErrorLoggerListenerTest.php
+++ b/tests/EventListener/ErrorLoggerListenerTest.php
@@ -9,69 +9,108 @@ use Overblog\GraphQLBundle\Error\UserError;
 use Overblog\GraphQLBundle\Error\UserWarning;
 use Overblog\GraphQLBundle\Event\ErrorFormattingEvent;
 use Overblog\GraphQLBundle\EventListener\ErrorLoggerListener;
-use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\MockObject\Matcher\Invocation;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 
-class ErrorLoggerListenerTest extends TestCase
+final class ErrorLoggerListenerTest extends TestCase
 {
-    /** @var ErrorLoggerListener */
+    /**
+     * @var ErrorLoggerListener
+     */
     private $listener;
 
-    /** @var LoggerInterface|MockObject */
+    /**
+     * @var LoggerInterface&MockObject
+     */
     private $logger;
 
     public function setUp(): void
     {
-        $this->logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
+        $this->logger = $this->createMock(LoggerInterface::class);
         $this->listener = new ErrorLoggerListener($this->logger);
     }
 
     /**
-     * @param Error             $error
-     * @param Invocation        $loggerExpects
-     * @param Constraint|string $loggerMethod
-     * @param array|null        $with
-     *
-     * @dataProvider fixtures
+     * @dataProvider onErrorFormattingDataProvider
      */
-    public function testOnErrorFormatting(Error $error, $loggerExpects, $loggerMethod, array $with = null): void
+    public function testOnErrorFormatting(Error $error, Invocation $expectedLoggerCalls, array $expectedLoggerMethodArguments): void
     {
-        $mock = $this->logger->expects($loggerExpects)->method($loggerMethod);
-        if ($with) {
-            $mock->with(...$with);
-        }
+        $this->logger->expects($expectedLoggerCalls)
+            ->method('log')
+            ->with(...$expectedLoggerMethodArguments);
 
         $this->listener->onErrorFormatting(new ErrorFormattingEvent($error, []));
     }
 
-    public function fixtures()
+    public function onErrorFormattingDataProvider(): \Generator
     {
-        try {
-            throw new \Exception('Ko!');
-        } catch (\Exception $exception) {
-        }
-        $with = [
-            \sprintf('[GraphQL] %s: %s[%d] (caught throwable) at %s line %s.', \Exception::class, 'Ko!', 0, __FILE__, $exception->getLine()),
-            ['throwable' => $exception],
+        $exception = new \Exception('Ko!');
+
+        yield [
+            new Error('Basic error'),
+            $this->never(),
+            [$this->anything()],
         ];
 
-        return [
-            [self::createError('Basic error'), $this->never(), $this->anything()],
-            [self::createError('Wrapped Base UserError without previous', new \GraphQL\Error\UserError('User error message')), $this->never(), $this->anything()],
-            [self::createError('Wrapped UserError without previous', new UserError('User error message')), $this->never(), $this->anything()],
-            [self::createError('Wrapped UserWarning without previous', new UserWarning('User warning message')), $this->never(), $this->anything()],
-            [self::createError('Wrapped unknown exception', $exception), $this->once(), 'critical', $with],
-            [self::createError('Wrapped Base UserError with previous', new \GraphQL\Error\UserError('User error message', 0, $exception)), $this->once(), 'error', $with],
-            [self::createError('Wrapped UserError with previous', new UserError('User error message', 0, $exception)), $this->once(), 'error', $with],
-            [self::createError('Wrapped UserWarning with previous', new UserWarning('User warning message', 0, $exception)), $this->once(), 'warning', $with],
+        yield [
+            new Error('Wrapped Base UserError without previous', null, null, null, null, new UserError('User error message')),
+            $this->never(),
+            [$this->anything()],
         ];
-    }
 
-    private static function createError($message, \Exception $exception = null)
-    {
-        return new Error($message, null, null, null, null, $exception);
+        yield [
+            new Error('Wrapped UserError without previous', null, null, null, null, new UserError('User error message')),
+            $this->never(),
+            [$this->anything()],
+        ];
+
+        yield [
+            new Error('Wrapped UserWarning without previous', null, null, null, null, new UserWarning('User warning message')),
+            $this->never(),
+            [$this->anything()],
+        ];
+
+        yield [
+            new Error('Wrapped unknown exception', null, null, null, null, $exception),
+            $this->once(),
+            [
+                LogLevel::CRITICAL,
+                \sprintf('[GraphQL] Exception: Ko![0] (caught throwable) at %s line %s.', __FILE__, $exception->getLine()),
+                ['exception' => $exception],
+            ],
+        ];
+
+        yield [
+            new Error('Wrapped Base UserError with previous', null, null, null, null, new UserError('User error message', 0, $exception)),
+            $this->once(),
+            [
+                LogLevel::ERROR,
+                \sprintf('[GraphQL] Exception: Ko![0] (caught throwable) at %s line %s.', __FILE__, $exception->getLine()),
+                ['exception' => $exception],
+            ],
+        ];
+
+        yield [
+            new Error('Wrapped UserError with previous', null, null, null, null, new UserError('User error message', 0, $exception)),
+            $this->once(),
+            [
+                LogLevel::ERROR,
+                \sprintf('[GraphQL] Exception: Ko![0] (caught throwable) at %s line %s.', __FILE__, $exception->getLine()),
+                ['exception' => $exception],
+            ],
+        ];
+
+        yield [
+            new Error('Wrapped UserWarning with previous', null, null, null, null, new UserWarning('User warning message', 0, $exception)),
+            $this->once(),
+            [
+                LogLevel::WARNING,
+                \sprintf('[GraphQL] Exception: Ko![0] (caught throwable) at %s line %s.', __FILE__, $exception->getLine()),
+                ['exception' => $exception],
+            ],
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| License       | MIT

I noticed that most of the Monolog default handlers uses the `exception` key instead of `throwable` to retrieve the exception from the context data of a log, thus with this PR I'm gonna fix the `ErrorLoggerListener` listener. Here a list of handlers that make this assumption:

- Sentry handler (both v1 and v2)
- Rollbar handler
- New Relic handler

To not break BC both keys could be used and in the next major version the old one could be dropped. Let me know how you want to proceed, and if you want of course.