### PR TITLE
Annotations refactoring

### DIFF
--- a/docs/annotations/annotations-reference.md
+++ b/docs/annotations/annotations-reference.md
@@ -384,6 +384,10 @@ This annotation applies on methods for classes tagged with the `@Provider` annot
 The resulting field is added to the root Mutation type (defined in configuration at key `overblog_graphql.definitions.schema.mutation`).  
 The class exposing the mutation(s) must be declared as a [service](https://symfony.com/doc/current/service_container.html).
 
+Optional attributes:
+
+-   **targetType** : The GraphQL type to attach the field to. It must be a mutation. (by default, it'll be the root Mutation type of the default schema).
+
 Example:
 
 This will add an `updateUserEmail` mutation, with as resolver `@=service('App\Graphql\MutationProvider').updateUserEmail(...)`.
@@ -432,7 +436,7 @@ The class exposing the query(ies) must be declared as a [service](https://symfon
 
 Optional attributes:
 
--   **targetType** : The GraphQL type to attach the field to (by default, it'll be the root Query type).
+-   **targetType** : The GraphQL type to attach the field to (by default, it'll be the root Query type of the default schema).
 
 Example:
 
@@ -464,9 +468,10 @@ This annotation is used on _class_ to define a GraphQL Type.
 Optional attributes:
 
 -   **name** : The GraphQL name of the type (default to the class name without namespace)
--   **interfaces** : An array of GraphQL interface this type inherits from
+-   **interfaces** : An array of GraphQL interface this type inherits from (can be auto-guessed. See interface documentation).
 -   **isRelay** : Set to true to have a Relay compatible type (ie. A `clientMutationId` will be added).
--   **builders**: An array of `@FieldsBuilder` annotations
+-   **builders** : An array of `@FieldsBuilder` annotations
+-   **isTypeOf** : Is type of resolver for interface implementation
 
 ```php
 <?php
@@ -554,7 +559,7 @@ This annotation is used on a _class_ to define an union.
 
 Required attributes:
 
--   **types** : An array of GraphQL Type as string
+-   **types** : An array of GraphQL Type as string (can be auto-guessed. See union documenation).
 
 Optional attributes:
 

--- a/docs/definitions/type-system/object.md
+++ b/docs/definitions/type-system/object.md
@@ -77,6 +77,8 @@ Droid:
 
 ## With Annotations
 
+Note: With annotations, you can omit the `interfaces` option. If so, the system will try to guess the interfaces automaticaly by getting the GraphQL Interface associated with classes that the Class type extends or implements.  
+
 ```php
 <?php
 

--- a/docs/definitions/type-system/object.md
+++ b/docs/definitions/type-system/object.md
@@ -77,7 +77,7 @@ Droid:
 
 ## With Annotations
 
-Note: With annotations, you can omit the `interfaces` option. If so, the system will try to guess the interfaces automaticaly by getting the GraphQL Interface associated with classes that the Class type extends or implements.  
+Note: With annotations, you can omit the `interfaces` option. If so, the system will try to guess the interfaces automatically by getting the GraphQL Interface associated with classes that the Class type extends or implements.  
 
 ```php
 <?php

--- a/docs/definitions/type-system/union.md
+++ b/docs/definitions/type-system/union.md
@@ -16,7 +16,7 @@ HumanAndDroid:
 
 ## With annotations
 
-Note: With annotations, you can ommit the `types` parameter. If so, the system will try to detect GraphQL Type associated with classes that inherit or implement the Union class.  
+Note: With annotations, you can omit the `types` parameter. If so, the system will try to detect GraphQL Type associated with classes that inherit or implement the Union class.  
 
 ```php
 <?php

--- a/docs/definitions/type-system/union.md
+++ b/docs/definitions/type-system/union.md
@@ -16,6 +16,8 @@ HumanAndDroid:
 
 ## With annotations
 
+Note: With annotations, you can ommit the `types` parameter. If so, the system will try to detect GraphQL Type associated with classes that inherit or implement the Union class.  
+
 ```php
 <?php
 

--- a/src/Annotation/Mutation.php
+++ b/src/Annotation/Mutation.php
@@ -12,4 +12,10 @@ namespace Overblog\GraphQLBundle\Annotation;
  */
 final class Mutation extends Field
 {
+    /**
+     * The target type to attach this mutation to (usefull when multiple schemas are allowed).
+     *
+     * @var string
+     */
+    public $targetType;
 }

--- a/src/Annotation/Type.php
+++ b/src/Annotation/Type.php
@@ -46,4 +46,11 @@ class Type implements Annotation
      * @var array<\Overblog\GraphQLBundle\Annotation\FieldsBuilder>
      */
     public $builders = [];
+
+    /**
+     * Expression to resolve type for interfaces.
+     *
+     * @var string
+     */
+    public $isTypeOf;
 }

--- a/src/Annotation/Union.php
+++ b/src/Annotation/Union.php
@@ -22,8 +22,6 @@ final class Union implements Annotation
     /**
      * Union types.
      *
-     * @required
-     *
      * @var array<string>
      */
     public $types;

--- a/src/Config/Parser/Annotation/GraphClass.php
+++ b/src/Config/Parser/Annotation/GraphClass.php
@@ -8,7 +8,6 @@ use Doctrine\Common\Annotations\AnnotationException;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use ReflectionClass;
-use ReflectionException;
 use ReflectionMethod;
 use ReflectionProperty;
 use RuntimeException;
@@ -41,57 +40,11 @@ class GraphClass extends ReflectionClass
     }
 
     /**
-     * Get an array of parent class names.
-     *
-     * @return string[]
-     */
-    public function getParents(): array
-    {
-        $parents = [];
-        $class = $this;
-        while ($parent = $class->getParentClass()) {
-            $parents[] = $parent->getName();
-            $class = $parent;
-        }
-
-        return $parents;
-    }
-
-    /**
-     * Get the list of methods name.
-     *
-     * @return string[]
-     */
-    public function getMethodsNames(): array
-    {
-        return array_map(fn (ReflectionMethod $method) => $method->getName(), $this->getMethods());
-    }
-
-    public function getMethodAnnotations(string $name): array
-    {
-        return self::getAnnotationReader()->getMethodAnnotations($this->getMethod($name));
-    }
-
-    public function getPropertyAnnotations(string $name): array
-    {
-        return self::getAnnotationReader()->getPropertyAnnotations($this->getProperty($name));
-    }
-
-    /**
      * @return ReflectionProperty[]
      */
     public function getPropertiesExtended()
     {
         return $this->propertiesExtended;
-    }
-
-    public function getPropertyExtended(string $name): ReflectionProperty
-    {
-        if (!isset($this->propertiesExtended[$name])) {
-            throw new ReflectionException(sprintf('Missing property %s on class or parent class %s', $name, $this->getName()));
-        }
-
-        return $this->propertiesExtended[$name];
     }
 
     /**

--- a/src/Config/Parser/Annotation/GraphClass.php
+++ b/src/Config/Parser/Annotation/GraphClass.php
@@ -119,8 +119,8 @@ class GraphClass extends ReflectionClass
     private static function getAnnotationReader(): AnnotationReader
     {
         if (null === self::$annotationReader) {
-            if (!class_exists('\\Doctrine\\Common\\Annotations\\AnnotationReader') ||
-                !class_exists('\\Doctrine\\Common\\Annotations\\AnnotationRegistry')) {
+            if (!class_exists(AnnotationReader::class) ||
+                !class_exists(AnnotationRegistry::class)) {
                 throw new RuntimeException('In order to use graphql annotation, you need to require doctrine annotations');
             }
 

--- a/src/Config/Parser/Annotation/GraphClass.php
+++ b/src/Config/Parser/Annotation/GraphClass.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Config\Parser\Annotation;
+
+use Doctrine\Common\Annotations\AnnotationException;
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionMethod;
+use ReflectionProperty;
+use RuntimeException;
+use function class_exists;
+
+class GraphClass extends ReflectionClass
+{
+    private static ?AnnotationReader $annotationReader = null;
+
+    protected array $annotations = [];
+
+    protected array $propertiesExtended = [];
+
+    public function __construct(string $className)
+    {
+        parent::__construct($className);
+
+        $annotationReader = self::getAnnotationReader();
+        $this->annotations = $annotationReader->getClassAnnotations($this);
+
+        $reflection = $this;
+        do {
+            foreach ($reflection->getProperties() as $property) {
+                if (isset($this->propertiesExtended[$property->getName()])) {
+                    continue;
+                }
+                $this->propertiesExtended[$property->getName()] = $property;
+            }
+        } while ($reflection = $reflection->getParentClass());
+    }
+
+    /**
+     * Get an array of parent class names.
+     *
+     * @return string[]
+     */
+    public function getParents(): array
+    {
+        $parents = [];
+        $class = $this;
+        while ($parent = $class->getParentClass()) {
+            $parents[] = $parent->getName();
+            $class = $parent;
+        }
+
+        return $parents;
+    }
+
+    /**
+     * Get the list of methods name.
+     *
+     * @return string[]
+     */
+    public function getMethodsNames(): array
+    {
+        return array_map(fn (ReflectionMethod $method) => $method->getName(), $this->getMethods());
+    }
+
+    public function getMethodAnnotations(string $name): array
+    {
+        return self::getAnnotationReader()->getMethodAnnotations($this->getMethod($name));
+    }
+
+    public function getPropertyAnnotations(string $name): array
+    {
+        return self::getAnnotationReader()->getPropertyAnnotations($this->getProperty($name));
+    }
+
+    /**
+     * @return ReflectionProperty[]
+     */
+    public function getPropertiesExtended()
+    {
+        return $this->propertiesExtended;
+    }
+
+    public function getPropertyExtended(string $name): ReflectionProperty
+    {
+        if (!isset($this->propertiesExtended[$name])) {
+            throw new ReflectionException(sprintf('Missing property %s on class or parent class %s', $name, $this->getName()));
+        }
+
+        return $this->propertiesExtended[$name];
+    }
+
+    /**
+     * @param ReflectionMethod|ReflectionProperty|null $from
+     *
+     * @return array
+     */
+    public function getAnnotations(object $from = null)
+    {
+        if (!$from) {
+            return $this->annotations;
+        }
+
+        if ($from instanceof ReflectionMethod) {
+            return self::getAnnotationReader()->getMethodAnnotations($from);
+        }
+
+        if ($from instanceof ReflectionProperty) {
+            return self::getAnnotationReader()->getPropertyAnnotations($from);
+        }
+
+        throw new AnnotationException(sprintf('Unable to retrieve annotations from object of class "%s".', get_class($from)));
+    }
+
+    private static function getAnnotationReader(): AnnotationReader
+    {
+        if (null === self::$annotationReader) {
+            if (!class_exists('\\Doctrine\\Common\\Annotations\\AnnotationReader') ||
+                !class_exists('\\Doctrine\\Common\\Annotations\\AnnotationRegistry')) {
+                throw new RuntimeException('In order to use graphql annotation, you need to require doctrine annotations');
+            }
+
+            AnnotationRegistry::registerLoader('class_exists');
+            self::$annotationReader = new AnnotationReader();
+        }
+
+        return self::$annotationReader;
+    }
+}

--- a/src/Config/Parser/Annotation/GraphClass.php
+++ b/src/Config/Parser/Annotation/GraphClass.php
@@ -21,7 +21,10 @@ class GraphClass extends ReflectionClass
 
     protected array $propertiesExtended = [];
 
-    public function __construct(string $className)
+    /**
+     * @param mixed $className
+     */
+    public function __construct($className)
     {
         parent::__construct($className);
 
@@ -66,6 +69,7 @@ class GraphClass extends ReflectionClass
             return self::getAnnotationReader()->getPropertyAnnotations($from);
         }
 
+        /** @phpstan-ignore-next-line */
         throw new AnnotationException(sprintf('Unable to retrieve annotations from object of class "%s".', get_class($from)));
     }
 

--- a/src/Config/Parser/AnnotationParser.php
+++ b/src/Config/Parser/AnnotationParser.php
@@ -321,8 +321,8 @@ class AnnotationParser implements PreParserInterface
     private static function getAnnotationReader(): AnnotationReader
     {
         if (null === self::$annotationReader) {
-            if (!class_exists('\\Doctrine\\Common\\Annotations\\AnnotationReader') ||
-                !class_exists('\\Doctrine\\Common\\Annotations\\AnnotationRegistry')) {
+            if (!class_exists(AnnotationReader::class) ||
+                !class_exists(AnnotationRegistry::class)) {
                 throw new RuntimeException('In order to use graphql annotation, you need to require doctrine annotations');
             }
 

--- a/src/Config/Parser/AnnotationParser.php
+++ b/src/Config/Parser/AnnotationParser.php
@@ -253,20 +253,22 @@ class AnnotationParser implements PreParserInterface
         array $configs
     ): array {
         $isMutation = $isDefault = $isRoot = false;
-        foreach ($configs['definitions']['schema'] as $schemaName => $schema) {
-            $schemaQuery = $schema['query'] ?? null;
-            $schemaMutation = $schema['mutation'] ?? null;
+        if (isset($configs['definitions']['schema'])) {
+            foreach ($configs['definitions']['schema'] as $schemaName => $schema) {
+                $schemaQuery = $schema['query'] ?? null;
+                $schemaMutation = $schema['mutation'] ?? null;
 
-            if ($schemaQuery && $gqlName === $schemaQuery) {
-                $isRoot = true;
-                if ('default' == $schemaName) {
-                    $isDefault = true;
-                }
-            } elseif ($schemaMutation && $gqlName === $schemaMutation) {
-                $isMutation = true;
-                $isRoot = true;
-                if ('default' == $schemaName) {
-                    $isDefault = true;
+                if ($schemaQuery && $gqlName === $schemaQuery) {
+                    $isRoot = true;
+                    if ('default' == $schemaName) {
+                        $isDefault = true;
+                    }
+                } elseif ($schemaMutation && $gqlName === $schemaMutation) {
+                    $isMutation = true;
+                    $isRoot = true;
+                    if ('default' == $schemaName) {
+                        $isDefault = true;
+                    }
                 }
             }
         }
@@ -436,10 +438,8 @@ class AnnotationParser implements PreParserInterface
         if ($unionAnnotation->types) {
             $unionConfiguration['types'] = $unionAnnotation->types;
         } else {
-            $unionConfiguration['types'] = array_keys(self::searchClassesMapBy(function ($gqlType, $configuration) use ($graphClass) {
+            $types = array_keys(self::searchClassesMapBy(function ($gqlType, $configuration) use ($graphClass) {
                 $typeClassName = $configuration['class'];
-                ['class' => $typeClassName] = $configuration;
-
                 $typeMetadata = self::getGraphClass($typeClassName);
 
                 if ($graphClass->isInterface() && $typeMetadata->implementsInterface($graphClass->getName())) {
@@ -448,6 +448,8 @@ class AnnotationParser implements PreParserInterface
 
                 return $typeMetadata->isSubclassOf($graphClass->getName());
             }, self::GQL_TYPE));
+            sort($types);
+            $unionConfiguration['types'] = $types;
         }
 
         $unionConfiguration = self::getDescriptionConfiguration($graphClass->getAnnotations()) + $unionConfiguration;

--- a/src/Config/Parser/AnnotationParser.php
+++ b/src/Config/Parser/AnnotationParser.php
@@ -304,7 +304,7 @@ class AnnotationParser implements PreParserInterface
         if (null !== $typeAnnotation->interfaces) {
             $typeConfiguration['interfaces'] = $typeAnnotation->interfaces;
         } else {
-            $typeConfiguration['interfaces'] = array_keys(self::searchClassesMapBy(function ($gqlType, $configuration) use ($graphClass) {
+            $interfaces = array_keys(self::searchClassesMapBy(function ($gqlType, $configuration) use ($graphClass) {
                 ['class' => $interfaceClassName] = $configuration;
 
                 $interfaceMetadata = self::getGraphClass($interfaceClassName);
@@ -314,6 +314,9 @@ class AnnotationParser implements PreParserInterface
 
                 return $graphClass->isSubclassOf($interfaceClassName);
             }, self::GQL_INTERFACE));
+
+            sort($interfaces);
+            $typeConfiguration['interfaces'] = $interfaces;
         }
 
         if ($typeAnnotation->resolveField) {

--- a/src/Config/Parser/AnnotationParser.php
+++ b/src/Config/Parser/AnnotationParser.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Config\Parser;
 
-use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToMany;
@@ -14,12 +12,14 @@ use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\OneToOne;
 use Exception;
 use Overblog\GraphQLBundle\Annotation as GQL;
+use Overblog\GraphQLBundle\Config\Parser\Annotation\GraphClass;
 use Overblog\GraphQLBundle\Relay\Connection\ConnectionInterface;
 use Overblog\GraphQLBundle\Relay\Connection\EdgeInterface;
-use ReflectionClass;
 use ReflectionException;
 use ReflectionMethod;
 use ReflectionNamedType;
+use ReflectionProperty;
+use Reflector;
 use RuntimeException;
 use SplFileInfo;
 use Symfony\Component\Config\Resource\FileResource;
@@ -29,7 +29,6 @@ use function array_filter;
 use function array_keys;
 use function array_map;
 use function array_unshift;
-use function class_exists;
 use function current;
 use function file_get_contents;
 use function get_class;
@@ -47,11 +46,10 @@ use function trim;
 
 class AnnotationParser implements PreParserInterface
 {
-    private static ?AnnotationReader $annotationReader = null;
     private static array $classesMap = [];
     private static array $providers = [];
     private static array $doctrineMapping = [];
-    private static array $classAnnotationsCache = [];
+    private static array $graphClassCache = [];
 
     private const GQL_SCALAR = 'scalar';
     private const GQL_ENUM = 'enum';
@@ -91,8 +89,7 @@ class AnnotationParser implements PreParserInterface
     {
         self::$classesMap = [];
         self::$providers = [];
-        self::$classAnnotationsCache = [];
-        self::$annotationReader = null;
+        self::$graphClassCache = [];
     }
 
     /**
@@ -111,17 +108,15 @@ class AnnotationParser implements PreParserInterface
             if (preg_match('#namespace (.+);#', file_get_contents($file->getRealPath()), $matches)) {
                 $className = trim($matches[1]).'\\'.$className;
             }
-            [$reflectionEntity, $classAnnotations, $properties, $methods] = self::extractClassAnnotations($className);
-            $gqlTypes = [];
 
-            foreach ($classAnnotations as $classAnnotation) {
+            $gqlTypes = [];
+            $graphClass = self::getGraphClass($className);
+
+            foreach ($graphClass->getAnnotations() as $classAnnotation) {
                 $gqlTypes = self::classAnnotationsToGQLConfiguration(
-                    $reflectionEntity,
+                    $graphClass,
                     $classAnnotation,
                     $configs,
-                    $classAnnotations,
-                    $properties,
-                    $methods,
                     $gqlTypes,
                     $preProcess
                 );
@@ -134,12 +129,9 @@ class AnnotationParser implements PreParserInterface
     }
 
     private static function classAnnotationsToGQLConfiguration(
-        ReflectionClass $reflectionEntity,
+        GraphClass $graphClass,
         object $classAnnotation,
         array $configs,
-        array $classAnnotations,
-        array $properties,
-        array $methods,
         array $gqlTypes,
         bool $preProcess
     ): array {
@@ -148,19 +140,17 @@ class AnnotationParser implements PreParserInterface
         switch (true) {
             case $classAnnotation instanceof GQL\Type:
                 $gqlType = self::GQL_TYPE;
-                $gqlName = $classAnnotation->name ?: $reflectionEntity->getShortName();
+                $gqlName = $classAnnotation->name ?: $graphClass->getShortName();
                 if (!$preProcess) {
-                    $gqlConfiguration = self::typeAnnotationToGQLConfiguration(
-                        $reflectionEntity, $classAnnotation, $gqlName, $classAnnotations, $properties, $methods, $configs
-                    );
+                    $gqlConfiguration = self::typeAnnotationToGQLConfiguration($graphClass, $classAnnotation, $gqlName, $configs);
 
                     if ($classAnnotation instanceof GQL\Relay\Connection) {
-                        if (!$reflectionEntity->implementsInterface(ConnectionInterface::class)) {
-                            throw new InvalidArgumentException(sprintf('The annotation @Connection on class "%s" can only be used on class implementing the ConnectionInterface.', $reflectionEntity->getName()));
+                        if (!$graphClass->implementsInterface(ConnectionInterface::class)) {
+                            throw new InvalidArgumentException(sprintf('The annotation @Connection on class "%s" can only be used on class implementing the ConnectionInterface.', $graphClass->getName()));
                         }
 
                         if (!($classAnnotation->edge xor $classAnnotation->node)) {
-                            throw new InvalidArgumentException(sprintf('The annotation @Connection on class "%s" is invalid. You must define the "edge" OR the "node" attribute.', $reflectionEntity->getName()));
+                            throw new InvalidArgumentException(sprintf('The annotation @Connection on class "%s" is invalid. You must define the "edge" OR the "node" attribute.', $graphClass->getName()));
                         }
 
                         $edgeType = $classAnnotation->edge;
@@ -185,67 +175,57 @@ class AnnotationParser implements PreParserInterface
 
             case $classAnnotation instanceof GQL\Input:
                 $gqlType = self::GQL_INPUT;
-                $gqlName = $classAnnotation->name ?: self::suffixName($reflectionEntity->getShortName(), 'Input');
+                $gqlName = $classAnnotation->name ?: self::suffixName($graphClass->getShortName(), 'Input');
                 if (!$preProcess) {
-                    $gqlConfiguration = self::inputAnnotationToGQLConfiguration(
-                        $classAnnotation, $classAnnotations, $properties, $reflectionEntity->getNamespaceName()
-                    );
+                    $gqlConfiguration = self::inputAnnotationToGQLConfiguration($graphClass, $classAnnotation);
                 }
                 break;
 
             case $classAnnotation instanceof GQL\Scalar:
                 $gqlType = self::GQL_SCALAR;
                 if (!$preProcess) {
-                    $gqlConfiguration = self::scalarAnnotationToGQLConfiguration(
-                        $reflectionEntity->getName(), $classAnnotation, $classAnnotations
-                    );
+                    $gqlConfiguration = self::scalarAnnotationToGQLConfiguration($graphClass, $classAnnotation);
                 }
                 break;
 
             case $classAnnotation instanceof GQL\Enum:
                 $gqlType = self::GQL_ENUM;
                 if (!$preProcess) {
-                    $gqlConfiguration = self::enumAnnotationToGQLConfiguration(
-                        $classAnnotation, $classAnnotations, $reflectionEntity->getConstants()
-                    );
+                    $gqlConfiguration = self::enumAnnotationToGQLConfiguration($graphClass, $classAnnotation);
                 }
                 break;
 
             case $classAnnotation instanceof GQL\Union:
                 $gqlType = self::GQL_UNION;
                 if (!$preProcess) {
-                    $gqlConfiguration = self::unionAnnotationToGQLConfiguration(
-                        $reflectionEntity->getName(), $classAnnotation, $classAnnotations, $methods
-                    );
+                    $gqlConfiguration = self::unionAnnotationToGQLConfiguration($graphClass, $classAnnotation);
                 }
                 break;
 
             case $classAnnotation instanceof GQL\TypeInterface:
                 $gqlType = self::GQL_INTERFACE;
                 if (!$preProcess) {
-                    $gqlConfiguration = self::typeInterfaceAnnotationToGQLConfiguration(
-                        $classAnnotation, $classAnnotations, $properties, $methods, $reflectionEntity->getNamespaceName()
-                    );
+                    $gqlConfiguration = self::typeInterfaceAnnotationToGQLConfiguration($graphClass, $classAnnotation);
                 }
                 break;
 
             case $classAnnotation instanceof GQL\Provider:
                 if ($preProcess) {
-                    self::$providers[$reflectionEntity->getName()] = ['annotation' => $classAnnotation, 'methods' => $methods, 'annotations' => $classAnnotations];
+                    self::$providers[] = ['metadata' => $graphClass, 'annotation' => $classAnnotation];
                 }
                 break;
         }
 
         if (null !== $gqlType) {
             if (!$gqlName) {
-                $gqlName = $classAnnotation->name ?: $reflectionEntity->getShortName();
+                $gqlName = $classAnnotation->name ?: $graphClass->getShortName();
             }
 
             if ($preProcess) {
                 if (isset(self::$classesMap[$gqlName])) {
                     throw new InvalidArgumentException(sprintf('The GraphQL type "%s" has already been registered in class "%s"', $gqlName, self::$classesMap[$gqlName]['class']));
                 }
-                self::$classesMap[$gqlName] = ['type' => $gqlType, 'class' => $reflectionEntity->getName()];
+                self::$classesMap[$gqlName] = ['type' => $gqlType, 'class' => $graphClass->getName()];
             } else {
                 $gqlTypes = [$gqlName => $gqlConfiguration] + $gqlTypes;
             }
@@ -257,57 +237,50 @@ class AnnotationParser implements PreParserInterface
     /**
      * @throws ReflectionException
      */
-    private static function extractClassAnnotations(string $className): array
+    private static function getGraphClass(string $className): GraphClass
     {
-        if (!isset(self::$classAnnotationsCache[$className])) {
-            $annotationReader = self::getAnnotationReader();
-            $reflectionEntity = new ReflectionClass($className); // @phpstan-ignore-line
-            $classAnnotations = $annotationReader->getClassAnnotations($reflectionEntity);
-
-            $properties = [];
-            $reflectionClass = new ReflectionClass($className); // @phpstan-ignore-line
-            do {
-                foreach ($reflectionClass->getProperties() as $property) {
-                    if (isset($properties[$property->getName()])) {
-                        continue;
-                    }
-                    $properties[$property->getName()] = ['property' => $property, 'annotations' => $annotationReader->getPropertyAnnotations($property)];
-                }
-            } while ($reflectionClass = $reflectionClass->getParentClass());
-
-            $methods = [];
-            foreach ($reflectionEntity->getMethods() as $method) {
-                $methods[$method->getName()] = ['method' => $method, 'annotations' => $annotationReader->getMethodAnnotations($method)];
-            }
-
-            self::$classAnnotationsCache[$className] = [$reflectionEntity, $classAnnotations, $properties, $methods];
+        if (!isset(self::$graphClassCache[$className])) {
+            self::$graphClassCache[$className] = new GraphClass($className);
         }
 
-        return self::$classAnnotationsCache[$className];
+        return self::$graphClassCache[$className];
     }
 
     private static function typeAnnotationToGQLConfiguration(
-        ReflectionClass $reflectionEntity,
+        GraphClass $graphClass,
         GQL\Type $classAnnotation,
         string $gqlName,
-        array $classAnnotations,
-        array $properties,
-        array $methods,
         array $configs
     ): array {
-        $rootQueryType = $configs['definitions']['schema']['default']['query'] ?? null;
-        $rootMutationType = $configs['definitions']['schema']['default']['mutation'] ?? null;
-        $isRootQuery = ($rootQueryType && $gqlName === $rootQueryType);
-        $isRootMutation = ($rootMutationType && $gqlName === $rootMutationType);
-        $currentValue = ($isRootQuery || $isRootMutation) ? sprintf("service('%s')", self::formatNamespaceForExpression($reflectionEntity->getName())) : 'value';
+        $isMutation = $isDefault = $isRoot = false;
+        foreach ($configs['definitions']['schema'] as $schemaName => $schema) {
+            $schemaQuery = $schema['query'] ?? null;
+            $schemaMutation = $schema['mutation'] ?? null;
 
-        $gqlConfiguration = self::graphQLTypeConfigFromAnnotation($classAnnotation, $classAnnotations, $properties, $methods, $reflectionEntity->getNamespaceName(), $currentValue);
-        $providerFields = self::getGraphQLFieldsFromProviders($reflectionEntity->getNamespaceName(), $isRootMutation ? 'Mutation' : 'Query', $gqlName, ($isRootQuery || $isRootMutation));
-        $gqlConfiguration['config']['fields'] = $providerFields + $gqlConfiguration['config']['fields'];
+            if ($schemaQuery && $gqlName === $schemaQuery) {
+                $isRoot = true;
+                if ('default' == $schemaName) {
+                    $isDefault = true;
+                }
+            } elseif ($schemaMutation && $gqlName === $schemaMutation) {
+                $isMutation = true;
+                $isRoot = true;
+                if ('default' == $schemaName) {
+                    $isDefault = true;
+                }
+            }
+        }
+
+        $currentValue = $isRoot ? sprintf("service('%s')", self::formatNamespaceForExpression($graphClass->getName())) : 'value';
+
+        $gqlConfiguration = self::graphQLTypeConfigFromAnnotation($graphClass, $classAnnotation, $currentValue);
+
+        $providerFields = self::getGraphQLFieldsFromProviders($graphClass, $isMutation ? GQL\Mutation::class : GQL\Query::class, $gqlName, $isDefault);
+        $gqlConfiguration['config']['fields'] = array_merge($gqlConfiguration['config']['fields'], $providerFields);
 
         if ($classAnnotation instanceof GQL\Relay\Edge) {
-            if (!$reflectionEntity->implementsInterface(EdgeInterface::class)) {
-                throw new InvalidArgumentException(sprintf('The annotation @Edge on class "%s" can only be used on class implementing the EdgeInterface.', $reflectionEntity->getName()));
+            if (!$graphClass->implementsInterface(EdgeInterface::class)) {
+                throw new InvalidArgumentException(sprintf('The annotation @Edge on class "%s" can only be used on class implementing the EdgeInterface.', $graphClass->getName()));
             }
             if (!isset($gqlConfiguration['config']['builders'])) {
                 $gqlConfiguration['config']['builders'] = [];
@@ -318,33 +291,28 @@ class AnnotationParser implements PreParserInterface
         return $gqlConfiguration;
     }
 
-    private static function getAnnotationReader(): AnnotationReader
-    {
-        if (null === self::$annotationReader) {
-            if (!class_exists(AnnotationReader::class) ||
-                !class_exists(AnnotationRegistry::class)) {
-                throw new RuntimeException('In order to use graphql annotation, you need to require doctrine annotations');
-            }
-
-            AnnotationRegistry::registerLoader('class_exists');
-            self::$annotationReader = new AnnotationReader();
-        }
-
-        return self::$annotationReader;
-    }
-
-    private static function graphQLTypeConfigFromAnnotation(GQL\Type $typeAnnotation, array $classAnnotations, array $properties, array $methods, string $namespace, string $currentValue): array
+    private static function graphQLTypeConfigFromAnnotation(GraphClass $graphClass, GQL\Type $typeAnnotation, string $currentValue): array
     {
         $typeConfiguration = [];
+        $fieldsFromProperties = self::getGraphQLTypeFieldsFromAnnotations($graphClass, $graphClass->getPropertiesExtended(), GQL\Field::class, $currentValue);
+        $fieldsFromMethods = self::getGraphQLTypeFieldsFromAnnotations($graphClass, $graphClass->getMethods(), GQL\Field::class, $currentValue);
 
-        $fields = self::getGraphQLFieldsFromAnnotations($namespace, $properties, false, false, $currentValue);
-        $fields = self::getGraphQLFieldsFromAnnotations($namespace, $methods, false, true, $currentValue) + $fields;
-
-        $typeConfiguration['fields'] = $fields;
-        $typeConfiguration = self::getDescriptionConfiguration($classAnnotations) + $typeConfiguration;
+        $typeConfiguration['fields'] = array_merge($fieldsFromProperties, $fieldsFromMethods);
+        $typeConfiguration = self::getDescriptionConfiguration($graphClass->getAnnotations()) + $typeConfiguration;
 
         if ($typeAnnotation->interfaces) {
             $typeConfiguration['interfaces'] = $typeAnnotation->interfaces;
+        } else {
+            $typeConfiguration['interfaces'] = array_keys(self::searchClassesMapBy(function ($gqlType, $configuration) use ($graphClass) {
+                ['class' => $interfaceClassName] = $configuration;
+
+                $interfaceMetadata = self::getGraphClass($interfaceClassName);
+                if ($interfaceMetadata->isInterface() && $graphClass->implementsInterface($interfaceMetadata->getName())) {
+                    return true;
+                }
+
+                return $graphClass->isSubclassOf($interfaceClassName);
+            }, self::GQL_INTERFACE));
         }
 
         if ($typeAnnotation->resolveField) {
@@ -357,12 +325,16 @@ class AnnotationParser implements PreParserInterface
             }, $typeAnnotation->builders);
         }
 
-        $publicAnnotation = self::getFirstAnnotationMatching($classAnnotations, GQL\IsPublic::class);
+        if ($typeAnnotation->isTypeOf) {
+            $typeConfiguration['isTypeOf'] = $typeAnnotation->isTypeOf;
+        }
+
+        $publicAnnotation = self::getFirstAnnotationMatching($graphClass->getAnnotations(), GQL\IsPublic::class);
         if ($publicAnnotation) {
             $typeConfiguration['fieldsDefaultPublic'] = self::formatExpression($publicAnnotation->value);
         }
 
-        $accessAnnotation = self::getFirstAnnotationMatching($classAnnotations, GQL\Access::class);
+        $accessAnnotation = self::getFirstAnnotationMatching($graphClass->getAnnotations(), GQL\Access::class);
         if ($accessAnnotation) {
             $typeConfiguration['fieldsDefaultAccess'] = self::formatExpression($accessAnnotation->value);
         }
@@ -373,15 +345,15 @@ class AnnotationParser implements PreParserInterface
     /**
      * Create a GraphQL Interface type configuration from annotations on properties.
      */
-    private static function typeInterfaceAnnotationToGQLConfiguration(GQL\TypeInterface $interfaceAnnotation, array $classAnnotations, array $properties, array $methods, string $namespace): array
+    private static function typeInterfaceAnnotationToGQLConfiguration(GraphClass $graphClass, GQL\TypeInterface $interfaceAnnotation): array
     {
         $interfaceConfiguration = [];
 
-        $fields = self::getGraphQLFieldsFromAnnotations($namespace, $properties);
-        $fields = self::getGraphQLFieldsFromAnnotations($namespace, $methods, false, true) + $fields;
+        $fieldsFromProperties = self::getGraphQLTypeFieldsFromAnnotations($graphClass, $graphClass->getPropertiesExtended());
+        $fieldsFromMethods = self::getGraphQLTypeFieldsFromAnnotations($graphClass, $graphClass->getMethods());
 
-        $interfaceConfiguration['fields'] = $fields;
-        $interfaceConfiguration = self::getDescriptionConfiguration($classAnnotations) + $interfaceConfiguration;
+        $interfaceConfiguration['fields'] = array_merge($fieldsFromProperties, $fieldsFromMethods);
+        $interfaceConfiguration = self::getDescriptionConfiguration($graphClass->getAnnotations()) + $interfaceConfiguration;
 
         $interfaceConfiguration['resolveType'] = self::formatExpression($interfaceAnnotation->resolveType);
 
@@ -391,13 +363,11 @@ class AnnotationParser implements PreParserInterface
     /**
      * Create a GraphQL Input type configuration from annotations on properties.
      */
-    private static function inputAnnotationToGQLConfiguration(GQL\Input $inputAnnotation, array $classAnnotations, array $properties, string $namespace): array
+    private static function inputAnnotationToGQLConfiguration(GraphClass $graphClass, GQL\Input $inputAnnotation): array
     {
-        $inputConfiguration = [];
-        $fields = self::getGraphQLFieldsFromAnnotations($namespace, $properties, true);
-
-        $inputConfiguration['fields'] = $fields;
-        $inputConfiguration = self::getDescriptionConfiguration($classAnnotations) + $inputConfiguration;
+        $inputConfiguration = array_merge([
+            'fields' => self::getGraphQLInputFieldsFromAnnotations($graphClass, $graphClass->getPropertiesExtended()),
+        ], self::getDescriptionConfiguration($graphClass->getAnnotations()));
 
         return ['type' => $inputAnnotation->isRelay ? 'relay-mutation-input' : 'input-object', 'config' => $inputConfiguration];
     }
@@ -405,7 +375,7 @@ class AnnotationParser implements PreParserInterface
     /**
      * Get a GraphQL scalar configuration from given scalar annotation.
      */
-    private static function scalarAnnotationToGQLConfiguration(string $className, GQL\Scalar $scalarAnnotation, array $classAnnotations): array
+    private static function scalarAnnotationToGQLConfiguration(GraphClass $graphClass, GQL\Scalar $scalarAnnotation): array
     {
         $scalarConfiguration = [];
 
@@ -413,13 +383,13 @@ class AnnotationParser implements PreParserInterface
             $scalarConfiguration['scalarType'] = self::formatExpression($scalarAnnotation->scalarType);
         } else {
             $scalarConfiguration = [
-                'serialize' => [$className, 'serialize'],
-                'parseValue' => [$className, 'parseValue'],
-                'parseLiteral' => [$className, 'parseLiteral'],
+                'serialize' => [$graphClass->getName(), 'serialize'],
+                'parseValue' => [$graphClass->getName(), 'parseValue'],
+                'parseLiteral' => [$graphClass->getName(), 'parseLiteral'],
             ];
         }
 
-        $scalarConfiguration = self::getDescriptionConfiguration($classAnnotations) + $scalarConfiguration;
+        $scalarConfiguration = self::getDescriptionConfiguration($graphClass->getAnnotations()) + $scalarConfiguration;
 
         return ['type' => 'custom-scalar', 'config' => $scalarConfiguration];
     }
@@ -427,13 +397,13 @@ class AnnotationParser implements PreParserInterface
     /**
      * Get a GraphQL Enum configuration from given enum annotation.
      */
-    private static function enumAnnotationToGQLConfiguration(GQL\Enum $enumAnnotation, array $classAnnotations, array $constants): array
+    private static function enumAnnotationToGQLConfiguration(GraphClass $graphClass, GQL\Enum $enumAnnotation): array
     {
         $enumValues = $enumAnnotation->values ? $enumAnnotation->values : [];
 
         $values = [];
 
-        foreach ($constants as $name => $value) {
+        foreach ($graphClass->getConstants() as $name => $value) {
             $valueAnnotation = current(array_filter($enumValues, function ($enumValueAnnotation) use ($name) {
                 return $enumValueAnnotation->name == $name;
             }));
@@ -452,7 +422,7 @@ class AnnotationParser implements PreParserInterface
         }
 
         $enumConfiguration = ['values' => $values];
-        $enumConfiguration = self::getDescriptionConfiguration($classAnnotations) + $enumConfiguration;
+        $enumConfiguration = self::getDescriptionConfiguration($graphClass->getAnnotations()) + $enumConfiguration;
 
         return ['type' => 'enum', 'config' => $enumConfiguration];
     }
@@ -460,18 +430,35 @@ class AnnotationParser implements PreParserInterface
     /**
      * Get a GraphQL Union configuration from given union annotation.
      */
-    private static function unionAnnotationToGQLConfiguration(string $className, GQL\Union $unionAnnotation, array $classAnnotations, array $methods): array
+    private static function unionAnnotationToGQLConfiguration(GraphClass $graphClass, GQL\Union $unionAnnotation): array
     {
-        $unionConfiguration = ['types' => $unionAnnotation->types];
-        $unionConfiguration = self::getDescriptionConfiguration($classAnnotations) + $unionConfiguration;
+        $unionConfiguration = [];
+        if ($unionAnnotation->types) {
+            $unionConfiguration['types'] = $unionAnnotation->types;
+        } else {
+            $unionConfiguration['types'] = array_keys(self::searchClassesMapBy(function ($gqlType, $configuration) use ($graphClass) {
+                $typeClassName = $configuration['class'];
+                ['class' => $typeClassName] = $configuration;
+
+                $typeMetadata = self::getGraphClass($typeClassName);
+
+                if ($graphClass->isInterface() && $typeMetadata->implementsInterface($graphClass->getName())) {
+                    return true;
+                }
+
+                return $typeMetadata->isSubclassOf($graphClass->getName());
+            }, self::GQL_TYPE));
+        }
+
+        $unionConfiguration = self::getDescriptionConfiguration($graphClass->getAnnotations()) + $unionConfiguration;
 
         if ($unionAnnotation->resolveType) {
             $unionConfiguration['resolveType'] = self::formatExpression($unionAnnotation->resolveType);
         } else {
-            if (isset($methods['resolveType'])) {
-                $method = $methods['resolveType']['method'];
+            if ($graphClass->hasMethod('resolveType')) {
+                $method = $graphClass->getMethod('resolveType');
                 if ($method->isStatic() && $method->isPublic()) {
-                    $unionConfiguration['resolveType'] = self::formatExpression(sprintf("@=call('%s::%s', [service('overblog_graphql.type_resolver'), value], true)", self::formatNamespaceForExpression($className), 'resolveType'));
+                    $unionConfiguration['resolveType'] = self::formatExpression(sprintf("@=call('%s::%s', [service('overblog_graphql.type_resolver'), value], true)", self::formatNamespaceForExpression($graphClass->getName()), 'resolveType'));
                 } else {
                     throw new InvalidArgumentException(sprintf('The "resolveType()" method on class must be static and public. Or you must define a "resolveType" attribute on the @Union annotation.'));
                 }
@@ -484,126 +471,149 @@ class AnnotationParser implements PreParserInterface
     }
 
     /**
-     * Create GraphQL fields configuration based on annotations.
+     * @param ReflectionMethod|ReflectionProperty $reflector
      */
-    private static function getGraphQLFieldsFromAnnotations(string $namespace, array $propertiesOrMethods, bool $isInput = false, bool $isMethod = false, string $currentValue = 'value', string $fieldAnnotationName = 'Field'): array
+    private static function getTypeFieldConfigurationFromReflector(GraphClass $graphClass, Reflector $reflector, string $fieldAnnotationName = GQL\Field::class, string $currentValue = 'value'): array
+    {
+        $annotations = $graphClass->getAnnotations($reflector);
+
+        $fieldAnnotation = self::getFirstAnnotationMatching($annotations, $fieldAnnotationName);
+        $accessAnnotation = self::getFirstAnnotationMatching($annotations, GQL\Access::class);
+        $publicAnnotation = self::getFirstAnnotationMatching($annotations, GQL\IsPublic::class);
+
+        $isMethod = $reflector instanceof ReflectionMethod;
+
+        if (!$fieldAnnotation) {
+            if ($accessAnnotation || $publicAnnotation) {
+                throw new InvalidArgumentException(sprintf('The annotations "@Access" and/or "@Visible" defined on "%s" are only usable in addition of annotation "@Field"', $reflector->getName()));
+            }
+
+            return [];
+        }
+
+        if ($isMethod && !$reflector->isPublic()) {
+            throw new InvalidArgumentException(sprintf('The Annotation "@Field" can only be applied to public method. The method "%s" is not public.', $reflector->getName()));
+        }
+
+        $fieldName = $reflector->getName();
+        $fieldType = $fieldAnnotation->type;
+        $fieldConfiguration = [];
+        if ($fieldType) {
+            $fieldConfiguration['type'] = $fieldType;
+        }
+
+        $fieldConfiguration = self::getDescriptionConfiguration($annotations, true) + $fieldConfiguration;
+
+        $args = self::getArgs($fieldAnnotation->args, $isMethod && !$fieldAnnotation->argsBuilder ? $reflector : null);
+
+        if (!empty($args)) {
+            $fieldConfiguration['args'] = $args;
+        }
+
+        $fieldName = $fieldAnnotation->name ?: $fieldName;
+
+        if ($fieldAnnotation->resolve) {
+            $fieldConfiguration['resolve'] = self::formatExpression($fieldAnnotation->resolve);
+        } else {
+            if ($isMethod) {
+                $fieldConfiguration['resolve'] = self::formatExpression(sprintf('call(%s.%s, %s)', $currentValue, $reflector->getName(), self::formatArgsForExpression($args)));
+            } else {
+                if ($fieldName !== $reflector->getName() || 'value' !== $currentValue) {
+                    $fieldConfiguration['resolve'] = self::formatExpression(sprintf('%s.%s', $currentValue, $reflector->getName()));
+                }
+            }
+        }
+
+        if ($fieldAnnotation->argsBuilder) {
+            if (is_string($fieldAnnotation->argsBuilder)) {
+                $fieldConfiguration['argsBuilder'] = $fieldAnnotation->argsBuilder;
+            } elseif (is_array($fieldAnnotation->argsBuilder)) {
+                list($builder, $builderConfig) = $fieldAnnotation->argsBuilder;
+                $fieldConfiguration['argsBuilder'] = ['builder' => $builder, 'config' => $builderConfig];
+            } else {
+                throw new InvalidArgumentException(sprintf('The attribute "argsBuilder" on GraphQL annotation "@%s" defined on "%s" must be a string or an array where first index is the builder name and the second is the config.', $fieldAnnotationName, $reflector->getName()));
+            }
+        }
+
+        if ($fieldAnnotation->fieldBuilder) {
+            if (is_string($fieldAnnotation->fieldBuilder)) {
+                $fieldConfiguration['builder'] = $fieldAnnotation->fieldBuilder;
+            } elseif (is_array($fieldAnnotation->fieldBuilder)) {
+                list($builder, $builderConfig) = $fieldAnnotation->fieldBuilder;
+                $fieldConfiguration['builder'] = $builder;
+                $fieldConfiguration['builderConfig'] = $builderConfig ?: [];
+            } else {
+                throw new InvalidArgumentException(sprintf('The attribute "argsBuilder" on GraphQL annotation "@%s" defined on "%s" must be a string or an array where first index is the builder name and the second is the config.', $fieldAnnotationName, $reflector->getName()));
+            }
+        } else {
+            if (!$fieldType) {
+                if ($isMethod) {
+                    if ($reflector->hasReturnType()) {
+                        try {
+                            $fieldConfiguration['type'] = self::resolveGraphQLTypeFromReflectionType($reflector->getReturnType(), self::VALID_OUTPUT_TYPES);
+                        } catch (Exception $e) {
+                            throw new InvalidArgumentException(sprintf('The attribute "type" on GraphQL annotation "@%s" is missing on method "%s" and cannot be auto-guessed from type hint "%s"', $fieldAnnotationName, $reflector->getName(), (string) $reflector->getReturnType()));
+                        }
+                    } else {
+                        throw new InvalidArgumentException(sprintf('The attribute "type" on GraphQL annotation "@%s" is missing on method "%s" and cannot be auto-guessed as there is not return type hint.', $fieldAnnotationName, $reflector->getName()));
+                    }
+                } else {
+                    try {
+                        $fieldConfiguration['type'] = self::guessType($graphClass, $annotations);
+                    } catch (Exception $e) {
+                        throw new InvalidArgumentException(sprintf('The attribute "type" on "@%s" defined on "%s" is required and cannot be auto-guessed : %s.', $fieldAnnotationName, $reflector->getName(), $e->getMessage()));
+                    }
+                }
+            }
+        }
+
+        if ($accessAnnotation) {
+            $fieldConfiguration['access'] = self::formatExpression($accessAnnotation->value);
+        }
+
+        if ($publicAnnotation) {
+            $fieldConfiguration['public'] = self::formatExpression($publicAnnotation->value);
+        }
+
+        if ($fieldAnnotation->complexity) {
+            $fieldConfiguration['complexity'] = self::formatExpression($fieldAnnotation->complexity);
+        }
+
+        return [$fieldName => $fieldConfiguration];
+    }
+
+    /**
+     * Create GraphQL input fields configuration based on annotations.
+     *
+     * @param ReflectionProperty[] $reflectors
+     */
+    private static function getGraphQLInputFieldsFromAnnotations(GraphClass $graphClass, array $reflectors): array
     {
         $fields = [];
-        foreach ($propertiesOrMethods as $target => $config) {
-            $annotations = $config['annotations'];
-            $method = $isMethod ? $config['method'] : false;
 
-            $fieldAnnotation = self::getFirstAnnotationMatching($annotations, sprintf('Overblog\GraphQLBundle\Annotation\%s', $fieldAnnotationName));
-            $accessAnnotation = self::getFirstAnnotationMatching($annotations, GQL\Access::class);
-            $publicAnnotation = self::getFirstAnnotationMatching($annotations, GQL\IsPublic::class);
-
-            if (!$fieldAnnotation) {
-                if ($accessAnnotation || $publicAnnotation) {
-                    throw new InvalidArgumentException(sprintf('The annotations "@Access" and/or "@Visible" defined on "%s" are only usable in addition of annotation "@Field"', $target));
-                }
-                continue;
-            }
-
-            if ($isMethod && !$method->isPublic()) {
-                throw new InvalidArgumentException(sprintf('The Annotation "@Field" can only be applied to public method. The method "%s" is not public.', $target));
-            }
+        foreach ($reflectors as $reflector) {
+            $annotations = $graphClass->getAnnotations($reflector);
+            $fieldAnnotation = self::getFirstAnnotationMatching($annotations, GQL\Field::class);
 
             // Ignore field with resolver when the type is an Input
-            if ($fieldAnnotation->resolve && $isInput) {
-                continue;
+            if ($fieldAnnotation->resolve) {
+                return [];
             }
 
-            $fieldName = $target;
+            $fieldName = $reflector->getName();
             $fieldType = $fieldAnnotation->type;
             $fieldConfiguration = [];
             if ($fieldType) {
                 $resolvedType = self::resolveClassFromType($fieldType);
-                if (null !== $resolvedType && $isInput && !in_array($resolvedType['type'], self::VALID_INPUT_TYPES)) {
-                    throw new InvalidArgumentException(sprintf('The type "%s" on "%s" is a "%s" not valid on an Input @Field. Only Input, Scalar and Enum are allowed.', $fieldType, $target, $resolvedType['type']));
+                // We found a type but it is not allowed
+                if (null !== $resolvedType && !in_array($resolvedType['type'], self::VALID_INPUT_TYPES)) {
+                    throw new InvalidArgumentException(sprintf('The type "%s" on "%s" is a "%s" not valid on an Input @Field. Only Input, Scalar and Enum are allowed.', $fieldType, $reflector->getName(), $resolvedType['type']));
                 }
 
                 $fieldConfiguration['type'] = $fieldType;
             }
 
-            $fieldConfiguration = self::getDescriptionConfiguration($annotations, true) + $fieldConfiguration;
-
-            if (!$isInput) {
-                $args = self::getArgs($fieldAnnotation->args, $isMethod && !$fieldAnnotation->argsBuilder ? $method : null);
-
-                if (!empty($args)) {
-                    $fieldConfiguration['args'] = $args;
-                }
-
-                $fieldName = $fieldAnnotation->name ?: $fieldName;
-
-                if ($fieldAnnotation->resolve) {
-                    $fieldConfiguration['resolve'] = self::formatExpression($fieldAnnotation->resolve);
-                } else {
-                    if ($isMethod) {
-                        $fieldConfiguration['resolve'] = self::formatExpression(sprintf('call(%s.%s, %s)', $currentValue, $target, self::formatArgsForExpression($args)));
-                    } else {
-                        if ($fieldName !== $target || 'value' !== $currentValue) {
-                            $fieldConfiguration['resolve'] = self::formatExpression(sprintf('%s.%s', $currentValue, $target));
-                        }
-                    }
-                }
-
-                if ($fieldAnnotation->argsBuilder) {
-                    if (is_string($fieldAnnotation->argsBuilder)) {
-                        $fieldConfiguration['argsBuilder'] = $fieldAnnotation->argsBuilder;
-                    } elseif (is_array($fieldAnnotation->argsBuilder)) {
-                        list($builder, $builderConfig) = $fieldAnnotation->argsBuilder;
-                        $fieldConfiguration['argsBuilder'] = ['builder' => $builder, 'config' => $builderConfig];
-                    } else {
-                        throw new InvalidArgumentException(sprintf('The attribute "argsBuilder" on GraphQL annotation "@%s" defined on "%s" must be a string or an array where first index is the builder name and the second is the config.', $fieldAnnotationName, $target));
-                    }
-                }
-
-                if ($fieldAnnotation->fieldBuilder) {
-                    if (is_string($fieldAnnotation->fieldBuilder)) {
-                        $fieldConfiguration['builder'] = $fieldAnnotation->fieldBuilder;
-                    } elseif (is_array($fieldAnnotation->fieldBuilder)) {
-                        list($builder, $builderConfig) = $fieldAnnotation->fieldBuilder;
-                        $fieldConfiguration['builder'] = $builder;
-                        $fieldConfiguration['builderConfig'] = $builderConfig ?: [];
-                    } else {
-                        throw new InvalidArgumentException(sprintf('The attribute "argsBuilder" on GraphQL annotation "@%s" defined on "%s" must be a string or an array where first index is the builder name and the second is the config.', $fieldAnnotationName, $target));
-                    }
-                } else {
-                    if (!$fieldType) {
-                        if ($isMethod) {
-                            if ($method->hasReturnType()) {
-                                try {
-                                    $fieldConfiguration['type'] = self::resolveGraphQLTypeFromReflectionType($method->getReturnType(), self::VALID_OUTPUT_TYPES);
-                                } catch (Exception $e) {
-                                    throw new InvalidArgumentException(sprintf('The attribute "type" on GraphQL annotation "@%s" is missing on method "%s" and cannot be auto-guessed from type hint "%s"', $fieldAnnotationName, $target, (string) $method->getReturnType()));
-                                }
-                            } else {
-                                throw new InvalidArgumentException(sprintf('The attribute "type" on GraphQL annotation "@%s" is missing on method "%s" and cannot be auto-guessed as there is not return type hint.', $fieldAnnotationName, $target));
-                            }
-                        } else {
-                            try {
-                                $fieldConfiguration['type'] = self::guessType($namespace, $annotations);
-                            } catch (Exception $e) {
-                                throw new InvalidArgumentException(sprintf('The attribute "type" on "@%s" defined on "%s" is required and cannot be auto-guessed : %s.', $fieldAnnotationName, $target, $e->getMessage()));
-                            }
-                        }
-                    }
-                }
-
-                if ($accessAnnotation) {
-                    $fieldConfiguration['access'] = self::formatExpression($accessAnnotation->value);
-                }
-
-                if ($publicAnnotation) {
-                    $fieldConfiguration['public'] = self::formatExpression($publicAnnotation->value);
-                }
-
-                if ($fieldAnnotation->complexity) {
-                    $fieldConfiguration['complexity'] = self::formatExpression($fieldAnnotation->complexity);
-                }
-            }
-
+            $fieldConfiguration = array_merge(self::getDescriptionConfiguration($annotations, true), $fieldConfiguration);
             $fields[$fieldName] = $fieldConfiguration;
         }
 
@@ -611,45 +621,71 @@ class AnnotationParser implements PreParserInterface
     }
 
     /**
-     * Return fields config from Provider methods.
+     * Create GraphQL type fields configuration based on annotations.
+     *
+     * @param ReflectionProperty[]|ReflectionMethod[] $reflectors
      */
-    private static function getGraphQLFieldsFromProviders(string $namespace, string $annotationName, string $targetType, bool $isRoot = false): array
+    private static function getGraphQLTypeFieldsFromAnnotations(GraphClass $graphClass, array $reflectors, string $fieldAnnotationName = GQL\Field::class, string $currentValue = 'value'): array
     {
         $fields = [];
-        foreach (self::$providers as $className => $configuration) {
-            $providerMethods = $configuration['methods'];
-            $providerAnnotation = $configuration['annotation'];
-            $providerAnnotations = $configuration['annotations'];
 
-            $defaultAccessAnnotation = self::getFirstAnnotationMatching($providerAnnotations, GQL\Access::class);
-            $defaultIsPublicAnnotation = self::getFirstAnnotationMatching($providerAnnotations, GQL\IsPublic::class);
+        foreach ($reflectors as $reflector) {
+            $fields = array_merge($fields, self::getTypeFieldConfigurationFromReflector($graphClass, $reflector, $fieldAnnotationName, $currentValue));
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Return fields config from Provider methods.
+     * Loop through configured provider and extract fields targeting the targetType.
+     */
+    private static function getGraphQLFieldsFromProviders(GraphClass $graphClass, string $expectedAnnotation, string $targetType, bool $isDefaultTarget = false): array
+    {
+        $fields = [];
+        foreach (self::$providers as ['metadata' => $providerMetadata, 'annotation' => $providerAnnotation]) {
+            $defaultAccessAnnotation = self::getFirstAnnotationMatching($providerMetadata->getAnnotations(), GQL\Access::class);
+            $defaultIsPublicAnnotation = self::getFirstAnnotationMatching($providerMetadata->getAnnotations(), GQL\IsPublic::class);
 
             $defaultAccess = $defaultAccessAnnotation ? self::formatExpression($defaultAccessAnnotation->value) : false;
             $defaultIsPublic = $defaultIsPublicAnnotation ? self::formatExpression($defaultIsPublicAnnotation->value) : false;
 
-            $filteredMethods = [];
-            foreach ($providerMethods as $methodName => $config) {
-                $annotations = $config['annotations'];
+            $methods = [];
+            // First found the methods matching the targeted type
+            foreach ($providerMetadata->getMethods() as $method) {
+                $annotations = $providerMetadata->getAnnotations($method);
 
-                $annotation = self::getFirstAnnotationMatching($annotations, sprintf('Overblog\\GraphQLBundle\\Annotation\\%s', $annotationName));
+                $annotation = self::getFirstAnnotationMatching($annotations, [GQL\Mutation::class, GQL\Query::class]);
                 if (!$annotation) {
                     continue;
                 }
 
-                $annotationTarget = 'Query' === $annotationName ? $annotation->targetType : null;
-                if (!$annotationTarget && $isRoot) {
+                $annotationTarget = $annotation->targetType;
+                if (!$annotationTarget && $isDefaultTarget) {
                     $annotationTarget = $targetType;
+                    if (!($annotation instanceof $expectedAnnotation)) {
+                        continue;
+                    }
                 }
 
                 if ($annotationTarget !== $targetType) {
                     continue;
                 }
 
-                $filteredMethods[$methodName] = $config;
+                if (!($annotation instanceof $expectedAnnotation)) {
+                    if (GQL\Mutation::class == $expectedAnnotation) {
+                        $message = sprintf('The provider "%s" try to add a query field on type "%s" (through @Query on method "%s") but "%s" is a mutation.', $providerMetadata->getName(), $targetType, $method->getName(), $targetType);
+                    } else {
+                        $message = sprintf('The provider "%s" try to add a mutation on type "%s" (through @Mutation on method "%s") but "%s" is not a mutation.', $providerMetadata->getName(), $targetType, $method->getName(), $targetType);
+                    }
+
+                    throw new InvalidArgumentException($message);
+                }
+                $methods[$method->getName()] = $method;
             }
 
-            $currentValue = sprintf("service('%s')", self::formatNamespaceForExpression($className));
-            $providerFields = self::getGraphQLFieldsFromAnnotations($namespace, $filteredMethods, false, true, $currentValue, $annotationName);
+            $currentValue = sprintf("service('%s')", self::formatNamespaceForExpression($providerMetadata->getName()));
+            $providerFields = self::getGraphQLTypeFieldsFromAnnotations($graphClass, $methods, $expectedAnnotation, $currentValue);
             foreach ($providerFields as $fieldName => $fieldConfig) {
                 if ($providerAnnotation->prefix) {
                     $fieldName = sprintf('%s%s', $providerAnnotation->prefix, $fieldName);
@@ -772,11 +808,11 @@ class AnnotationParser implements PreParserInterface
     }
 
     /**
-     * Try to guess a field type base on is annotations.
+     * Try to guess a field type base on his annotations.
      *
      * @throws RuntimeException
      */
-    private static function guessType(string $namespace, array $annotations): string
+    private static function guessType(GraphClass $graphClass, array $annotations): string
     {
         $columnAnnotation = self::getFirstAnnotationMatching($annotations, Column::class);
         if ($columnAnnotation) {
@@ -798,7 +834,7 @@ class AnnotationParser implements PreParserInterface
 
         $associationAnnotation = self::getFirstAnnotationMatching($annotations, array_keys($associationAnnotations));
         if ($associationAnnotation) {
-            $target = self::fullyQualifiedClassName($associationAnnotation->targetEntity, $namespace);
+            $target = self::fullyQualifiedClassName($associationAnnotation->targetEntity, $graphClass->getNamespaceName());
             $type = self::resolveTypeFromClass($target, ['type']);
 
             if ($type) {
@@ -937,6 +973,27 @@ class AnnotationParser implements PreParserInterface
     private static function resolveClassFromType(string $type)
     {
         return self::$classesMap[$type] ?? null;
+    }
+
+    /**
+     * Search the classes map for class by predicate.
+     *
+     * @return array
+     */
+    private static function searchClassesMapBy(callable $predicate, string $type = null)
+    {
+        $classNames = [];
+        foreach (self::$classesMap as $gqlType => $config) {
+            if ($type && $config['type'] !== $type) {
+                continue;
+            }
+
+            if ($predicate($gqlType, $config)) {
+                $classNames[$gqlType] = $config;
+            }
+        }
+
+        return $classNames;
     }
 
     /**

--- a/src/Config/Parser/AnnotationParser.php
+++ b/src/Config/Parser/AnnotationParser.php
@@ -213,7 +213,8 @@ class AnnotationParser implements PreParserInterface
                 if ($preProcess) {
                     self::$providers[] = ['metadata' => $graphClass, 'annotation' => $classAnnotation];
                 }
-                break;
+
+                return [];
         }
 
         if (null !== $gqlType) {
@@ -239,9 +240,7 @@ class AnnotationParser implements PreParserInterface
      */
     private static function getGraphClass(string $className): GraphClass
     {
-        if (!isset(self::$graphClassCache[$className])) {
-            self::$graphClassCache[$className] = new GraphClass($className);
-        }
+        self::$graphClassCache[$className] ??= new GraphClass($className);
 
         return self::$graphClassCache[$className];
     }
@@ -302,7 +301,7 @@ class AnnotationParser implements PreParserInterface
         $typeConfiguration['fields'] = array_merge($fieldsFromProperties, $fieldsFromMethods);
         $typeConfiguration = self::getDescriptionConfiguration($graphClass->getAnnotations()) + $typeConfiguration;
 
-        if ($typeAnnotation->interfaces) {
+        if (null !== $typeAnnotation->interfaces) {
             $typeConfiguration['interfaces'] = $typeAnnotation->interfaces;
         } else {
             $typeConfiguration['interfaces'] = array_keys(self::searchClassesMapBy(function ($gqlType, $configuration) use ($graphClass) {
@@ -435,7 +434,7 @@ class AnnotationParser implements PreParserInterface
     private static function unionAnnotationToGQLConfiguration(GraphClass $graphClass, GQL\Union $unionAnnotation): array
     {
         $unionConfiguration = [];
-        if ($unionAnnotation->types) {
+        if (null !== $unionAnnotation->types) {
             $unionConfiguration['types'] = $unionAnnotation->types;
         } else {
             $types = array_keys(self::searchClassesMapBy(function ($gqlType, $configuration) use ($graphClass) {
@@ -550,6 +549,7 @@ class AnnotationParser implements PreParserInterface
         } else {
             if (!$fieldType) {
                 if ($isMethod) {
+                    /** @var ReflectionMethod $reflector */
                     if ($reflector->hasReturnType()) {
                         try {
                             $fieldConfiguration['type'] = self::resolveGraphQLTypeFromReflectionType($reflector->getReturnType(), self::VALID_OUTPUT_TYPES);

--- a/src/DependencyInjection/OverblogGraphQLExtension.php
+++ b/src/DependencyInjection/OverblogGraphQLExtension.php
@@ -31,6 +31,7 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\Validator\Validation;
 use function array_fill_keys;
 use function class_exists;
 use function realpath;
@@ -105,7 +106,7 @@ class OverblogGraphQLExtension extends Extension
 
     private function registerValidatorFactory(ContainerBuilder $container): void
     {
-        if (class_exists('Symfony\\Component\\Validator\\Validation')) {
+        if (class_exists(Validation::class)) {
             $container->register(ValidatorFactory::class)
                 ->setArguments([
                     new Reference('validator.validator_factory'),

--- a/tests/Config/Parser/AnnotationParserTest.php
+++ b/tests/Config/Parser/AnnotationParserTest.php
@@ -22,6 +22,7 @@ class AnnotationParserTest extends TestCase
         'definitions' => [
             'schema' => [
                 'default' => ['query' => 'RootQuery', 'mutation' => 'RootMutation'],
+                'second' => ['query' => 'RootQuery2', 'mutation' => 'RootMutation2'],
             ],
         ],
         'doctrine' => [
@@ -99,6 +100,7 @@ class AnnotationParserTest extends TestCase
         $this->expect('Droid', 'object', [
             'description' => 'The Droid type',
             'interfaces' => ['Character'],
+            'isTypeOf' => "@=isTypeOf('App\Entity\Droid')",
             'fields' => [
                 'name' => ['type' => 'String!', 'description' => 'The name of the character'],
                 'friends' => ['type' => '[Character]', 'description' => 'The friends of the character', 'resolve' => "@=resolver('App\\\\MyResolver::getFriends')"],
@@ -211,6 +213,25 @@ class AnnotationParserTest extends TestCase
         ]);
     }
 
+    public function testUnionAutoguessed(): void
+    {
+        $this->expect('Killable', 'union', [
+            'types' => ['Mandalorian', 'Hero', 'Sith'],
+            'resolveType' => '@=value.getType()',
+        ]);
+    }
+
+    public function testInterfaceAutoguessed(): void
+    {
+        $this->expect('Mandalorian', 'object', [
+            'interfaces' => ['Character'],
+            'fields' => [
+                'name' => ['type' => 'String!', 'description' => 'The name of the character'],
+                'friends' => ['type' => '[Character]', 'description' => 'The friends of the character', 'resolve' => "@=resolver('App\\\\MyResolver::getFriends')"],
+            ],
+        ]);
+    }
+
     public function testScalar(): void
     {
         $this->expect('GalaxyCoordinates', 'custom-scalar', [
@@ -241,6 +262,32 @@ class AnnotationParserTest extends TestCase
                     'type' => 'Planet',
                     'args' => ['planetInput' => ['type' => 'PlanetInput!']],
                     'resolve' => "@=call(service('Overblog\\\\GraphQLBundle\\\\Tests\\\\Config\\\\Parser\\\\fixtures\\\\annotations\\\\Repository\\\\PlanetRepository').createPlanet, arguments({planetInput: \"PlanetInput!\"}, args))",
+                    'access' => '@=default_access',
+                    'public' => '@=override_public',
+                ],
+            ],
+        ]);
+    }
+
+    public function testProvidersMultischema(): void
+    {
+        $this->expect('RootQuery2', 'object', [
+            'fields' => [
+                'planet_getPlanetSchema2' => [
+                    'type' => 'Planet',
+                    'resolve' => "@=call(service('Overblog\\\\GraphQLBundle\\\\Tests\\\\Config\\\\Parser\\\\fixtures\\\\annotations\\\\Repository\\\\PlanetRepository').getPlanetSchema2, arguments({}, args))",
+                    'access' => '@=default_access',
+                    'public' => '@=default_public',
+                ],
+            ],
+        ]);
+
+        $this->expect('RootMutation2', 'object', [
+            'fields' => [
+                'planet_createPlanetSchema2' => [
+                    'type' => 'Planet',
+                    'args' => ['planetInput' => ['type' => 'PlanetInput!']],
+                    'resolve' => "@=call(service('Overblog\\\\GraphQLBundle\\\\Tests\\\\Config\\\\Parser\\\\fixtures\\\\annotations\\\\Repository\\\\PlanetRepository').createPlanetSchema2, arguments({planetInput: \"PlanetInput!\"}, args))",
                     'access' => '@=default_access',
                     'public' => '@=override_public',
                 ],
@@ -404,6 +451,35 @@ class AnnotationParserTest extends TestCase
         } catch (Exception $e) {
             $this->assertInstanceOf(InvalidArgumentException::class, $e);
             $this->assertMatchesRegularExpression('/The Annotation "@Field" can only be applied to public method/', $e->getPrevious()->getMessage());
+        }
+    }
+
+    public function testInvalidProviderQueryOnMutation(): void
+    {
+        $file = __DIR__.'/fixtures/annotations/Invalid/InvalidProvider.php';
+        AnnotationParser::preParse(new SplFileInfo($file), $this->containerBuilder, $this->parserConfig);
+
+        try {
+            $mutationFile = __DIR__.'/fixtures/annotations/Type/RootMutation2.php';
+            AnnotationParser::parse(new SplFileInfo($mutationFile), $this->containerBuilder, $this->parserConfig);
+            $this->fail('Using @Query targeting mutation type should raise an exception');
+        } catch (Exception $e) {
+            $this->assertInstanceOf(InvalidArgumentException::class, $e);
+            $this->assertMatchesRegularExpression('/try to add a query field on type "RootMutation2"/', $e->getPrevious()->getMessage());
+        }
+    }
+
+    public function testInvalidProviderMutationOnQuery(): void
+    {
+        $file = __DIR__.'/fixtures/annotations/Invalid/InvalidProvider.php';
+        AnnotationParser::preParse(new SplFileInfo($file), $this->containerBuilder, $this->parserConfig);
+        try {
+            $queryFile = __DIR__.'/fixtures/annotations/Type/RootQuery2.php';
+            AnnotationParser::parse(new SplFileInfo($queryFile), $this->containerBuilder, $this->parserConfig);
+            $this->fail('Using @Mutation targeting query type should raise an exception');
+        } catch (Exception $e) {
+            $this->assertInstanceOf(InvalidArgumentException::class, $e);
+            $this->assertMatchesRegularExpression('/try to add a mutation on type "RootQuery2"/', $e->getPrevious()->getMessage());
         }
     }
 }

--- a/tests/Config/Parser/AnnotationParserTest.php
+++ b/tests/Config/Parser/AnnotationParserTest.php
@@ -216,7 +216,7 @@ class AnnotationParserTest extends TestCase
     public function testUnionAutoguessed(): void
     {
         $this->expect('Killable', 'union', [
-            'types' => ['Mandalorian', 'Hero', 'Sith'],
+            'types' => ['Hero', 'Mandalorian',  'Sith'],
             'resolveType' => '@=value.getType()',
         ]);
     }

--- a/tests/Config/Parser/AnnotationParserTest.php
+++ b/tests/Config/Parser/AnnotationParserTest.php
@@ -224,7 +224,7 @@ class AnnotationParserTest extends TestCase
     public function testInterfaceAutoguessed(): void
     {
         $this->expect('Mandalorian', 'object', [
-            'interfaces' => ['Character'],
+            'interfaces' => ['Armored', 'Character'],
             'fields' => [
                 'name' => ['type' => 'String!', 'description' => 'The name of the character'],
                 'friends' => ['type' => '[Character]', 'description' => 'The friends of the character', 'resolve' => "@=resolver('App\\\\MyResolver::getFriends')"],

--- a/tests/Config/Parser/fixtures/annotations/Invalid/InvalidProvider.php
+++ b/tests/Config/Parser/fixtures/annotations/Invalid/InvalidProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Invalid;
+
+use Overblog\GraphQLBundle\Annotation as GQL;
+
+/**
+ * @GQL\Provider
+ */
+class InvalidProvider
+{
+    /**
+     * @GQL\Query(type="Int", targetType="RootMutation2")
+     */
+    public function noQueryOnMutation(): array
+    {
+        return [];
+    }
+
+    /**
+     * @GQL\Mutation(type="Int", targetType="RootQuery2")
+     */
+    public function noMutationOnQuery(): array
+    {
+        return [];
+    }
+}

--- a/tests/Config/Parser/fixtures/annotations/Repository/PlanetRepository.php
+++ b/tests/Config/Parser/fixtures/annotations/Repository/PlanetRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Repository;
 
 use Overblog\GraphQLBundle\Annotation as GQL;
+use Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Type\Planet;
 
 /**
  * @GQL\Provider(prefix="planet_")
@@ -39,6 +40,25 @@ class PlanetRepository
      * @GQL\Access("override_access")
      */
     public function getAllowedPlanetsForDroids(): array
+    {
+        return [];
+    }
+
+    /**
+     * @GQL\Query(type="Planet", targetType="RootQuery2")
+     */
+    public function getPlanetSchema2(): ?Planet
+    {
+        return null;
+    }
+
+    /**
+     * @GQL\Mutation(type="Planet", targetType="RootMutation2", args={
+     *    @GQL\Arg(type="PlanetInput!", name="planetInput")
+     * })
+     * @GQL\IsPublic("override_public")
+     */
+    public function createPlanetSchema2(array $planetInput): array
     {
         return [];
     }

--- a/tests/Config/Parser/fixtures/annotations/Type/Armored.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/Armored.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Type;
 
 use Overblog\GraphQLBundle\Annotation as GQL;
-use Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Union\Killable;
 
 /**
- * @GQL\Type
+ * @GQL\TypeInterface(resolveType="@=resolver('character_type', [value])")
+ * @GQL\Description("The armored interface")
  */
-class Mandalorian extends Character implements Killable, Armored
+interface Armored
 {
 }

--- a/tests/Config/Parser/fixtures/annotations/Type/Droid.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/Droid.php
@@ -7,7 +7,7 @@ namespace Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Type;
 use Overblog\GraphQLBundle\Annotation as GQL;
 
 /**
- * @GQL\Type(interfaces={"Character"})
+ * @GQL\Type(isTypeOf="@=isTypeOf('App\Entity\Droid')")
  * @GQL\Description("The Droid type")
  */
 class Droid extends Character

--- a/tests/Config/Parser/fixtures/annotations/Type/Hero.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/Hero.php
@@ -6,12 +6,13 @@ namespace Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Type;
 
 use Overblog\GraphQLBundle\Annotation as GQL;
 use Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Enum\Race;
+use Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Union\Killable;
 
 /**
  * @GQL\Type(interfaces={"Character"})
  * @GQL\Description("The Hero type")
  */
-class Hero extends Character
+class Hero extends Character implements Killable
 {
     /**
      * @GQL\Field(type="Race")

--- a/tests/Config/Parser/fixtures/annotations/Type/Mandalorian.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/Mandalorian.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Type;
+
+use Overblog\GraphQLBundle\Annotation as GQL;
+use Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Union\Killable;
+
+/**
+ * @GQL\Type
+ */
+class Mandalorian extends Character implements Killable
+{
+}

--- a/tests/Config/Parser/fixtures/annotations/Type/RootMutation2.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/RootMutation2.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Type;
+
+use Overblog\GraphQLBundle\Annotation as GQL;
+
+/**
+ * @GQL\Type
+ */
+class RootMutation2
+{
+}

--- a/tests/Config/Parser/fixtures/annotations/Type/RootQuery2.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/RootQuery2.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Type;
+
+use Overblog\GraphQLBundle\Annotation as GQL;
+
+/**
+ * @GQL\Type
+ */
+class RootQuery2
+{
+}

--- a/tests/Config/Parser/fixtures/annotations/Type/Sith.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/Sith.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Type;
 
 use Overblog\GraphQLBundle\Annotation as GQL;
+use Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Union\Killable;
 
 /**
  * @GQL\Type(interfaces={"Character"}, resolveField="value")
@@ -12,7 +13,7 @@ use Overblog\GraphQLBundle\Annotation as GQL;
  * @GQL\Access("isAuthenticated()")
  * @GQL\IsPublic("isAuthenticated()")
  */
-class Sith extends Character
+class Sith extends Character implements Killable
 {
     /**
      * @GQL\Field(type="String!")

--- a/tests/Config/Parser/fixtures/annotations/Union/Killable.php
+++ b/tests/Config/Parser/fixtures/annotations/Union/Killable.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Union;
+
+use Overblog\GraphQLBundle\Annotation as GQL;
+
+/**
+ * @GQL\Union(resolveType="value.getType()")
+ */
+interface Killable
+{
+}

--- a/tests/EventListener/ValidationErrorsListenerTest.php
+++ b/tests/EventListener/ValidationErrorsListenerTest.php
@@ -12,6 +12,7 @@ use Overblog\GraphQLBundle\EventListener\ValidationErrorsListener;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Validation;
 use function class_exists;
 
 class ValidationErrorsListenerTest extends TestCase
@@ -21,7 +22,7 @@ class ValidationErrorsListenerTest extends TestCase
 
     protected function setUp(): void
     {
-        if (!class_exists('Symfony\\Component\\Validator\\Validation')) {
+        if (!class_exists(Validation::class)) {
             $this->markTestSkipped('Symfony validator component is not installed');
         }
         $this->listener = new ValidationErrorsListener();

--- a/tests/ExpressionLanguage/ExpressionFunction/GraphQL/ArgumentsTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/GraphQL/ArgumentsTest.php
@@ -15,6 +15,7 @@ use Overblog\GraphQLBundle\Tests\Transformer\Enum1;
 use Overblog\GraphQLBundle\Tests\Transformer\InputType1;
 use Overblog\GraphQLBundle\Tests\Transformer\InputType2;
 use Overblog\GraphQLBundle\Transformer\ArgumentsTransformer;
+use Symfony\Component\Validator\Validation;
 use Symfony\Component\Validator\Validator\RecursiveValidator;
 use function class_exists;
 use function count;
@@ -23,7 +24,7 @@ class ArgumentsTest extends TestCase
 {
     public function setUp(): void
     {
-        if (!class_exists('Symfony\\Component\\Validator\\Validation')) {
+        if (!class_exists(Validation::class)) {
             $this->markTestSkipped('Symfony validator component is not installed');
         }
         parent::setUp();

--- a/tests/Functional/Validator/InputValidatorTest.php
+++ b/tests/Functional/Validator/InputValidatorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Tests\Functional\Validator;
 
 use Overblog\GraphQLBundle\Tests\Functional\TestCase;
+use Symfony\Component\Validator\Validation;
 use function class_exists;
 use function json_decode;
 
@@ -13,7 +14,7 @@ class InputValidatorTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        if (!class_exists('Symfony\\Component\\Validator\\Validation')) {
+        if (!class_exists(Validation::class)) {
             $this->markTestSkipped('Symfony validator component is not installed');
         }
         static::bootKernel(['test_case' => 'validator']);

--- a/tests/Transformer/ArgumentsTransformerTest.php
+++ b/tests/Transformer/ArgumentsTransformerTest.php
@@ -16,6 +16,7 @@ use Overblog\GraphQLBundle\Transformer\ArgumentsTransformer;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Validation;
 use Symfony\Component\Validator\Validator\RecursiveValidator;
 use function class_exists;
 use function count;
@@ -26,7 +27,7 @@ class ArgumentsTransformerTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        if (!class_exists('Symfony\\Component\\Validator\\Validation')) {
+        if (!class_exists(Validation::class)) {
             $this->markTestSkipped('Symfony validator component is not installed');
         }
     }

--- a/tests/Validator/InputValidatorTest.php
+++ b/tests/Validator/InputValidatorTest.php
@@ -9,6 +9,7 @@ use Overblog\GraphQLBundle\Validator\ValidatorFactory;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\Validator\ConstraintValidatorFactory;
+use Symfony\Component\Validator\Validation;
 use function class_exists;
 
 class InputValidatorTest extends TestCase
@@ -16,7 +17,7 @@ class InputValidatorTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        if (!class_exists('Symfony\\Component\\Validator\\Validation')) {
+        if (!class_exists(Validation::class)) {
             $this->markTestSkipped('Symfony validator component is not installed');
         }
     }

--- a/tests/Validator/Mapping/MetadataFactoryTest.php
+++ b/tests/Validator/Mapping/MetadataFactoryTest.php
@@ -11,13 +11,14 @@ use Overblog\GraphQLBundle\Validator\ValidationNode;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Symfony\Component\Validator\Exception\NoSuchMetadataException;
+use Symfony\Component\Validator\Validation;
 use function class_exists;
 
 class MetadataFactoryTest extends TestCase
 {
     public function setUp(): void
     {
-        if (!class_exists('Symfony\\Component\\Validator\\Validation')) {
+        if (!class_exists(Validation::class)) {
             $this->markTestSkipped('Symfony validator component is not installed');
         }
         parent::setUp();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? |no
| Tests pass?   | yes
| Documented?   | not yet
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

- Annotations Refactoring (with a GraphClass)
- Add missing `isTypeOf` on `@GQL\Type`
- Add `targetType` on `@GQL\Mutation` to handle multiple schema #526
- Autodiscover Interfaces for `@GQL\Type` based on PHP interfaces or parent classes #701
- Autodiscover Union types for `@GQL\Union` based on PHP interfaces or children classes #701
