### PR TITLE
Make the encoder for the cursors of the edges of a connection customizable

### DIFF
--- a/UPGRADE-1.0.md
+++ b/UPGRADE-1.0.md
@@ -1,0 +1,32 @@
+UPGRADE FROM 0.13 to 1.0
+=======================
+
+# Table of Contents
+
+- [Customize the cursor encoder of the edges of a connection](#customize-the-cursor-encoder-of-the-edges-of-a-connection)
+
+### Customize the cursor encoder of the edges of a connection
+
+The connection builder now accepts an optional custom cursor encoder as first argument of the constructor.
+
+```diff
+$connectionBuilder = new ConnectionBuilder(
++   new class implements CursorEncoderInterface {
++       public function encode($value): string
++       {
++           ...
++       }
++
++       public function decode(string $cursor)
++       {
++           ...
++       }
++   }
+    static function (iterable $edges, PageInfoInterface $pageInfo) {
+        ...
+    },
+    static function (string $cursor, $value, int $index) {
+        ...
+    }
+);
+```

--- a/docs/helpers/relay-paginator.md
+++ b/docs/helpers/relay-paginator.md
@@ -269,18 +269,22 @@ Sometimes, you want to add fields to your Connection or Edges. In order to do so
 
 ```php
 use Overblog\GraphQLBundle\Relay\Connection\ConnectionBuilder;
+use Overblog\GraphQLBundle\Relay\Connection\Cursor\Base64CursorEncoder;
 
 public function resolveSomething(Argument $args)
 {
-    $connectionBuilder = new ConnectionBuilder( 
+    $connectionBuilder = new ConnectionBuilder(
+        new Base64CursorEncoder(),
         function(iterable $edges, PageInfo $pageInfo) : FriendsConnection {
-            $connection = new FriendsConnection($edges, $pageInfo)
+            $connection = new FriendsConnection($edges, $pageInfo);
             $connection->setAverageAge(calculateAverage($edges));
+
             return $connection;
         },
-        function(string $cursor, UserFriend $entity, int $index):FriendEdge {
+        function(string $cursor, UserFriend $entity, int $index): FriendEdge {
             $edge = new FriendEdge($cursor, $entity->getUser());
             $edge->setFriendshipTime($entity->getCreatedAt());
+
             return $edge;
         }
     );
@@ -291,7 +295,7 @@ public function resolveSomething(Argument $args)
 }
 ```
 
-The `ConnectionBuilder` constructor accepts two parameters. The first one is a callback to build the Connection object, and the second one is a callback to build an Edge object.  
+The `ConnectionBuilder` constructor accepts three parameters. The first one is an encoder that will be used to encode the cursor of the edges, the second is a callback to build the Connection object and the last one is a callback to build an Edge object.
 
 The connection callback will be call with the following parameters :
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -626,11 +626,6 @@ parameters:
 			path: src/Relay/Connection/ConnectionBuilder.php
 
 		-
-			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|false given\\.$#"
-			count: 1
-			path: src/Relay/Connection/ConnectionBuilder.php
-
-		-
 			message: "#^If condition is always true\\.$#"
 			count: 2
 			path: src/Relay/Connection/ConnectionBuilder.php
@@ -1132,12 +1127,22 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 0 on iterable\\<Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\EdgeInterface\\>\\.$#"
-			count: 3
+			count: 4
 			path: tests/Relay/Connection/ConnectionBuilderTest.php
 
 		-
 			message: "#^Cannot access offset 1 on iterable\\<Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\EdgeInterface\\>\\.$#"
-			count: 3
+			count: 4
+			path: tests/Relay/Connection/ConnectionBuilderTest.php
+
+		-
+			message: "#^Cannot access offset 2 on iterable\\<Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\EdgeInterface\\>\\.$#"
+			count: 1
+			path: tests/Relay/Connection/ConnectionBuilderTest.php
+
+		-
+			message: "#^Cannot access offset 3 on iterable\\<Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\EdgeInterface\\>\\.$#"
+			count: 1
 			path: tests/Relay/Connection/ConnectionBuilderTest.php
 
 		-

--- a/src/Relay/Connection/Cursor/Base64CursorEncoder.php
+++ b/src/Relay/Connection/Cursor/Base64CursorEncoder.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Relay\Connection\Cursor;
+
+use Overblog\GraphQLBundle\Util\Base64Encoder;
+
+/**
+ * @phpstan-implements CursorEncoderInterface<string>
+ */
+final class Base64CursorEncoder implements CursorEncoderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function encode($value): string
+    {
+        return Base64Encoder::encodeUrlSafe($value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function decode(string $cursor)
+    {
+        return Base64Encoder::decodeUrlSafe($cursor);
+    }
+}

--- a/src/Relay/Connection/Cursor/Base64UrlSafeCursorEncoder.php
+++ b/src/Relay/Connection/Cursor/Base64UrlSafeCursorEncoder.php
@@ -9,14 +9,14 @@ use Overblog\GraphQLBundle\Util\Base64Encoder;
 /**
  * @phpstan-implements CursorEncoderInterface<string>
  */
-final class Base64CursorEncoder implements CursorEncoderInterface
+final class Base64UrlSafeCursorEncoder implements CursorEncoderInterface
 {
     /**
      * {@inheritdoc}
      */
     public function encode($value): string
     {
-        return Base64Encoder::encode($value);
+        return Base64Encoder::encodeUrlSafe($value);
     }
 
     /**
@@ -24,6 +24,6 @@ final class Base64CursorEncoder implements CursorEncoderInterface
      */
     public function decode(string $cursor)
     {
-        return Base64Encoder::decode($cursor);
+        return Base64Encoder::decodeUrlSafe($cursor);
     }
 }

--- a/src/Relay/Connection/Cursor/CursorEncoderInterface.php
+++ b/src/Relay/Connection/Cursor/CursorEncoderInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Relay\Connection\Cursor;
+
+/**
+ * @phpstan-template T
+ */
+interface CursorEncoderInterface
+{
+    /**
+     * @param mixed $value
+     *
+     * @phpstan-param T $value
+     */
+    public function encode($value): string;
+
+    /**
+     * @return mixed
+     *
+     * @phpstan-return T
+     */
+    public function decode(string $cursor);
+}

--- a/src/Relay/Connection/Cursor/PlainCursorEncoder.php
+++ b/src/Relay/Connection/Cursor/PlainCursorEncoder.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Relay\Connection\Cursor;
+
+/**
+ * @phpstan-implements CursorEncoderInterface<string>
+ */
+final class PlainCursorEncoder implements CursorEncoderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function encode($value): string
+    {
+        return $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function decode(string $cursor)
+    {
+        return $cursor;
+    }
+}

--- a/src/Util/Base64Encoder.php
+++ b/src/Util/Base64Encoder.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Util;
+
+final class Base64Encoder
+{
+    public static function encodeUrlSafe(string $value, bool $padding = false): string
+    {
+        $result = \base64_encode($value);
+        $result = \str_replace(['+', '/'], ['-', '_'], $result);
+
+        if (!$padding) {
+            $result = \str_replace('=', '', $result);
+        }
+
+        return $result;
+    }
+
+    public static function decodeUrlSafe(string $value, bool $strict = true): string
+    {
+        $value = \str_replace(['-', '_'], ['+', '/'], $value);
+
+        if (0 === \strrpos($value, '=', -1) && 0 !== \strlen($value) % 4) {
+            $value = \str_pad($value, (\strlen($value) + 3) & ~3, '=');
+        }
+
+        $result = \base64_decode($value, $strict);
+
+        if (false === $result) {
+            throw new \InvalidArgumentException(\sprintf('The "%s" value failed to be decoded from base64 format.', $value));
+        }
+
+        return $result;
+    }
+}

--- a/src/Util/Base64Encoder.php
+++ b/src/Util/Base64Encoder.php
@@ -6,6 +6,22 @@ namespace Overblog\GraphQLBundle\Util;
 
 final class Base64Encoder
 {
+    public static function encode(string $value): string
+    {
+        return \base64_encode($value);
+    }
+
+    public static function decode(string $value, bool $strict = true): string
+    {
+        $result = \base64_decode($value, $strict);
+
+        if (false === $result) {
+            throw new \InvalidArgumentException(\sprintf('The "%s" value failed to be decoded from base64 format.', $value));
+        }
+
+        return $result;
+    }
+
     public static function encodeUrlSafe(string $value, bool $padding = false): string
     {
         $result = \base64_encode($value);
@@ -22,7 +38,7 @@ final class Base64Encoder
     {
         $value = \str_replace(['-', '_'], ['+', '/'], $value);
 
-        if (0 === \strrpos($value, '=', -1) && 0 !== \strlen($value) % 4) {
+        if (0 === \substr_compare($value, '=', -1) && 0 !== \strlen($value) % 4) {
             $value = \str_pad($value, (\strlen($value) + 3) & ~3, '=');
         }
 

--- a/tests/Relay/Connection/AbstractConnectionBuilderTest.php
+++ b/tests/Relay/Connection/AbstractConnectionBuilderTest.php
@@ -17,11 +17,11 @@ abstract class AbstractConnectionBuilderTest extends TestCase
     protected function getExpectedConnection(array $wantedEdges, $hasPreviousPage, $hasNextPage): ConnectionInterface
     {
         $edges = [
-            'A' => new Edge('YXJyYXljb25uZWN0aW9uOjA=', 'A'),
-            'B' => new Edge('YXJyYXljb25uZWN0aW9uOjE=', 'B'),
-            'C' => new Edge('YXJyYXljb25uZWN0aW9uOjI=', 'C'),
-            'D' => new Edge('YXJyYXljb25uZWN0aW9uOjM=', 'D'),
-            'E' => new Edge('YXJyYXljb25uZWN0aW9uOjQ=', 'E'),
+            'A' => new Edge('YXJyYXljb25uZWN0aW9uOjA', 'A'),
+            'B' => new Edge('YXJyYXljb25uZWN0aW9uOjE', 'B'),
+            'C' => new Edge('YXJyYXljb25uZWN0aW9uOjI', 'C'),
+            'D' => new Edge('YXJyYXljb25uZWN0aW9uOjM', 'D'),
+            'E' => new Edge('YXJyYXljb25uZWN0aW9uOjQ', 'E'),
         ];
 
         $expectedEdges = \array_values(\array_intersect_key($edges, \array_flip($wantedEdges)));

--- a/tests/Relay/Connection/AbstractConnectionBuilderTest.php
+++ b/tests/Relay/Connection/AbstractConnectionBuilderTest.php
@@ -17,11 +17,11 @@ abstract class AbstractConnectionBuilderTest extends TestCase
     protected function getExpectedConnection(array $wantedEdges, $hasPreviousPage, $hasNextPage): ConnectionInterface
     {
         $edges = [
-            'A' => new Edge('YXJyYXljb25uZWN0aW9uOjA', 'A'),
-            'B' => new Edge('YXJyYXljb25uZWN0aW9uOjE', 'B'),
-            'C' => new Edge('YXJyYXljb25uZWN0aW9uOjI', 'C'),
-            'D' => new Edge('YXJyYXljb25uZWN0aW9uOjM', 'D'),
-            'E' => new Edge('YXJyYXljb25uZWN0aW9uOjQ', 'E'),
+            'A' => new Edge('YXJyYXljb25uZWN0aW9uOjA=', 'A'),
+            'B' => new Edge('YXJyYXljb25uZWN0aW9uOjE=', 'B'),
+            'C' => new Edge('YXJyYXljb25uZWN0aW9uOjI=', 'C'),
+            'D' => new Edge('YXJyYXljb25uZWN0aW9uOjM=', 'D'),
+            'E' => new Edge('YXJyYXljb25uZWN0aW9uOjQ=', 'E'),
         ];
 
         $expectedEdges = \array_values(\array_intersect_key($edges, \array_flip($wantedEdges)));

--- a/tests/Relay/Connection/ConnectionBuilderTest.php
+++ b/tests/Relay/Connection/ConnectionBuilderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Tests\Relay\Connection;
 
 use Overblog\GraphQLBundle\Relay\Connection\ConnectionBuilder;
+use Overblog\GraphQLBundle\Relay\Connection\Cursor\CursorEncoderInterface;
 use Overblog\GraphQLBundle\Relay\Connection\Output\Connection;
 use Overblog\GraphQLBundle\Relay\Connection\Output\PageInfo;
 
@@ -63,7 +64,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArray'],
             $this->letters,
-            ['first' => 2, 'after' => 'YXJyYXljb25uZWN0aW9uOjE=']
+            ['first' => 2, 'after' => 'YXJyYXljb25uZWN0aW9uOjE']
         );
 
         $expected = $this->getExpectedConnection(['C', 'D'], false, true);
@@ -75,7 +76,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArray'],
             $this->letters,
-            ['first' => 10, 'after' => 'YXJyYXljb25uZWN0aW9uOjE=']
+            ['first' => 10, 'after' => 'YXJyYXljb25uZWN0aW9uOjE']
         );
 
         $expected = $this->getExpectedConnection(['C', 'D', 'E'], false, false);
@@ -87,7 +88,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArray'],
             $this->letters,
-            ['last' => 2, 'before' => 'YXJyYXljb25uZWN0aW9uOjM=']
+            ['last' => 2, 'before' => 'YXJyYXljb25uZWN0aW9uOjM']
         );
 
         $expected = $this->getExpectedConnection(['B', 'C'], true, false);
@@ -99,7 +100,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArray'],
             $this->letters,
-            ['last' => 10, 'before' => 'YXJyYXljb25uZWN0aW9uOjM=']
+            ['last' => 10, 'before' => 'YXJyYXljb25uZWN0aW9uOjM']
         );
 
         $expected = $this->getExpectedConnection(['A', 'B', 'C'], false, false);
@@ -111,7 +112,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArray'],
             $this->letters,
-            ['first' => 2, 'after' => 'YXJyYXljb25uZWN0aW9uOjA=', 'before' => 'YXJyYXljb25uZWN0aW9uOjQ=']
+            ['first' => 2, 'after' => 'YXJyYXljb25uZWN0aW9uOjA', 'before' => 'YXJyYXljb25uZWN0aW9uOjQ']
         );
 
         $expected = $this->getExpectedConnection(['B', 'C'], false, true);
@@ -123,7 +124,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArray'],
             $this->letters,
-            ['first' => 4, 'after' => 'YXJyYXljb25uZWN0aW9uOjA=', 'before' => 'YXJyYXljb25uZWN0aW9uOjQ=']
+            ['first' => 4, 'after' => 'YXJyYXljb25uZWN0aW9uOjA', 'before' => 'YXJyYXljb25uZWN0aW9uOjQ']
         );
 
         $expected = $this->getExpectedConnection(['B', 'C', 'D'], false, false);
@@ -135,7 +136,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArray'],
             $this->letters,
-            ['first' => 3, 'after' => 'YXJyYXljb25uZWN0aW9uOjA=', 'before' => 'YXJyYXljb25uZWN0aW9uOjQ=']
+            ['first' => 3, 'after' => 'YXJyYXljb25uZWN0aW9uOjA', 'before' => 'YXJyYXljb25uZWN0aW9uOjQ']
         );
 
         $expected = $this->getExpectedConnection(['B', 'C', 'D'], false, false);
@@ -147,7 +148,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArray'],
             $this->letters,
-            ['last' => 2, 'after' => 'YXJyYXljb25uZWN0aW9uOjA=', 'before' => 'YXJyYXljb25uZWN0aW9uOjQ=']
+            ['last' => 2, 'after' => 'YXJyYXljb25uZWN0aW9uOjA', 'before' => 'YXJyYXljb25uZWN0aW9uOjQ']
         );
 
         $expected = $this->getExpectedConnection(['C', 'D'], true, false);
@@ -159,7 +160,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArray'],
             $this->letters,
-            ['last' => 4, 'after' => 'YXJyYXljb25uZWN0aW9uOjA=', 'before' => 'YXJyYXljb25uZWN0aW9uOjQ=']
+            ['last' => 4, 'after' => 'YXJyYXljb25uZWN0aW9uOjA', 'before' => 'YXJyYXljb25uZWN0aW9uOjQ']
         );
 
         $expected = $this->getExpectedConnection(['B', 'C', 'D'], false, false);
@@ -171,7 +172,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArray'],
             $this->letters,
-            ['last' => 3, 'after' => 'YXJyYXljb25uZWN0aW9uOjA=', 'before' => 'YXJyYXljb25uZWN0aW9uOjQ=']
+            ['last' => 3, 'after' => 'YXJyYXljb25uZWN0aW9uOjA', 'before' => 'YXJyYXljb25uZWN0aW9uOjQ']
         );
 
         $expected = $this->getExpectedConnection(['B', 'C', 'D'], false, false);
@@ -242,7 +243,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArray'],
             $this->letters,
-            ['before' => 'YXJyYXljb25uZWN0aW9uOjI=', 'after' => 'YXJyYXljb25uZWN0aW9uOjQ=']
+            ['before' => 'YXJyYXljb25uZWN0aW9uOjI', 'after' => 'YXJyYXljb25uZWN0aW9uOjQ=']
         );
 
         $expected = $this->getExpectedConnection([], false, false);
@@ -257,7 +258,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArraySlice'],
             \array_slice($this->letters, 1, 2), // equals to letters.slice(1,3) in JS
-            ['first' => 2, 'after' => 'YXJyYXljb25uZWN0aW9uOjA='],
+            ['first' => 2, 'after' => 'YXJyYXljb25uZWN0aW9uOjA'],
             ['sliceStart' => 1, 'arrayLength' => 5]
         );
 
@@ -273,7 +274,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArraySlice'],
             \array_slice($this->letters, 0, 3), // equals to letters.slice(0,3) in JS
-            ['first' => 2, 'after' => 'YXJyYXljb25uZWN0aW9uOjA='],
+            ['first' => 2, 'after' => 'YXJyYXljb25uZWN0aW9uOjA'],
             ['sliceStart' => 0, 'arrayLength' => 5]
         );
 
@@ -289,7 +290,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArraySlice'],
             \array_slice($this->letters, 2, 2), // equals to letters.slice(2,4) in JS
-            ['first' => 1, 'after' => 'YXJyYXljb25uZWN0aW9uOjE='],
+            ['first' => 1, 'after' => 'YXJyYXljb25uZWN0aW9uOjE'],
             ['sliceStart' => 2, 'arrayLength' => 5]
         );
 
@@ -305,7 +306,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArraySlice'],
             \array_slice($this->letters, 1, 3), // equals to letters.slice(1,4) in JS
-            ['first' => 1, 'after' => 'YXJyYXljb25uZWN0aW9uOjE='],
+            ['first' => 1, 'after' => 'YXJyYXljb25uZWN0aW9uOjE'],
             ['sliceStart' => 1, 'arrayLength' => 5]
         );
 
@@ -321,7 +322,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArraySlice'],
             \array_slice($this->letters, 3, 2), // equals to letters.slice(3,5) in JS
-            ['first' => 3, 'after' => 'YXJyYXljb25uZWN0aW9uOjE='],
+            ['first' => 3, 'after' => 'YXJyYXljb25uZWN0aW9uOjE'],
             ['sliceStart' => 3, 'arrayLength' => 5]
         );
 
@@ -337,7 +338,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArraySlice'],
             \array_slice($this->letters, 2, 2), // equals to letters.slice(2,4) in JS
-            ['first' => 3, 'after' => 'YXJyYXljb25uZWN0aW9uOjE='],
+            ['first' => 3, 'after' => 'YXJyYXljb25uZWN0aW9uOjE'],
             ['sliceStart' => 2, 'arrayLength' => 5]
         );
 
@@ -353,7 +354,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArraySlice'],
             \array_slice($this->letters, 3, 1), // equals to letters.slice(3,4) in JS
-            ['first' => 3, 'after' => 'YXJyYXljb25uZWN0aW9uOjE='],
+            ['first' => 3, 'after' => 'YXJyYXljb25uZWN0aW9uOjE'],
             ['sliceStart' => 3, 'arrayLength' => 5]
         );
 
@@ -366,7 +367,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $letterCursor = \call_user_func([static::getBuilder(), 'cursorForObjectInConnection'], $this->letters, 'B');
 
-        $this->assertSame('YXJyYXljb25uZWN0aW9uOjE=', $letterCursor);
+        $this->assertSame('YXJyYXljb25uZWN0aW9uOjE', $letterCursor);
     }
 
     public function testReturnsAnEdgesCursorGivenAnArrayAndANonMemberObject(): void
@@ -376,9 +377,29 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
         $this->assertNull($letterCursor);
     }
 
+    public function testCursorEncoder(): void
+    {
+        $cursorEncoder = $this->createMock(CursorEncoderInterface::class);
+        $cursorEncoder->expects($this->exactly(4))
+            ->method('encode')
+            ->willReturnArgument(0);
+
+        $cursorEncoder->expects($this->exactly(1))
+            ->method('decode')
+            ->willReturnArgument(0);
+
+        $connectionBuilder = new ConnectionBuilder($cursorEncoder);
+        $edges = $connectionBuilder->connectionFromArray($this->letters, ['after' => 'arrayconnection:0'])->getEdges();
+
+        $this->assertSame($edges[0]->getCursor(), 'arrayconnection:1');
+        $this->assertSame($edges[1]->getCursor(), 'arrayconnection:2');
+        $this->assertSame($edges[2]->getCursor(), 'arrayconnection:3');
+        $this->assertSame($edges[3]->getCursor(), 'arrayconnection:4');
+    }
+
     public function testConnectionCallback(): void
     {
-        $connectionBuilder = new ConnectionBuilder(function ($edges, $pageInfo) {
+        $connectionBuilder = new ConnectionBuilder(null, function ($edges, $pageInfo) {
             $connection = new fixtures\CustomConnection($edges, $pageInfo);
             $connection->averageAge = 10;
 
@@ -392,7 +413,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
 
     public function testEdgeCallback(): void
     {
-        $connectionBuilder = new ConnectionBuilder(null, function ($cursor, $value, $index) {
+        $connectionBuilder = new ConnectionBuilder(null, null, function ($cursor, $value, $index) {
             $edge = new fixtures\CustomEdge($cursor, $value);
             $edge->customProperty = 'edge'.$index;
 
@@ -403,8 +424,8 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
         $this->assertInstanceOf(fixtures\CustomEdge::class, $actualEdges[0]);
         $this->assertInstanceOf(fixtures\CustomEdge::class, $actualEdges[1]);
 
-        $this->assertEquals($actualEdges[0]->getCursor(), 'YXJyYXljb25uZWN0aW9uOjA=');
-        $this->assertEquals($actualEdges[1]->getCursor(), 'YXJyYXljb25uZWN0aW9uOjE=');
+        $this->assertEquals($actualEdges[0]->getCursor(), 'YXJyYXljb25uZWN0aW9uOjA');
+        $this->assertEquals($actualEdges[1]->getCursor(), 'YXJyYXljb25uZWN0aW9uOjE');
 
         $this->assertEquals($actualEdges[0]->customProperty, 'edge0');
         $this->assertEquals($actualEdges[1]->customProperty, 'edge1');

--- a/tests/Relay/Connection/ConnectionBuilderTest.php
+++ b/tests/Relay/Connection/ConnectionBuilderTest.php
@@ -64,7 +64,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArray'],
             $this->letters,
-            ['first' => 2, 'after' => 'YXJyYXljb25uZWN0aW9uOjE']
+            ['first' => 2, 'after' => 'YXJyYXljb25uZWN0aW9uOjE=']
         );
 
         $expected = $this->getExpectedConnection(['C', 'D'], false, true);
@@ -76,7 +76,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArray'],
             $this->letters,
-            ['first' => 10, 'after' => 'YXJyYXljb25uZWN0aW9uOjE']
+            ['first' => 10, 'after' => 'YXJyYXljb25uZWN0aW9uOjE=']
         );
 
         $expected = $this->getExpectedConnection(['C', 'D', 'E'], false, false);
@@ -88,7 +88,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArray'],
             $this->letters,
-            ['last' => 2, 'before' => 'YXJyYXljb25uZWN0aW9uOjM']
+            ['last' => 2, 'before' => 'YXJyYXljb25uZWN0aW9uOjM=']
         );
 
         $expected = $this->getExpectedConnection(['B', 'C'], true, false);
@@ -100,7 +100,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArray'],
             $this->letters,
-            ['last' => 10, 'before' => 'YXJyYXljb25uZWN0aW9uOjM']
+            ['last' => 10, 'before' => 'YXJyYXljb25uZWN0aW9uOjM=']
         );
 
         $expected = $this->getExpectedConnection(['A', 'B', 'C'], false, false);
@@ -112,7 +112,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArray'],
             $this->letters,
-            ['first' => 2, 'after' => 'YXJyYXljb25uZWN0aW9uOjA', 'before' => 'YXJyYXljb25uZWN0aW9uOjQ']
+            ['first' => 2, 'after' => 'YXJyYXljb25uZWN0aW9uOjA=', 'before' => 'YXJyYXljb25uZWN0aW9uOjQ=']
         );
 
         $expected = $this->getExpectedConnection(['B', 'C'], false, true);
@@ -124,7 +124,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArray'],
             $this->letters,
-            ['first' => 4, 'after' => 'YXJyYXljb25uZWN0aW9uOjA', 'before' => 'YXJyYXljb25uZWN0aW9uOjQ']
+            ['first' => 4, 'after' => 'YXJyYXljb25uZWN0aW9uOjA=', 'before' => 'YXJyYXljb25uZWN0aW9uOjQ=']
         );
 
         $expected = $this->getExpectedConnection(['B', 'C', 'D'], false, false);
@@ -136,7 +136,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArray'],
             $this->letters,
-            ['first' => 3, 'after' => 'YXJyYXljb25uZWN0aW9uOjA', 'before' => 'YXJyYXljb25uZWN0aW9uOjQ']
+            ['first' => 3, 'after' => 'YXJyYXljb25uZWN0aW9uOjA=', 'before' => 'YXJyYXljb25uZWN0aW9uOjQ=']
         );
 
         $expected = $this->getExpectedConnection(['B', 'C', 'D'], false, false);
@@ -148,7 +148,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArray'],
             $this->letters,
-            ['last' => 2, 'after' => 'YXJyYXljb25uZWN0aW9uOjA', 'before' => 'YXJyYXljb25uZWN0aW9uOjQ']
+            ['last' => 2, 'after' => 'YXJyYXljb25uZWN0aW9uOjA=', 'before' => 'YXJyYXljb25uZWN0aW9uOjQ=']
         );
 
         $expected = $this->getExpectedConnection(['C', 'D'], true, false);
@@ -160,7 +160,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArray'],
             $this->letters,
-            ['last' => 4, 'after' => 'YXJyYXljb25uZWN0aW9uOjA', 'before' => 'YXJyYXljb25uZWN0aW9uOjQ']
+            ['last' => 4, 'after' => 'YXJyYXljb25uZWN0aW9uOjA=', 'before' => 'YXJyYXljb25uZWN0aW9uOjQ=']
         );
 
         $expected = $this->getExpectedConnection(['B', 'C', 'D'], false, false);
@@ -172,7 +172,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArray'],
             $this->letters,
-            ['last' => 3, 'after' => 'YXJyYXljb25uZWN0aW9uOjA', 'before' => 'YXJyYXljb25uZWN0aW9uOjQ']
+            ['last' => 3, 'after' => 'YXJyYXljb25uZWN0aW9uOjA=', 'before' => 'YXJyYXljb25uZWN0aW9uOjQ=']
         );
 
         $expected = $this->getExpectedConnection(['B', 'C', 'D'], false, false);
@@ -243,7 +243,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArray'],
             $this->letters,
-            ['before' => 'YXJyYXljb25uZWN0aW9uOjI', 'after' => 'YXJyYXljb25uZWN0aW9uOjQ=']
+            ['before' => 'YXJyYXljb25uZWN0aW9uOjI=', 'after' => 'YXJyYXljb25uZWN0aW9uOjQ=']
         );
 
         $expected = $this->getExpectedConnection([], false, false);
@@ -258,7 +258,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArraySlice'],
             \array_slice($this->letters, 1, 2), // equals to letters.slice(1,3) in JS
-            ['first' => 2, 'after' => 'YXJyYXljb25uZWN0aW9uOjA'],
+            ['first' => 2, 'after' => 'YXJyYXljb25uZWN0aW9uOjA='],
             ['sliceStart' => 1, 'arrayLength' => 5]
         );
 
@@ -274,7 +274,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArraySlice'],
             \array_slice($this->letters, 0, 3), // equals to letters.slice(0,3) in JS
-            ['first' => 2, 'after' => 'YXJyYXljb25uZWN0aW9uOjA'],
+            ['first' => 2, 'after' => 'YXJyYXljb25uZWN0aW9uOjA='],
             ['sliceStart' => 0, 'arrayLength' => 5]
         );
 
@@ -290,7 +290,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArraySlice'],
             \array_slice($this->letters, 2, 2), // equals to letters.slice(2,4) in JS
-            ['first' => 1, 'after' => 'YXJyYXljb25uZWN0aW9uOjE'],
+            ['first' => 1, 'after' => 'YXJyYXljb25uZWN0aW9uOjE='],
             ['sliceStart' => 2, 'arrayLength' => 5]
         );
 
@@ -306,7 +306,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArraySlice'],
             \array_slice($this->letters, 1, 3), // equals to letters.slice(1,4) in JS
-            ['first' => 1, 'after' => 'YXJyYXljb25uZWN0aW9uOjE'],
+            ['first' => 1, 'after' => 'YXJyYXljb25uZWN0aW9uOjE='],
             ['sliceStart' => 1, 'arrayLength' => 5]
         );
 
@@ -322,7 +322,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArraySlice'],
             \array_slice($this->letters, 3, 2), // equals to letters.slice(3,5) in JS
-            ['first' => 3, 'after' => 'YXJyYXljb25uZWN0aW9uOjE'],
+            ['first' => 3, 'after' => 'YXJyYXljb25uZWN0aW9uOjE='],
             ['sliceStart' => 3, 'arrayLength' => 5]
         );
 
@@ -338,7 +338,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArraySlice'],
             \array_slice($this->letters, 2, 2), // equals to letters.slice(2,4) in JS
-            ['first' => 3, 'after' => 'YXJyYXljb25uZWN0aW9uOjE'],
+            ['first' => 3, 'after' => 'YXJyYXljb25uZWN0aW9uOjE='],
             ['sliceStart' => 2, 'arrayLength' => 5]
         );
 
@@ -354,7 +354,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $actual = \call_user_func([static::getBuilder(), 'connectionFromArraySlice'],
             \array_slice($this->letters, 3, 1), // equals to letters.slice(3,4) in JS
-            ['first' => 3, 'after' => 'YXJyYXljb25uZWN0aW9uOjE'],
+            ['first' => 3, 'after' => 'YXJyYXljb25uZWN0aW9uOjE='],
             ['sliceStart' => 3, 'arrayLength' => 5]
         );
 
@@ -367,7 +367,7 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
     {
         $letterCursor = \call_user_func([static::getBuilder(), 'cursorForObjectInConnection'], $this->letters, 'B');
 
-        $this->assertSame('YXJyYXljb25uZWN0aW9uOjE', $letterCursor);
+        $this->assertSame('YXJyYXljb25uZWN0aW9uOjE=', $letterCursor);
     }
 
     public function testReturnsAnEdgesCursorGivenAnArrayAndANonMemberObject(): void
@@ -424,8 +424,8 @@ class ConnectionBuilderTest extends AbstractConnectionBuilderTest
         $this->assertInstanceOf(fixtures\CustomEdge::class, $actualEdges[0]);
         $this->assertInstanceOf(fixtures\CustomEdge::class, $actualEdges[1]);
 
-        $this->assertEquals($actualEdges[0]->getCursor(), 'YXJyYXljb25uZWN0aW9uOjA');
-        $this->assertEquals($actualEdges[1]->getCursor(), 'YXJyYXljb25uZWN0aW9uOjE');
+        $this->assertEquals($actualEdges[0]->getCursor(), 'YXJyYXljb25uZWN0aW9uOjA=');
+        $this->assertEquals($actualEdges[1]->getCursor(), 'YXJyYXljb25uZWN0aW9uOjE=');
 
         $this->assertEquals($actualEdges[0]->customProperty, 'edge0');
         $this->assertEquals($actualEdges[1]->customProperty, 'edge1');

--- a/tests/Relay/Connection/Cursor/Base64CursorEncoderTest.php
+++ b/tests/Relay/Connection/Cursor/Base64CursorEncoderTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Relay\Connection\Cursor;
+
+use Overblog\GraphQLBundle\Relay\Connection\Cursor\Base64CursorEncoder;
+use PHPUnit\Framework\TestCase;
+
+final class Base64CursorEncoderTest extends TestCase
+{
+    /**
+     * @var Base64CursorEncoder
+     */
+    private $encoder;
+
+    protected function setUp(): void
+    {
+        $this->encoder = new Base64CursorEncoder();
+    }
+
+    /**
+     * @dataProvider valuesDataProvider
+     */
+    public function testEncode(string $decodedValue, string $value): void
+    {
+        $this->assertSame($value, $this->encoder->encode($decodedValue));
+    }
+
+    /**
+     * @dataProvider valuesDataProvider
+     */
+    public function testDecode(string $decodedValue, string $value): void
+    {
+        $this->assertSame($decodedValue, $this->encoder->decode($value));
+    }
+
+    public function valuesDataProvider(): \Generator
+    {
+        yield [
+            '000000',
+            'MDAwMDAw',
+        ];
+
+        yield [
+            "\0\0\0\0",
+            'AAAAAA',
+        ];
+
+        yield [
+            "\xff",
+            '_w',
+        ];
+
+        yield [
+            "\xff\xff",
+            '__8',
+        ];
+
+        yield [
+            "\xff\xff\xff",
+            '____',
+        ];
+
+        yield [
+            "\xff\xff\xff\xff",
+            '_____w',
+        ];
+
+        yield [
+            "\xfb",
+            '-w',
+        ];
+
+        yield [
+            '',
+            '',
+        ];
+    }
+}

--- a/tests/Relay/Connection/Cursor/Base64UrlSafeCursorEncoderTest.php
+++ b/tests/Relay/Connection/Cursor/Base64UrlSafeCursorEncoderTest.php
@@ -4,19 +4,19 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Tests\Relay\Connection\Cursor;
 
-use Overblog\GraphQLBundle\Relay\Connection\Cursor\Base64CursorEncoder;
+use Overblog\GraphQLBundle\Relay\Connection\Cursor\Base64UrlSafeCursorEncoder;
 use PHPUnit\Framework\TestCase;
 
-final class Base64CursorEncoderTest extends TestCase
+final class Base64UrlSafeCursorEncoderTest extends TestCase
 {
     /**
-     * @var Base64CursorEncoder
+     * @var Base64UrlSafeCursorEncoder
      */
     private $encoder;
 
     protected function setUp(): void
     {
-        $this->encoder = new Base64CursorEncoder();
+        $this->encoder = new Base64UrlSafeCursorEncoder();
     }
 
     /**
@@ -40,49 +40,41 @@ final class Base64CursorEncoderTest extends TestCase
         yield [
             '000000',
             'MDAwMDAw',
-            false,
         ];
 
         yield [
             "\0\0\0\0",
-            'AAAAAA==',
-            false,
+            'AAAAAA',
         ];
 
         yield [
             "\xff",
-            '/w==',
-            false,
+            '_w',
         ];
 
         yield [
             "\xff\xff",
-            '//8=',
-            false,
+            '__8',
         ];
 
         yield [
             "\xff\xff\xff",
-            '////',
-            false,
+            '____',
         ];
 
         yield [
             "\xff\xff\xff\xff",
-            '/////w==',
-            false,
+            '_____w',
         ];
 
         yield [
             "\xfb",
-            '+w==',
-            false,
+            '-w',
         ];
 
         yield [
             '',
             '',
-            false,
         ];
     }
 }

--- a/tests/Relay/Connection/Cursor/PlainCursorEncoderTest.php
+++ b/tests/Relay/Connection/Cursor/PlainCursorEncoderTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Relay\Connection\Cursor;
+
+use Overblog\GraphQLBundle\Relay\Connection\Cursor\PlainCursorEncoder;
+use PHPUnit\Framework\TestCase;
+
+final class PlainCursorEncoderTest extends TestCase
+{
+    /**
+     * @var PlainCursorEncoder
+     */
+    private $encoder;
+
+    protected function setUp(): void
+    {
+        $this->encoder = new PlainCursorEncoder();
+    }
+
+    public function testEncode(): void
+    {
+        $this->assertSame('foo', $this->encoder->encode('foo'));
+    }
+
+    public function testDecode(): void
+    {
+        $this->assertSame('foo', $this->encoder->decode('foo'));
+    }
+}

--- a/tests/Util/Base64EncoderTest.php
+++ b/tests/Util/Base64EncoderTest.php
@@ -12,17 +12,17 @@ final class Base64EncoderTest extends TestCase
     /**
      * @dataProvider valuesDataProvider
      */
-    public function testEncodeUrlSafe(string $value, string $encodedValue, bool $usePadding): void
+    public function testEncode(string $value, string $encodedValue): void
     {
-        $this->assertSame($encodedValue, Base64Encoder::encodeUrlSafe($value, $usePadding));
+        $this->assertSame($encodedValue, Base64Encoder::encode($value));
     }
 
     /**
      * @dataProvider valuesDataProvider
      */
-    public function testDecodeUrlSafe(string $value, string $encodedValue): void
+    public function testDecode(string $value, string $encodedValue): void
     {
-        $this->assertSame($value, Base64Encoder::decodeUrlSafe($encodedValue));
+        $this->assertSame($value, Base64Encoder::decode($encodedValue));
     }
 
     public function valuesDataProvider(): \Generator
@@ -35,37 +35,37 @@ final class Base64EncoderTest extends TestCase
 
         yield [
             "\0\0\0\0",
-            'AAAAAA',
+            'AAAAAA==',
             false,
         ];
 
         yield [
             "\xff",
-            '_w',
+            '/w==',
             false,
         ];
 
         yield [
             "\xff\xff",
-            '__8',
+            '//8=',
             false,
         ];
 
         yield [
             "\xff\xff\xff",
-            '____',
+            '////',
             false,
         ];
 
         yield [
             "\xff\xff\xff\xff",
-            '_____w',
+            '/////w==',
             false,
         ];
 
         yield [
             "\xfb",
-            '-w',
+            '+w==',
             false,
         ];
 
@@ -73,50 +73,14 @@ final class Base64EncoderTest extends TestCase
             '',
             '',
             false,
-        ];
-
-        yield [
-            'f',
-            'Zg==',
-            true,
-        ];
-
-        yield [
-            'fo',
-            'Zm8=',
-            true,
-        ];
-
-        yield [
-            'foo',
-            'Zm9v',
-            true,
-        ];
-
-        yield [
-            'foob',
-            'Zm9vYg==',
-            true,
-        ];
-
-        yield [
-            'fooba',
-            'Zm9vYmE=',
-            true,
-        ];
-
-        yield [
-            'foobar',
-            'Zm9vYmFy',
-            true,
         ];
     }
 
-    public function testDecodeUrlSafeThrowsOnInvalidValue(): void
+    public function testDecodeThrowsOnInvalidValue(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The "cxr0fdsezrewklerewxoz423ocfsa3bw432yjydsa9lhdsalw" value failed to be decoded from base64 format.');
 
-        Base64Encoder::decodeUrlSafe('cxr0fdsezrewklerewxoz423ocfsa3bw432yjydsa9lhdsalw');
+        Base64Encoder::decode('cxr0fdsezrewklerewxoz423ocfsa3bw432yjydsa9lhdsalw');
     }
 }

--- a/tests/Util/Base64EncoderTest.php
+++ b/tests/Util/Base64EncoderTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Util;
+
+use Overblog\GraphQLBundle\Util\Base64Encoder;
+use PHPUnit\Framework\TestCase;
+
+final class Base64EncoderTest extends TestCase
+{
+    /**
+     * @dataProvider valuesDataProvider
+     */
+    public function testEncodeUrlSafe(string $value, string $encodedValue, bool $usePadding): void
+    {
+        $this->assertSame($encodedValue, Base64Encoder::encodeUrlSafe($value, $usePadding));
+    }
+
+    /**
+     * @dataProvider valuesDataProvider
+     */
+    public function testDecodeUrlSafe(string $value, string $encodedValue): void
+    {
+        $this->assertSame($value, Base64Encoder::decodeUrlSafe($encodedValue));
+    }
+
+    public function valuesDataProvider(): \Generator
+    {
+        yield [
+            '000000',
+            'MDAwMDAw',
+            false,
+        ];
+
+        yield [
+            "\0\0\0\0",
+            'AAAAAA',
+            false,
+        ];
+
+        yield [
+            "\xff",
+            '_w',
+            false,
+        ];
+
+        yield [
+            "\xff\xff",
+            '__8',
+            false,
+        ];
+
+        yield [
+            "\xff\xff\xff",
+            '____',
+            false,
+        ];
+
+        yield [
+            "\xff\xff\xff\xff",
+            '_____w',
+            false,
+        ];
+
+        yield [
+            "\xfb",
+            '-w',
+            false,
+        ];
+
+        yield [
+            '',
+            '',
+            false,
+        ];
+
+        yield [
+            'f',
+            'Zg==',
+            true,
+        ];
+
+        yield [
+            'fo',
+            'Zm8=',
+            true,
+        ];
+
+        yield [
+            'foo',
+            'Zm9v',
+            true,
+        ];
+
+        yield [
+            'foob',
+            'Zm9vYg==',
+            true,
+        ];
+
+        yield [
+            'fooba',
+            'Zm9vYmE=',
+            true,
+        ];
+
+        yield [
+            'foobar',
+            'Zm9vYmFy',
+            true,
+        ];
+    }
+
+    public function testDecodeUrlSafeThrowsOnInvalidValue(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "cxr0fdsezrewklerewxoz423ocfsa3bw432yjydsa9lhdsalw" value failed to be decoded from base64 format.');
+
+        Base64Encoder::decodeUrlSafe('cxr0fdsezrewklerewxoz423ocfsa3bw432yjydsa9lhdsalw');
+    }
+}

--- a/tests/Util/Base64UrlSafeEncoderTest.php
+++ b/tests/Util/Base64UrlSafeEncoderTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Util;
+
+use Overblog\GraphQLBundle\Util\Base64Encoder;
+use PHPUnit\Framework\TestCase;
+
+final class Base64UrlSafeEncoderTest extends TestCase
+{
+    /**
+     * @dataProvider urlSafeValuesDataProvider
+     */
+    public function testEncodeUrlSafe(string $value, string $encodedValue, bool $usePadding): void
+    {
+        $this->assertSame($encodedValue, Base64Encoder::encodeUrlSafe($value, $usePadding));
+    }
+
+    /**
+     * @dataProvider urlSafeValuesDataProvider
+     */
+    public function testDecodeUrlSafe(string $value, string $encodedValue): void
+    {
+        $this->assertSame($value, Base64Encoder::decodeUrlSafe($encodedValue));
+    }
+
+    public function urlSafeValuesDataProvider(): \Generator
+    {
+        yield [
+            '000000',
+            'MDAwMDAw',
+            false,
+        ];
+
+        yield [
+            "\0\0\0\0",
+            'AAAAAA',
+            false,
+        ];
+
+        yield [
+            "\xff",
+            '_w',
+            false,
+        ];
+
+        yield [
+            "\xff\xff",
+            '__8',
+            false,
+        ];
+
+        yield [
+            "\xff\xff\xff",
+            '____',
+            false,
+        ];
+
+        yield [
+            "\xff\xff\xff\xff",
+            '_____w',
+            false,
+        ];
+
+        yield [
+            "\xfb",
+            '-w',
+            false,
+        ];
+
+        yield [
+            '',
+            '',
+            false,
+        ];
+
+        yield [
+            'f',
+            'Zg==',
+            true,
+        ];
+
+        yield [
+            'fo',
+            'Zm8=',
+            true,
+        ];
+
+        yield [
+            'foo',
+            'Zm9v',
+            true,
+        ];
+
+        yield [
+            'foob',
+            'Zm9vYg==',
+            true,
+        ];
+
+        yield [
+            'fooba',
+            'Zm9vYmE=',
+            true,
+        ];
+
+        yield [
+            'foobar',
+            'Zm9vYmFy',
+            true,
+        ];
+    }
+
+    public function testDecodeUrlSafeWithWronglyPaddedString(): void
+    {
+        $this->assertSame('fooo', Base64Encoder::decodeUrlSafe('Zm9vbw='));
+    }
+
+    public function testDecodeUrlSafeThrowsOnInvalidValue(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "cxr0fdsezrewklerewxoz423ocfsa3bw432yjydsa9lhdsalw" value failed to be decoded from base64 format.');
+
+        Base64Encoder::decodeUrlSafe('cxr0fdsezrewklerewxoz423ocfsa3bw432yjydsa9lhdsalw');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| License       | MIT

Sometimes it's useful to change the way the cursor of the edges of a connection are encoded/decoded, e.g. in the tests or if base64 is not the format users want to use for their applications. With this PR the `ConnectionBuilder` now accepts a new parameter that allows such customization. I chose to put the parameter as first rather that as the last (sadly breaking BC) because I think that even if rare it's probably more common the willing of changing how the cursor is encoded instead of how the edges or the connection itself are built, but of course this can be re-evaluated.