### PR TITLE
Fix shorthand field definitions feature

### DIFF
--- a/src/Definition/ConfigProcessor/AclConfigProcessor.php
+++ b/src/Definition/ConfigProcessor/AclConfigProcessor.php
@@ -27,7 +27,7 @@ final class AclConfigProcessor implements ConfigProcessorInterface
             throw new UserWarning('Access denied to this field.');
         };
         foreach ($fields as &$field) {
-            if (isset($field['access']) && true !== $field['access']) {
+            if (\is_array($field) && isset($field['access']) && true !== $field['access']) {
                 $accessChecker = $field['access'];
                 if (false === $accessChecker) {
                     $field['resolve'] = $deniedAccess;

--- a/src/Definition/ConfigProcessor/PublicFieldsFilterConfigProcessor.php
+++ b/src/Definition/ConfigProcessor/PublicFieldsFilterConfigProcessor.php
@@ -13,7 +13,7 @@ final class PublicFieldsFilterConfigProcessor implements ConfigProcessorInterfac
             function ($field, $fieldName) {
                 $exposed = true;
 
-                if (isset($field['public']) && \is_callable($field['public'])) {
+                if (\is_array($field) && isset($field['public']) && \is_callable($field['public'])) {
                     $exposed = (bool) \call_user_func($field['public'], $fieldName);
                 }
 

--- a/src/Definition/ConfigProcessor/WrapArgumentConfigProcessor.php
+++ b/src/Definition/ConfigProcessor/WrapArgumentConfigProcessor.php
@@ -34,7 +34,7 @@ final class WrapArgumentConfigProcessor implements ConfigProcessorInterface
     private static function wrapFieldsArgument(array $fields)
     {
         foreach ($fields as &$field) {
-            if (isset($field['resolve']) && \is_callable($field['resolve'])) {
+            if (\is_array($field) && isset($field['resolve']) && \is_callable($field['resolve'])) {
                 $field['resolve'] = Resolver::wrapArgs($field['resolve']);
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Fix the bug preventing use of shorthand field definitions described [here](https://webonyx.github.io/graphql-php/type-system/object-types/) (section **Shorthand field definitions**)
