### PR TITLE
Treat `useStrictAccess` option as true by default

### DIFF
--- a/src/Definition/ConfigProcessor/AclConfigProcessor.php
+++ b/src/Definition/ConfigProcessor/AclConfigProcessor.php
@@ -38,7 +38,7 @@ final class AclConfigProcessor implements ConfigProcessorInterface
                     $field['resolve'] = function ($value, $args, $context, ResolveInfo $info) use ($field, $accessChecker, $accessResolver, $defaultResolver) {
                         $resolverCallback = self::findFieldResolver($field, $info, $defaultResolver);
 
-                        return $accessResolver->resolve($accessChecker, $resolverCallback, [$value, $args, $context, $info], $field['useStrictAccess']);
+                        return $accessResolver->resolve($accessChecker, $resolverCallback, [$value, $args, $context, $info], $field['useStrictAccess'] ?? true);
                     };
                 }
             }

--- a/src/Generator/TypeBuilder.php
+++ b/src/Generator/TypeBuilder.php
@@ -61,7 +61,6 @@ use function trim;
  * TODO (murtukov):
  *  1. Add <code> docblocks for every method
  *  2. Replace hard-coded string types with constants ('object', 'input-object' etc.).
- *  3. Change formatting of generated arguments.
  */
 class TypeBuilder
 {
@@ -94,9 +93,6 @@ class TypeBuilder
         Config::registerConverter($expressionConverter, ConverterInterface::TYPE_STRING);
     }
 
-    /**
-     * TODO (murtukov). Implement file prototype to increase performance.
-     */
     public function build(array $config, string $type): PhpFile
     {
         $this->config = $config;
@@ -179,7 +175,7 @@ class TypeBuilder
          * @var string|null   $description
          * @var array|null    $interfaces
          * @var string|null   $resolveType
-         * @var string|null   $validation   - only by InputType
+         * @var array|null    $validation   - only by InputType
          * @var array|null    $types        - only by UnionType
          * @var array|null    $values       - only by EnumType
          * @var callback|null $serialize    - only by CustomScalarType
@@ -566,8 +562,6 @@ class TypeBuilder
 
         if (!empty($access) && is_string($access) && ExpressionLanguage::expressionContainsVar('object', $access)) {
             $field->addItem('useStrictAccess', false);
-        } else {
-            $field->addItem('useStrictAccess', true);
         }
 
         if ('input-object' === $this->type && isset($validation)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no

The `useStrictAccess` is a boolean option on GraphQL types. It is `true` by default. There is no need to render both states (true and false), so this PR changes it: it will be rendered only if set to `false`. If it's not defined, it will be considered as `true`.

Here is an example of an object type:
```php
final class HumanType extends ObjectType implements GeneratedTypeInterface
{
    public const NAME = 'Human';
    
    public function __construct(ConfigProcessor $configProcessor, GlobalVariables $globalVariables = null)
    {
        $configLoader = fn() => [
            'name' => self::NAME,
            'description' => 'A humanoid creature in the Star Wars universe.',
            'fields' => fn() => [
                'id' => [
                    'type' => Type::nonNull(Type::string()),
                    'deprecationReason' => 'A terrible reason',
                    'description' => 'The id of the character.',
                    'useStrictAccess' => true,
                ],
                'name' => [
                    'type' => Type::string(),
                    'description' => 'The name of the character.',
                    'useStrictAccess' => true,
                ],
                'friends' => [
                    'type' => Type::listOf($globalVariables->get('typeResolver')->resolve('Character')),
                    'resolve' => fn () => ...,
                    'description' => 'The friends of the character.',
                    'useStrictAccess' => true,
                ],
                'appearsIn' => [
                    'type' => Type::listOf($globalVariables->get('typeResolver')->resolve('Episode')),
                    'description' => 'Which movies they appear in.',
                    'useStrictAccess' => true,
                ],
            ],
        ];
        $config = $configProcessor->process(LazyConfig::create($configLoader, $globalVariables))->load();
        parent::__construct($config);
    }
}
```
Obviously `'useStrictAccess' => true` is not needed here.

Just a quick reminder: the `useStrictAccess` option is set to `false` only if all the following conditions are met:
- The `access` option is set
- The `access` option is an expression
- The `access` expression  contains the `object` variable.
