### PR TITLE
Changes setup of expression language functions to fix issue #588

### DIFF
--- a/src/ExpressionLanguage/ExpressionFunction/DependencyInjection/Parameter.php
+++ b/src/ExpressionLanguage/ExpressionFunction/DependencyInjection/Parameter.php
@@ -5,19 +5,18 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\DependencyInjection;
 
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 final class Parameter extends ExpressionFunction
 {
-    public function __construct(ParameterBagInterface $parameterBag, $name = 'parameter')
+    public function __construct($name = 'parameter')
     {
         parent::__construct(
             $name,
-            function (string $value) {
+            static function (string $value) {
                 return "\$globalVariable->get('container')->getParameter($value)";
             },
-            function ($arguments, $paramName) use ($parameterBag) {
-                return $parameterBag->get($paramName);
+            static function ($arguments, $paramName) {
+                return $arguments['globalVariable']->get('container')->getParameter($paramName);
             }
         );
     }

--- a/src/ExpressionLanguage/ExpressionFunction/DependencyInjection/Service.php
+++ b/src/ExpressionLanguage/ExpressionFunction/DependencyInjection/Service.php
@@ -5,19 +5,18 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\DependencyInjection;
 
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 final class Service extends ExpressionFunction
 {
-    public function __construct(ContainerInterface $container, $name = 'service')
+    public function __construct($name = 'service')
     {
         parent::__construct(
             $name,
-            function (string $serviceId): string {
+            static function (string $serviceId): string {
                 return "\$globalVariable->get('container')->get($serviceId)";
             },
-            function ($arguments, $serviceId) use ($container): ?object {
-                return $container->get($serviceId);
+            static function ($arguments, $serviceId): ?object {
+                return $arguments['globalVariable']->get('container')->get($serviceId);
             }
         );
     }

--- a/src/ExpressionLanguage/ExpressionFunction/GraphQL/Arguments.php
+++ b/src/ExpressionLanguage/ExpressionFunction/GraphQL/Arguments.php
@@ -5,19 +5,18 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\GraphQL;
 
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction;
-use Overblog\GraphQLBundle\Transformer\ArgumentsTransformer;
 
 final class Arguments extends ExpressionFunction
 {
-    public function __construct(ArgumentsTransformer $transformer)
+    public function __construct()
     {
         parent::__construct(
             'arguments',
-            function ($mapping, $data) {
+            static function ($mapping, $data) {
                 return "\$globalVariable->get('container')->get('overblog_graphql.arguments_transformer')->getArguments($mapping, $data, \$info)";
             },
-            function ($arguments, $mapping, $data) use ($transformer) {
-                return $transformer->getArguments($mapping, $data, $arguments['info']);
+            static function ($arguments, $mapping, $data) {
+                return $arguments['globalVariable']->get('container')->get('overblog_graphql.arguments_transformer')->getArguments($mapping, $data, $arguments['info']);
             }
         );
     }

--- a/src/ExpressionLanguage/ExpressionFunction/Security/GetUser.php
+++ b/src/ExpressionLanguage/ExpressionFunction/Security/GetUser.php
@@ -5,19 +5,18 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\Security;
 
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction;
-use Overblog\GraphQLBundle\Security\Security;
 
 final class GetUser extends ExpressionFunction
 {
-    public function __construct(Security $security)
+    public function __construct()
     {
         parent::__construct(
             'getUser',
             static function (): string {
                 return '$globalVariable->get(\'security\')->getUser()';
             },
-            static function () use ($security) {
-                return $security->getUser();
+            static function ($arguments) {
+                return $arguments['globalVariable']->get('security')->getUser();
             }
         );
     }

--- a/src/ExpressionLanguage/ExpressionFunction/Security/HasAnyPermission.php
+++ b/src/ExpressionLanguage/ExpressionFunction/Security/HasAnyPermission.php
@@ -5,19 +5,18 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\Security;
 
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction;
-use Overblog\GraphQLBundle\Security\Security;
 
 final class HasAnyPermission extends ExpressionFunction
 {
-    public function __construct(Security $security)
+    public function __construct()
     {
         parent::__construct(
             'hasAnyPermission',
             static function ($object, $permissions): string {
                 return \sprintf('$globalVariable->get(\'security\')->hasAnyPermission(%s, %s)', $object, $permissions);
             },
-            function ($_, $object, $permissions) use ($security): bool {
-                return $security->hasAnyPermission($object, $permissions);
+            static function ($arguments, $object, $permissions): bool {
+                return $arguments['globalVariable']->get('security')->hasAnyPermission($object, $permissions);
             }
         );
     }

--- a/src/ExpressionLanguage/ExpressionFunction/Security/HasAnyRole.php
+++ b/src/ExpressionLanguage/ExpressionFunction/Security/HasAnyRole.php
@@ -5,19 +5,18 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\Security;
 
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction;
-use Overblog\GraphQLBundle\Security\Security;
 
 final class HasAnyRole extends ExpressionFunction
 {
-    public function __construct(Security $security)
+    public function __construct()
     {
         parent::__construct(
             'hasAnyRole',
             static function ($roles): string {
                 return \sprintf('$globalVariable->get(\'security\')->hasAnyRole(%s)', $roles);
             },
-            static function ($_, $roles) use ($security): bool {
-                return $security->hasAnyRole($roles);
+            static function ($arguments, $roles): bool {
+                return $arguments['globalVariable']->get('security')->hasAnyRole($roles);
             }
         );
     }

--- a/src/ExpressionLanguage/ExpressionFunction/Security/HasPermission.php
+++ b/src/ExpressionLanguage/ExpressionFunction/Security/HasPermission.php
@@ -5,19 +5,18 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\Security;
 
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction;
-use Overblog\GraphQLBundle\Security\Security;
 
 final class HasPermission extends ExpressionFunction
 {
-    public function __construct(Security $security)
+    public function __construct()
     {
         parent::__construct(
             'hasPermission',
             static function ($object, $permission): string {
                 return \sprintf('$globalVariable->get(\'security\')->hasPermission(%s, %s)', $object, $permission);
             },
-            static function ($_, $object, $permission) use ($security): bool {
-                return $security->hasPermission($object, $permission);
+            static function ($arguments, $object, $permission): bool {
+                return $arguments['globalVariable']->get('security')->hasPermission($object, $permission);
             }
         );
     }

--- a/src/ExpressionLanguage/ExpressionFunction/Security/HasRole.php
+++ b/src/ExpressionLanguage/ExpressionFunction/Security/HasRole.php
@@ -5,19 +5,18 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\Security;
 
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction;
-use Overblog\GraphQLBundle\Security\Security;
 
 final class HasRole extends ExpressionFunction
 {
-    public function __construct(Security $security)
+    public function __construct()
     {
         parent::__construct(
             'hasRole',
             static function ($role): string {
                 return \sprintf('$globalVariable->get(\'security\')->hasRole(%s)', $role);
             },
-            static function ($_, $role) use ($security): bool {
-                return $security->hasRole($role);
+            static function ($arguments, $role): bool {
+                return $arguments['globalVariable']->get('security')->hasRole($role);
             }
         );
     }

--- a/src/ExpressionLanguage/ExpressionFunction/Security/IsAnonymous.php
+++ b/src/ExpressionLanguage/ExpressionFunction/Security/IsAnonymous.php
@@ -5,19 +5,18 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\Security;
 
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction;
-use Overblog\GraphQLBundle\Security\Security;
 
 final class IsAnonymous extends ExpressionFunction
 {
-    public function __construct(Security $security)
+    public function __construct()
     {
         parent::__construct(
             'isAnonymous',
             static function (): string {
                 return '$globalVariable->get(\'security\')->isAnonymous()';
             },
-            static function () use ($security): bool {
-                return $security->isAnonymous();
+            static function ($arguments): bool {
+                return $arguments['globalVariable']->get('security')->isAnonymous();
             }
         );
     }

--- a/src/ExpressionLanguage/ExpressionFunction/Security/IsAuthenticated.php
+++ b/src/ExpressionLanguage/ExpressionFunction/Security/IsAuthenticated.php
@@ -5,19 +5,18 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\Security;
 
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction;
-use Overblog\GraphQLBundle\Security\Security;
 
 final class IsAuthenticated extends ExpressionFunction
 {
-    public function __construct(Security $security)
+    public function __construct()
     {
         parent::__construct(
             'isAuthenticated',
             static function (): string {
                 return '$globalVariable->get(\'security\')->isAuthenticated()';
             },
-            static function () use ($security): bool {
-                return $security->isAuthenticated();
+            static function ($arguments): bool {
+                return $arguments['globalVariable']->get('security')->isAuthenticated();
             }
         );
     }

--- a/src/ExpressionLanguage/ExpressionFunction/Security/IsFullyAuthenticated.php
+++ b/src/ExpressionLanguage/ExpressionFunction/Security/IsFullyAuthenticated.php
@@ -5,19 +5,18 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\Security;
 
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction;
-use Overblog\GraphQLBundle\Security\Security;
 
 final class IsFullyAuthenticated extends ExpressionFunction
 {
-    public function __construct(Security $security)
+    public function __construct()
     {
         parent::__construct(
             'isFullyAuthenticated',
             static function (): string {
                 return '$globalVariable->get(\'security\')->isFullyAuthenticated()';
             },
-            static function () use ($security): bool {
-                return $security->isFullyAuthenticated();
+            static function ($arguments): bool {
+                return $arguments['globalVariable']->get('security')->isFullyAuthenticated();
             }
         );
     }

--- a/src/ExpressionLanguage/ExpressionFunction/Security/IsGranted.php
+++ b/src/ExpressionLanguage/ExpressionFunction/Security/IsGranted.php
@@ -5,19 +5,18 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\Security;
 
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction;
-use Overblog\GraphQLBundle\Security\Security;
 
 final class IsGranted extends ExpressionFunction
 {
-    public function __construct(Security $security)
+    public function __construct()
     {
         parent::__construct(
             'isGranted',
             static function ($attributes, $object = 'null'): string {
                 return \sprintf('$globalVariable->get(\'security\')->isGranted(%s, %s)', $attributes, $object);
             },
-            static function ($_, $attributes, $object = null) use ($security): bool {
-                return $security->isGranted($attributes, $object);
+            static function ($arguments, $attributes, $object = null): bool {
+                return $arguments['globalVariable']->get('security')->isGranted($attributes, $object);
             }
         );
     }

--- a/src/ExpressionLanguage/ExpressionFunction/Security/IsRememberMe.php
+++ b/src/ExpressionLanguage/ExpressionFunction/Security/IsRememberMe.php
@@ -5,19 +5,18 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\Security;
 
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction;
-use Overblog\GraphQLBundle\Security\Security;
 
 final class IsRememberMe extends ExpressionFunction
 {
-    public function __construct(Security $security)
+    public function __construct()
     {
         parent::__construct(
             'isRememberMe',
             static function (): string {
                 return '$globalVariable->get(\'security\')->isRememberMe()';
             },
-            static function () use ($security): bool {
-                return $security->isRememberMe();
+            static function ($arguments): bool {
+                return $arguments['globalVariable']->get('security')->isRememberMe();
             }
         );
     }

--- a/src/Validator/Constraints/ExpressionValidator.php
+++ b/src/Validator/Constraints/ExpressionValidator.php
@@ -21,7 +21,7 @@ class ExpressionValidator extends \Symfony\Component\Validator\Constraints\Expre
     public function __construct(ExpressionLanguage $expressionLanguage, GlobalVariables $globalVariables)
     {
         $this->expressionLanguage = $expressionLanguage;
-        $this->globalVariables    = $globalVariables;
+        $this->globalVariables = $globalVariables;
         if (Kernel::VERSION_ID >= 40400) {
             parent::__construct($expressionLanguage);
         } else {
@@ -35,11 +35,11 @@ class ExpressionValidator extends \Symfony\Component\Validator\Constraints\Expre
     public function validate($value, Constraint $constraint): void
     {
         if (!$constraint instanceof Expression) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__ . '\Expression');
+            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Expression');
         }
 
-        $variables                   = $constraint->values;
-        $variables['value']          = $value;
+        $variables = $constraint->values;
+        $variables['value'] = $value;
         $variables['globalVariable'] = $this->globalVariables;
 
         $object = $this->context->getObject();
@@ -48,9 +48,9 @@ class ExpressionValidator extends \Symfony\Component\Validator\Constraints\Expre
 
         if ($object instanceof ValidationNode) {
             $variables['parentValue'] = $object->getResolverArg('value');
-            $variables['context']     = $object->getResolverArg('context');
-            $variables['args']        = $object->getResolverArg('args');
-            $variables['info']        = $object->getResolverArg('info');
+            $variables['context'] = $object->getResolverArg('context');
+            $variables['args'] = $object->getResolverArg('args');
+            $variables['info'] = $object->getResolverArg('info');
         }
 
         if (!$this->expressionLanguage->evaluate($constraint->expression, $variables)) {

--- a/src/Validator/Constraints/ExpressionValidator.php
+++ b/src/Validator/Constraints/ExpressionValidator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Validator\Constraints;
 
+use Overblog\GraphQLBundle\Definition\GlobalVariables;
 use Overblog\GraphQLBundle\Validator\ValidationNode;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpKernel\Kernel;
@@ -15,9 +16,12 @@ class ExpressionValidator extends \Symfony\Component\Validator\Constraints\Expre
 {
     private $expressionLanguage;
 
-    public function __construct(ExpressionLanguage $expressionLanguage)
+    private $globalVariables;
+
+    public function __construct(ExpressionLanguage $expressionLanguage, GlobalVariables $globalVariables)
     {
         $this->expressionLanguage = $expressionLanguage;
+        $this->globalVariables    = $globalVariables;
         if (Kernel::VERSION_ID >= 40400) {
             parent::__construct($expressionLanguage);
         } else {
@@ -31,11 +35,12 @@ class ExpressionValidator extends \Symfony\Component\Validator\Constraints\Expre
     public function validate($value, Constraint $constraint): void
     {
         if (!$constraint instanceof Expression) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Expression');
+            throw new UnexpectedTypeException($constraint, __NAMESPACE__ . '\Expression');
         }
 
-        $variables = $constraint->values;
-        $variables['value'] = $value;
+        $variables                   = $constraint->values;
+        $variables['value']          = $value;
+        $variables['globalVariable'] = $this->globalVariables;
 
         $object = $this->context->getObject();
 
@@ -43,16 +48,16 @@ class ExpressionValidator extends \Symfony\Component\Validator\Constraints\Expre
 
         if ($object instanceof ValidationNode) {
             $variables['parentValue'] = $object->getResolverArg('value');
-            $variables['context'] = $object->getResolverArg('context');
-            $variables['args'] = $object->getResolverArg('args');
-            $variables['info'] = $object->getResolverArg('info');
+            $variables['context']     = $object->getResolverArg('context');
+            $variables['args']        = $object->getResolverArg('args');
+            $variables['info']        = $object->getResolverArg('info');
         }
 
         if (!$this->expressionLanguage->evaluate($constraint->expression, $variables)) {
             $this->context->buildViolation($constraint->message)
-                ->setParameter('{{ value }}', $this->formatValue($value, self::OBJECT_TO_STRING))
-                ->setCode(Expression::EXPRESSION_FAILED_ERROR)
-                ->addViolation();
+                          ->setParameter('{{ value }}', $this->formatValue($value, self::OBJECT_TO_STRING))
+                          ->setCode(Expression::EXPRESSION_FAILED_ERROR)
+                          ->addViolation();
         }
     }
 }

--- a/tests/ExpressionLanguage/ExpressionFunction/DependencyInjection/ParameterTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/DependencyInjection/ParameterTest.php
@@ -26,7 +26,7 @@ class ParameterTest extends TestCase
     {
         $globalVariable = new GlobalVariables(['container' => $this->getDIContainerMock([], ['test' => 5])]);
         $globalVariable->get('container');
-        $this->assertSame(5, eval('return ' . $this->expressionLanguage->compile($name . '("test")') . ';'));
+        $this->assertSame(5, eval('return '.$this->expressionLanguage->compile($name.'("test")').';'));
     }
 
     /**
@@ -38,7 +38,7 @@ class ParameterTest extends TestCase
         $globalVariable = new GlobalVariables(['container' => $this->getDIContainerMock([], ['test' => 5])]);
         $this->assertSame(
             5,
-            $this->expressionLanguage->evaluate($name . '("test")', ['globalVariable' => $globalVariable])
+            $this->expressionLanguage->evaluate($name.'("test")', ['globalVariable' => $globalVariable])
         );
     }
 

--- a/tests/ExpressionLanguage/ExpressionFunction/DependencyInjection/ParameterTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/DependencyInjection/ParameterTest.php
@@ -7,18 +7,14 @@ namespace Overblog\GraphQLBundle\Tests\ExpressionLanguage\ExpressionFunction\Dep
 use Overblog\GraphQLBundle\Definition\GlobalVariables;
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\DependencyInjection\Parameter;
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
 class ParameterTest extends TestCase
 {
     protected function getFunctions()
     {
-        $parameterBag = new ParameterBag();
-        $parameterBag->set('test', 5);
-
         return [
-            new Parameter($parameterBag),
-            new Parameter($parameterBag, 'param'),
+            new Parameter(),
+            new Parameter('param'),
         ];
     }
 
@@ -30,7 +26,7 @@ class ParameterTest extends TestCase
     {
         $globalVariable = new GlobalVariables(['container' => $this->getDIContainerMock([], ['test' => 5])]);
         $globalVariable->get('container');
-        $this->assertSame(5, eval('return '.$this->expressionLanguage->compile($name.'("test")').';'));
+        $this->assertSame(5, eval('return ' . $this->expressionLanguage->compile($name . '("test")') . ';'));
     }
 
     /**
@@ -39,7 +35,11 @@ class ParameterTest extends TestCase
      */
     public function testParameterEvaluation($name): void
     {
-        $this->assertSame(5, $this->expressionLanguage->evaluate($name.'("test")'));
+        $globalVariable = new GlobalVariables(['container' => $this->getDIContainerMock([], ['test' => 5])]);
+        $this->assertSame(
+            5,
+            $this->expressionLanguage->evaluate($name . '("test")', ['globalVariable' => $globalVariable])
+        );
     }
 
     public function getNames()

--- a/tests/ExpressionLanguage/ExpressionFunction/DependencyInjection/ServiceTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/DependencyInjection/ServiceTest.php
@@ -10,16 +10,11 @@ use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 
 class ServiceTest extends TestCase
 {
-    private $evaluationObject;
-
     protected function getFunctions()
     {
-        $this->evaluationObject = new \stdClass();
-        $container = $this->getDIContainerMock(['toto' => $this->evaluationObject]);
-
         return [
-            new Service($container),
-            new Service($container, 'serv'),
+            new Service(),
+            new Service('serv'),
         ];
     }
 
@@ -29,10 +24,10 @@ class ServiceTest extends TestCase
      */
     public function testServiceCompilation(string $name): void
     {
-        $object = new \stdClass();
+        $object         = new \stdClass();
         $globalVariable = new GlobalVariables(['container' => $this->getDIContainerMock(['toto' => $object])]);
         $globalVariable->get('container');
-        $this->assertSame($object, eval('return '.$this->expressionLanguage->compile($name.'("toto")').';'));
+        $this->assertSame($object, eval('return ' . $this->expressionLanguage->compile($name . '("toto")') . ';'));
     }
 
     /**
@@ -42,7 +37,12 @@ class ServiceTest extends TestCase
      */
     public function testServiceEvaluation(string $name): void
     {
-        $this->assertSame($this->evaluationObject, $this->expressionLanguage->evaluate($name.'("toto")'));
+        $object         = new \stdClass();
+        $globalVariable = new GlobalVariables(['container' => $this->getDIContainerMock(['toto' => $object])]);
+        $this->assertSame(
+            $object,
+            $this->expressionLanguage->evaluate($name . '("toto")', ['globalVariable' => $globalVariable])
+        );
     }
 
     public function getNames()

--- a/tests/ExpressionLanguage/ExpressionFunction/DependencyInjection/ServiceTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/DependencyInjection/ServiceTest.php
@@ -24,10 +24,10 @@ class ServiceTest extends TestCase
      */
     public function testServiceCompilation(string $name): void
     {
-        $object         = new \stdClass();
+        $object = new \stdClass();
         $globalVariable = new GlobalVariables(['container' => $this->getDIContainerMock(['toto' => $object])]);
         $globalVariable->get('container');
-        $this->assertSame($object, eval('return ' . $this->expressionLanguage->compile($name . '("toto")') . ';'));
+        $this->assertSame($object, eval('return '.$this->expressionLanguage->compile($name.'("toto")').';'));
     }
 
     /**
@@ -37,11 +37,11 @@ class ServiceTest extends TestCase
      */
     public function testServiceEvaluation(string $name): void
     {
-        $object         = new \stdClass();
+        $object = new \stdClass();
         $globalVariable = new GlobalVariables(['container' => $this->getDIContainerMock(['toto' => $object])]);
         $this->assertSame(
             $object,
-            $this->expressionLanguage->evaluate($name . '("toto")', ['globalVariable' => $globalVariable])
+            $this->expressionLanguage->evaluate($name.'("toto")', ['globalVariable' => $globalVariable])
         );
     }
 

--- a/tests/ExpressionLanguage/ExpressionFunction/GraphQL/ArgumentsTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/GraphQL/ArgumentsTest.php
@@ -33,7 +33,7 @@ class ArgumentsTest extends TestCase
 
     public function getResolveInfo($types): ResolveInfo
     {
-        $info         = $this->getMockBuilder(ResolveInfo::class)->disableOriginalConstructor()->getMock();
+        $info = $this->getMockBuilder(ResolveInfo::class)->disableOriginalConstructor()->getMock();
         $info->schema = new Schema(['types' => $types]);
 
         return $info;
@@ -55,17 +55,17 @@ class ArgumentsTest extends TestCase
         $info = $this->getResolveInfo(ArgumentsTransformerTest::getTypes());
 
         $mapping = [
-            'input1'  => 'InputType1',
-            'input2'  => 'InputType2',
-            'enum1'   => 'Enum1',
-            'int1'    => 'Int!',
+            'input1' => 'InputType1',
+            'input2' => 'InputType2',
+            'enum1' => 'Enum1',
+            'int1' => 'Int!',
             'string1' => 'String!',
         ];
-        $data    = [
-            'input1'  => ['field1' => 'hello', 'field2' => 12, 'field3' => true],
-            'input2'  => ['field1' => [['field1' => 'hello1'], ['field1' => 'hello2']], 'field2' => 12],
-            'enum1'   => 2,
-            'int1'    => 14,
+        $data = [
+            'input1' => ['field1' => 'hello', 'field2' => 12, 'field3' => true],
+            'input2' => ['field1' => [['field1' => 'hello1'], ['field1' => 'hello2']], 'field2' => 12],
+            'enum1' => 2,
+            'int1' => 14,
             'string1' => 'test_string',
         ];
 
@@ -73,7 +73,7 @@ class ArgumentsTest extends TestCase
             [
                 'InputType1' => ['type' => 'input', 'class' => 'Overblog\GraphQLBundle\Tests\Transformer\InputType1'],
                 'InputType2' => ['type' => 'input', 'class' => 'Overblog\GraphQLBundle\Tests\Transformer\InputType2'],
-                'Enum1'      => ['type' => 'enum', 'class' => 'Overblog\GraphQLBundle\Tests\Transformer\Enum1'],
+                'Enum1' => ['type' => 'enum', 'class' => 'Overblog\GraphQLBundle\Tests\Transformer\Enum1'],
             ]
         );
 
@@ -87,9 +87,9 @@ class ArgumentsTest extends TestCase
             'arguments(mapping, data, info)',
             [
                 'globalVariable' => $globalVariable,
-                'mapping'        => $mapping,
-                'data'           => $data,
-                'info'           => $info,
+                'mapping' => $mapping,
+                'data' => $data,
+                'info' => $info,
             ]
         );
 
@@ -101,7 +101,7 @@ class ArgumentsTest extends TestCase
         $this->assertEquals($res[4], 'test_string');
 
         $data = [];
-        $res  = $transformer->getInstanceAndValidate('InputType1', $data, $info, 'input1');
+        $res = $transformer->getInstanceAndValidate('InputType1', $data, $info, 'input1');
         $this->assertInstanceOf(InputType1::class, $res);
 
         $res = $transformer->getInstanceAndValidate('InputType2', ['field3' => 'enum1'], $info, 'input2');

--- a/tests/ExpressionLanguage/ExpressionFunction/GraphQL/ArgumentsTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/GraphQL/ArgumentsTest.php
@@ -6,6 +6,7 @@ namespace Overblog\GraphQLBundle\Tests\ExpressionLanguage\ExpressionFunction\Gra
 
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Schema;
+use Overblog\GraphQLBundle\Definition\GlobalVariables;
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\GraphQL\Arguments;
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 use Overblog\GraphQLBundle\Tests\Transformer\ArgumentsTransformerTest;
@@ -17,8 +18,6 @@ use Symfony\Component\Validator\Validator\RecursiveValidator;
 
 class ArgumentsTest extends TestCase
 {
-    private $transformer;
-
     public function setUp(): void
     {
         if (!\class_exists('Symfony\\Component\\Validator\\Validation')) {
@@ -29,18 +28,12 @@ class ArgumentsTest extends TestCase
 
     protected function getFunctions()
     {
-        $this->transformer = $this->getTransformer([
-            'InputType1' => ['type' => 'input', 'class' => 'Overblog\GraphQLBundle\Tests\Transformer\InputType1'],
-            'InputType2' => ['type' => 'input', 'class' => 'Overblog\GraphQLBundle\Tests\Transformer\InputType2'],
-            'Enum1' => ['type' => 'enum', 'class' => 'Overblog\GraphQLBundle\Tests\Transformer\Enum1'],
-        ]);
-
-        return [new Arguments($this->transformer)];
+        return [new Arguments()];
     }
 
     public function getResolveInfo($types): ResolveInfo
     {
-        $info = $this->getMockBuilder(ResolveInfo::class)->disableOriginalConstructor()->getMock();
+        $info         = $this->getMockBuilder(ResolveInfo::class)->disableOriginalConstructor()->getMock();
         $info->schema = new Schema(['types' => $types]);
 
         return $info;
@@ -61,20 +54,44 @@ class ArgumentsTest extends TestCase
     {
         $info = $this->getResolveInfo(ArgumentsTransformerTest::getTypes());
 
-        $mapping = ['input1' => 'InputType1', 'input2' => 'InputType2', 'enum1' => 'Enum1', 'int1' => 'Int!', 'string1' => 'String!'];
-        $data = [
-            'input1' => ['field1' => 'hello', 'field2' => 12, 'field3' => true],
-            'input2' => ['field1' => [['field1' => 'hello1'], ['field1' => 'hello2']], 'field2' => 12],
-            'enum1' => 2,
-            'int1' => 14,
+        $mapping = [
+            'input1'  => 'InputType1',
+            'input2'  => 'InputType2',
+            'enum1'   => 'Enum1',
+            'int1'    => 'Int!',
+            'string1' => 'String!',
+        ];
+        $data    = [
+            'input1'  => ['field1' => 'hello', 'field2' => 12, 'field3' => true],
+            'input2'  => ['field1' => [['field1' => 'hello1'], ['field1' => 'hello2']], 'field2' => 12],
+            'enum1'   => 2,
+            'int1'    => 14,
             'string1' => 'test_string',
         ];
 
-        $res = $this->expressionLanguage->evaluate('arguments(mapping, data, info)', [
-            'mapping' => $mapping,
-            'data' => $data,
-            'info' => $info,
-        ]);
+        $transformer = $this->getTransformer(
+            [
+                'InputType1' => ['type' => 'input', 'class' => 'Overblog\GraphQLBundle\Tests\Transformer\InputType1'],
+                'InputType2' => ['type' => 'input', 'class' => 'Overblog\GraphQLBundle\Tests\Transformer\InputType2'],
+                'Enum1'      => ['type' => 'enum', 'class' => 'Overblog\GraphQLBundle\Tests\Transformer\Enum1'],
+            ]
+        );
+
+        $globalVariable = new GlobalVariables(
+            [
+                'container' => $this->getDIContainerMock(['overblog_graphql.arguments_transformer' => $transformer]),
+            ]
+        );
+
+        $res = $this->expressionLanguage->evaluate(
+            'arguments(mapping, data, info)',
+            [
+                'globalVariable' => $globalVariable,
+                'mapping'        => $mapping,
+                'data'           => $data,
+                'info'           => $info,
+            ]
+        );
 
         $this->assertInstanceOf(InputType1::class, $res[0]);
         $this->assertInstanceOf(InputType2::class, $res[1]);
@@ -84,10 +101,10 @@ class ArgumentsTest extends TestCase
         $this->assertEquals($res[4], 'test_string');
 
         $data = [];
-        $res = $this->transformer->getInstanceAndValidate('InputType1', $data, $info, 'input1');
+        $res  = $transformer->getInstanceAndValidate('InputType1', $data, $info, 'input1');
         $this->assertInstanceOf(InputType1::class, $res);
 
-        $res = $this->transformer->getInstanceAndValidate('InputType2', ['field3' => 'enum1'], $info, 'input2');
+        $res = $transformer->getInstanceAndValidate('InputType2', ['field3' => 'enum1'], $info, 'input2');
         $this->assertInstanceOf(Enum1::class, $res->field3);
         $this->assertEquals('enum1', $res->field3->value);
     }

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/GetUserTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/GetUserTest.php
@@ -23,7 +23,7 @@ class GetUserTest extends TestCase
 
     public function testEvaluator(): void
     {
-        $testUser     = new User('testUser', 'testPassword');
+        $testUser = new User('testUser', 'testPassword');
         $coreSecurity = $this->createMock(CoreSecurity::class);
         $coreSecurity->method('getUser')->willReturn($testUser);
         $globalVariable = new GlobalVariables(['security' => new Security($coreSecurity)]);
@@ -41,7 +41,7 @@ class GetUserTest extends TestCase
 
     public function testGetUserNoToken(): void
     {
-        $tokenStorage   = $this->getMockBuilder(TokenStorageInterface::class)->getMock();
+        $tokenStorage = $this->getMockBuilder(TokenStorageInterface::class)->getMock();
         $globalVariable = new GlobalVariables(
             [
                 'security' => new Security(
@@ -65,8 +65,8 @@ class GetUserTest extends TestCase
      */
     public function testGetUser($user, $expectedUser): void
     {
-        $tokenStorage   = $this->getMockBuilder(TokenStorageInterface::class)->getMock();
-        $token          = $this->getMockBuilder(TokenInterface::class)->getMock();
+        $tokenStorage = $this->getMockBuilder(TokenStorageInterface::class)->getMock();
+        $token = $this->getMockBuilder(TokenInterface::class)->getMock();
         $globalVariable = new GlobalVariables(
             [
                 'security' => new Security(
@@ -105,6 +105,6 @@ class GetUserTest extends TestCase
 
     private function getCompileCode()
     {
-        return 'return ' . $this->expressionLanguage->compile('getUser()') . ';';
+        return 'return '.$this->expressionLanguage->compile('getUser()').';';
     }
 }

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/GetUserTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/GetUserTest.php
@@ -18,17 +18,17 @@ class GetUserTest extends TestCase
 {
     protected function getFunctions()
     {
-        $testUser = new User('testUser', 'testPassword');
-
-        $coreSecurity = $this->createMock(CoreSecurity::class);
-        $coreSecurity->method('getUser')->willReturn($testUser);
-
-        return [new GetUser(new Security($coreSecurity))];
+        return [new GetUser()];
     }
 
     public function testEvaluator(): void
     {
-        $user = $this->expressionLanguage->evaluate('getUser()');
+        $testUser     = new User('testUser', 'testPassword');
+        $coreSecurity = $this->createMock(CoreSecurity::class);
+        $coreSecurity->method('getUser')->willReturn($testUser);
+        $globalVariable = new GlobalVariables(['security' => new Security($coreSecurity)]);
+
+        $user = $this->expressionLanguage->evaluate('getUser()', ['globalVariable' => $globalVariable]);
         $this->assertInstanceOf(UserInterface::class, $user);
     }
 
@@ -41,12 +41,16 @@ class GetUserTest extends TestCase
 
     public function testGetUserNoToken(): void
     {
-        $tokenStorage = $this->getMockBuilder(TokenStorageInterface::class)->getMock();
-        $globalVariable = new GlobalVariables([
-            'security' => new Security(new CoreSecurity(
-                $this->getDIContainerMock(['security.token_storage' => $tokenStorage])
-            )),
-        ]);
+        $tokenStorage   = $this->getMockBuilder(TokenStorageInterface::class)->getMock();
+        $globalVariable = new GlobalVariables(
+            [
+                'security' => new Security(
+                    new CoreSecurity(
+                        $this->getDIContainerMock(['security.token_storage' => $tokenStorage])
+                    )
+                ),
+            ]
+        );
         $globalVariable->get('security');
 
         $this->getDIContainerMock(['security.token_storage' => $tokenStorage]);
@@ -61,13 +65,17 @@ class GetUserTest extends TestCase
      */
     public function testGetUser($user, $expectedUser): void
     {
-        $tokenStorage = $this->getMockBuilder(TokenStorageInterface::class)->getMock();
-        $token = $this->getMockBuilder(TokenInterface::class)->getMock();
-        $globalVariable = new GlobalVariables([
-            'security' => new Security(new CoreSecurity(
-                $this->getDIContainerMock(['security.token_storage' => $tokenStorage])
-            )),
-        ]);
+        $tokenStorage   = $this->getMockBuilder(TokenStorageInterface::class)->getMock();
+        $token          = $this->getMockBuilder(TokenInterface::class)->getMock();
+        $globalVariable = new GlobalVariables(
+            [
+                'security' => new Security(
+                    new CoreSecurity(
+                        $this->getDIContainerMock(['security.token_storage' => $tokenStorage])
+                    )
+                ),
+            ]
+        );
         $globalVariable->get('security');
 
         $token
@@ -97,6 +105,6 @@ class GetUserTest extends TestCase
 
     private function getCompileCode()
     {
-        return 'return '.$this->expressionLanguage->compile('getUser()').';';
+        return 'return ' . $this->expressionLanguage->compile('getUser()') . ';';
     }
 }

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/HasAnyPermissionTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/HasAnyPermissionTest.php
@@ -4,45 +4,53 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Tests\ExpressionLanguage\ExpressionFunction\Security;
 
+use Overblog\GraphQLBundle\Definition\GlobalVariables;
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\Security\HasAnyPermission;
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 
 class HasAnyPermissionTest extends TestCase
 {
-    private $expectedObject;
     private $testedExpression = 'hasAnyPermission(object,["OWNER", "WRITER"])';
 
     protected function getFunctions()
     {
-        $this->expectedObject = new \stdClass();
-
-        $security = $this->getSecurityIsGrantedWithExpectation(
-            [
-                $this->matchesRegularExpression('/^(OWNER|WRITER)$/'),
-                $this->identicalTo($this->expectedObject),
-            ],
-            $this->any()
-        );
-
-        return [new HasAnyPermission($security)];
+        return [new HasAnyPermission()];
     }
 
     public function testEvaluator(): void
     {
-        $hasPermission = $this->expressionLanguage->evaluate($this->testedExpression, ['object' => $this->expectedObject]);
+        $expectedObject = new \stdClass();
+        $security       = $this->getSecurityIsGrantedWithExpectation(
+            [
+                $this->matchesRegularExpression('/^(OWNER|WRITER)$/'),
+                $this->identicalTo($expectedObject),
+            ],
+            $this->any()
+        );
+        $globalVariable = new GlobalVariables(['security' => $security]);
+
+        $hasPermission = $this->expressionLanguage->evaluate(
+            $this->testedExpression,
+            [
+                'globalVariable' => $globalVariable,
+                'object'         => $expectedObject,
+            ]
+        );
         $this->assertTrue($hasPermission);
     }
 
     public function testHasAnyPermission(): void
     {
+        $expectedObject = new \stdClass();
+
         $this->assertExpressionCompile(
             $this->testedExpression,
             [
                 $this->matchesRegularExpression('/^(OWNER|WRITER)$/'),
-                $this->identicalTo($this->expectedObject),
+                $this->identicalTo($expectedObject),
             ],
             [
-                'object' => $this->expectedObject,
+                'object' => $expectedObject,
             ]
         );
 
@@ -50,10 +58,10 @@ class HasAnyPermissionTest extends TestCase
             $this->testedExpression,
             [
                 $this->matchesRegularExpression('/^(OWNER|WRITER)$/'),
-                $this->identicalTo($this->expectedObject),
+                $this->identicalTo($expectedObject),
             ],
             [
-                'object' => $this->expectedObject,
+                'object' => $expectedObject,
             ],
             $this->exactly(2),
             false,

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/HasAnyPermissionTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/HasAnyPermissionTest.php
@@ -20,7 +20,7 @@ class HasAnyPermissionTest extends TestCase
     public function testEvaluator(): void
     {
         $expectedObject = new \stdClass();
-        $security       = $this->getSecurityIsGrantedWithExpectation(
+        $security = $this->getSecurityIsGrantedWithExpectation(
             [
                 $this->matchesRegularExpression('/^(OWNER|WRITER)$/'),
                 $this->identicalTo($expectedObject),
@@ -33,7 +33,7 @@ class HasAnyPermissionTest extends TestCase
             $this->testedExpression,
             [
                 'globalVariable' => $globalVariable,
-                'object'         => $expectedObject,
+                'object' => $expectedObject,
             ]
         );
         $this->assertTrue($hasPermission);

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/HasAnyRoleTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/HasAnyRoleTest.php
@@ -17,7 +17,7 @@ class HasAnyRoleTest extends TestCase
 
     public function testEvaluator(): void
     {
-        $security       = $this->getSecurityIsGrantedWithExpectation('ROLE_ADMIN', $this->any());
+        $security = $this->getSecurityIsGrantedWithExpectation('ROLE_ADMIN', $this->any());
         $globalVariable = new GlobalVariables(['security' => $security]);
 
         $hasRole = $this->expressionLanguage->evaluate(

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/HasAnyRoleTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/HasAnyRoleTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Tests\ExpressionLanguage\ExpressionFunction\Security;
 
+use Overblog\GraphQLBundle\Definition\GlobalVariables;
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\Security\HasAnyRole;
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 
@@ -11,17 +12,18 @@ class HasAnyRoleTest extends TestCase
 {
     protected function getFunctions()
     {
-        $Security = $this->getSecurityIsGrantedWithExpectation(
-            'ROLE_ADMIN',
-            $this->any()
-        );
-
-        return [new HasAnyRole($Security)];
+        return [new HasAnyRole()];
     }
 
     public function testEvaluator(): void
     {
-        $hasRole = $this->expressionLanguage->evaluate('hasAnyRole(["ROLE_ADMIN", "ROLE_USER"])');
+        $security       = $this->getSecurityIsGrantedWithExpectation('ROLE_ADMIN', $this->any());
+        $globalVariable = new GlobalVariables(['security' => $security]);
+
+        $hasRole = $this->expressionLanguage->evaluate(
+            'hasAnyRole(["ROLE_ADMIN", "ROLE_USER"])',
+            ['globalVariable' => $globalVariable]
+        );
         $this->assertTrue($hasRole);
     }
 

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/HasPermissionTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/HasPermissionTest.php
@@ -20,7 +20,7 @@ class HasPermissionTest extends TestCase
     public function testEvaluator(): void
     {
         $expectedObject = new \stdClass();
-        $security       = $this->getSecurityIsGrantedWithExpectation(
+        $security = $this->getSecurityIsGrantedWithExpectation(
             [
                 'OWNER',
                 $this->identicalTo($expectedObject),
@@ -33,7 +33,7 @@ class HasPermissionTest extends TestCase
             $this->testedExpression,
             [
                 'globalVariable' => $globalVariable,
-                'object'         => $expectedObject,
+                'object' => $expectedObject,
             ]
         );
         $this->assertTrue($hasPermission);

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/HasPermissionTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/HasPermissionTest.php
@@ -4,45 +4,52 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Tests\ExpressionLanguage\ExpressionFunction\Security;
 
+use Overblog\GraphQLBundle\Definition\GlobalVariables;
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\Security\HasPermission;
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 
 class HasPermissionTest extends TestCase
 {
-    private $expectedObject;
     private $testedExpression = 'hasPermission(object,"OWNER")';
 
     protected function getFunctions()
     {
-        $this->expectedObject = new \stdClass();
-
-        $Security = $this->getSecurityIsGrantedWithExpectation(
-            [
-                'OWNER',
-                $this->identicalTo($this->expectedObject),
-            ],
-            $this->any()
-        );
-
-        return [new HasPermission($Security)];
+        return [new HasPermission()];
     }
 
     public function testEvaluator(): void
     {
-        $hasPermission = $this->expressionLanguage->evaluate($this->testedExpression, ['object' => $this->expectedObject]);
+        $expectedObject = new \stdClass();
+        $security       = $this->getSecurityIsGrantedWithExpectation(
+            [
+                'OWNER',
+                $this->identicalTo($expectedObject),
+            ],
+            $this->any()
+        );
+        $globalVariable = new GlobalVariables(['security' => $security]);
+
+        $hasPermission = $this->expressionLanguage->evaluate(
+            $this->testedExpression,
+            [
+                'globalVariable' => $globalVariable,
+                'object'         => $expectedObject,
+            ]
+        );
         $this->assertTrue($hasPermission);
     }
 
     public function testHasPermission(): void
     {
+        $expectedObject = new \stdClass();
         $this->assertExpressionCompile(
             $this->testedExpression,
             [
                 'OWNER',
-                $this->identicalTo($this->expectedObject),
+                $this->identicalTo($expectedObject),
             ],
             [
-                'object' => $this->expectedObject,
+                'object' => $expectedObject,
             ]
         );
     }

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/HasRoleTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/HasRoleTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Tests\ExpressionLanguage\ExpressionFunction\Security;
 
+use Overblog\GraphQLBundle\Definition\GlobalVariables;
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\Security\HasRole;
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 
@@ -11,17 +12,18 @@ class HasRoleTest extends TestCase
 {
     protected function getFunctions()
     {
-        $Security = $this->getSecurityIsGrantedWithExpectation(
-            'ROLE_USER',
-            $this->any()
-        );
-
-        return [new HasRole($Security)];
+        return [new HasRole()];
     }
 
     public function testEvaluator(): void
     {
-        $hasRole = $this->expressionLanguage->evaluate('hasRole("ROLE_USER")');
+        $security       = $this->getSecurityIsGrantedWithExpectation(
+            'ROLE_USER',
+            $this->any()
+        );
+        $globalVariable = new GlobalVariables(['security' => $security]);
+
+        $hasRole = $this->expressionLanguage->evaluate('hasRole("ROLE_USER")', ['globalVariable' => $globalVariable]);
         $this->assertTrue($hasRole);
     }
 

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/HasRoleTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/HasRoleTest.php
@@ -17,7 +17,7 @@ class HasRoleTest extends TestCase
 
     public function testEvaluator(): void
     {
-        $security       = $this->getSecurityIsGrantedWithExpectation(
+        $security = $this->getSecurityIsGrantedWithExpectation(
             'ROLE_USER',
             $this->any()
         );

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/IsAnonymousTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/IsAnonymousTest.php
@@ -17,7 +17,7 @@ class IsAnonymousTest extends TestCase
 
     public function testEvaluator(): void
     {
-        $security       = $this->getSecurityIsGrantedWithExpectation(
+        $security = $this->getSecurityIsGrantedWithExpectation(
             'IS_AUTHENTICATED_ANONYMOUSLY',
             $this->any()
         );

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/IsAnonymousTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/IsAnonymousTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Tests\ExpressionLanguage\ExpressionFunction\Security;
 
+use Overblog\GraphQLBundle\Definition\GlobalVariables;
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\Security\IsAnonymous;
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 
@@ -11,17 +12,18 @@ class IsAnonymousTest extends TestCase
 {
     protected function getFunctions()
     {
-        $Security = $this->getSecurityIsGrantedWithExpectation(
-            'IS_AUTHENTICATED_ANONYMOUSLY',
-            $this->any()
-        );
-
-        return [new IsAnonymous($Security)];
+        return [new IsAnonymous()];
     }
 
     public function testEvaluator(): void
     {
-        $isAnonymous = $this->expressionLanguage->evaluate('isAnonymous()');
+        $security       = $this->getSecurityIsGrantedWithExpectation(
+            'IS_AUTHENTICATED_ANONYMOUSLY',
+            $this->any()
+        );
+        $globalVariable = new GlobalVariables(['security' => $security]);
+
+        $isAnonymous = $this->expressionLanguage->evaluate('isAnonymous()', ['globalVariable' => $globalVariable]);
         $this->assertTrue($isAnonymous);
     }
 

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/IsAuthenticatedTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/IsAuthenticatedTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Tests\ExpressionLanguage\ExpressionFunction\Security;
 
+use Overblog\GraphQLBundle\Definition\GlobalVariables;
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\Security\IsAuthenticated;
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 
@@ -11,22 +12,29 @@ class IsAuthenticatedTest extends TestCase
 {
     protected function getFunctions()
     {
-        $Security = $this->getSecurityIsGrantedWithExpectation(
-            $this->matchesRegularExpression('/^IS_AUTHENTICATED_(REMEMBERED|FULLY)$/'),
-            $this->any()
-        );
-
-        return [new IsAuthenticated($Security)];
+        return [new IsAuthenticated()];
     }
 
     public function testEvaluator(): void
     {
-        $isAuthenticated = $this->expressionLanguage->evaluate('isAuthenticated()');
+        $security       = $this->getSecurityIsGrantedWithExpectation(
+            $this->matchesRegularExpression('/^IS_AUTHENTICATED_(REMEMBERED|FULLY)$/'),
+            $this->any()
+        );
+        $globalVariable = new GlobalVariables(['security' => $security]);
+
+        $isAuthenticated = $this->expressionLanguage->evaluate(
+            'isAuthenticated()',
+            ['globalVariable' => $globalVariable]
+        );
         $this->assertTrue($isAuthenticated);
     }
 
     public function testIsAuthenticated(): void
     {
-        $this->assertExpressionCompile('isAuthenticated()', $this->matchesRegularExpression('/^IS_AUTHENTICATED_(REMEMBERED|FULLY)$/'));
+        $this->assertExpressionCompile(
+            'isAuthenticated()',
+            $this->matchesRegularExpression('/^IS_AUTHENTICATED_(REMEMBERED|FULLY)$/')
+        );
     }
 }

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/IsAuthenticatedTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/IsAuthenticatedTest.php
@@ -17,7 +17,7 @@ class IsAuthenticatedTest extends TestCase
 
     public function testEvaluator(): void
     {
-        $security       = $this->getSecurityIsGrantedWithExpectation(
+        $security = $this->getSecurityIsGrantedWithExpectation(
             $this->matchesRegularExpression('/^IS_AUTHENTICATED_(REMEMBERED|FULLY)$/'),
             $this->any()
         );

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/IsFullyAuthenticatedTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/IsFullyAuthenticatedTest.php
@@ -17,7 +17,7 @@ class IsFullyAuthenticatedTest extends TestCase
 
     public function testEvaluator(): void
     {
-        $security       = $this->getSecurityIsGrantedWithExpectation(
+        $security = $this->getSecurityIsGrantedWithExpectation(
             'IS_AUTHENTICATED_FULLY',
             $this->any()
         );

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/IsFullyAuthenticatedTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/IsFullyAuthenticatedTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Tests\ExpressionLanguage\ExpressionFunction\Security;
 
+use Overblog\GraphQLBundle\Definition\GlobalVariables;
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\Security\IsFullyAuthenticated;
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 
@@ -11,17 +12,21 @@ class IsFullyAuthenticatedTest extends TestCase
 {
     protected function getFunctions()
     {
-        $Security = $this->getSecurityIsGrantedWithExpectation(
-            'IS_AUTHENTICATED_FULLY',
-            $this->any()
-        );
-
-        return [new IsFullyAuthenticated($Security)];
+        return [new IsFullyAuthenticated()];
     }
 
     public function testEvaluator(): void
     {
-        $isFullyAuthenticated = $this->expressionLanguage->evaluate('isFullyAuthenticated()');
+        $security       = $this->getSecurityIsGrantedWithExpectation(
+            'IS_AUTHENTICATED_FULLY',
+            $this->any()
+        );
+        $globalVariable = new GlobalVariables(['security' => $security]);
+
+        $isFullyAuthenticated = $this->expressionLanguage->evaluate(
+            'isFullyAuthenticated()',
+            ['globalVariable' => $globalVariable]
+        );
         $this->assertTrue($isFullyAuthenticated);
     }
 

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/IsGrantedTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/IsGrantedTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Tests\ExpressionLanguage\ExpressionFunction\Security;
 
+use Overblog\GraphQLBundle\Definition\GlobalVariables;
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\Security\IsGranted;
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 
@@ -11,17 +12,20 @@ class IsGrantedTest extends TestCase
 {
     protected function getFunctions()
     {
-        $security = $this->getSecurityIsGrantedWithExpectation(
-            $this->matchesRegularExpression('/^ROLE_(USER|ADMIN)$/'),
-            $this->any()
-        );
-
-        return [new IsGranted($security)];
+        return [new IsGranted()];
     }
 
     public function testEvaluator(): void
     {
-        $this->assertTrue($this->expressionLanguage->evaluate('isGranted("ROLE_USER")'));
+        $security       = $this->getSecurityIsGrantedWithExpectation(
+            $this->matchesRegularExpression('/^ROLE_(USER|ADMIN)$/'),
+            $this->any()
+        );
+        $globalVariable = new GlobalVariables(['security' => $security]);
+
+        $this->assertTrue(
+            $this->expressionLanguage->evaluate('isGranted("ROLE_USER")', ['globalVariable' => $globalVariable])
+        );
     }
 
     public function testIsGranted(): void

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/IsGrantedTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/IsGrantedTest.php
@@ -17,7 +17,7 @@ class IsGrantedTest extends TestCase
 
     public function testEvaluator(): void
     {
-        $security       = $this->getSecurityIsGrantedWithExpectation(
+        $security = $this->getSecurityIsGrantedWithExpectation(
             $this->matchesRegularExpression('/^ROLE_(USER|ADMIN)$/'),
             $this->any()
         );

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/IsRememberMeTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/IsRememberMeTest.php
@@ -17,7 +17,7 @@ class IsRememberMeTest extends TestCase
 
     public function testEvaluator(): void
     {
-        $security       = $this->getSecurityIsGrantedWithExpectation(
+        $security = $this->getSecurityIsGrantedWithExpectation(
             'IS_AUTHENTICATED_REMEMBERED',
             $this->any()
         );

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/IsRememberMeTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/IsRememberMeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Tests\ExpressionLanguage\ExpressionFunction\Security;
 
+use Overblog\GraphQLBundle\Definition\GlobalVariables;
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\Security\IsRememberMe;
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 
@@ -11,17 +12,18 @@ class IsRememberMeTest extends TestCase
 {
     protected function getFunctions()
     {
-        $Security = $this->getSecurityIsGrantedWithExpectation(
-            'IS_AUTHENTICATED_REMEMBERED',
-            $this->any()
-        );
-
-        return [new IsRememberMe($Security)];
+        return [new IsRememberMe()];
     }
 
     public function testEvaluator(): void
     {
-        $isRememberMe = $this->expressionLanguage->evaluate('isRememberMe()');
+        $security       = $this->getSecurityIsGrantedWithExpectation(
+            'IS_AUTHENTICATED_REMEMBERED',
+            $this->any()
+        );
+        $globalVariable = new GlobalVariables(['security' => $security]);
+
+        $isRememberMe = $this->expressionLanguage->evaluate('isRememberMe()', ['globalVariable' => $globalVariable]);
         $this->assertTrue($isRememberMe);
     }
 

--- a/tests/Functional/App/config/validator/config.yml
+++ b/tests/Functional/App/config/validator/config.yml
@@ -16,7 +16,9 @@ overblog_graphql:
 services:
     validator.expression:
         class: Overblog\GraphQLBundle\Validator\Constraints\ExpressionValidator
-        arguments: ['@Overblog\GraphQLBundle\ExpressionLanguage\ExpressionLanguage']
+        arguments:
+            - '@Overblog\GraphQLBundle\ExpressionLanguage\ExpressionLanguage'
+            - '@Overblog\GraphQLBundle\Definition\GlobalVariables'
         tags:
             - name: validator.constraint_validator
               alias: validator.expression


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #588 
| License       | MIT

As mentioned in comment https://github.com/overblog/GraphQLBundle/issues/588#issuecomment-610393275 the true problem behind issue #588 is that the setup of the expression language functions is flawed. The expression language functions are not designed to take services as constructor arguments. Instead they must rely on dependencies passed into the function during execution.

This PR fixes these issues with several expression language functions. Instead of passing dependencies to the constructor (from where they were injected into closures), the evaluators no rely on the `'globalVariable'` in the `$arguments` parameter - just as the compiler relies on `$globalVariable` variable in the execution context. `'globalVariable'` just points to an instance of `Overblog\GraphQLBundle\Definition\GlobalVariables` (again just the same as for complied function execution). 

Because all of the expression language functions are auto-wired and because the evaluator is only used directly in `Overblog\GraphQLBundle\Validator\Constraints\ExpressionValidator`, there has only been a slight service configuration change (the service `validator.expression` (instance of `Overblog\GraphQLBundle\Validator\Constraints\ExpressionValidator`) now also requires the `Overblog\GraphQLBundle\Definition\GlobalVariables` service as its second constructor argument.
