### PR TITLE
Add schema name as Executor argument & fix default schema

### DIFF
--- a/docs/annotations/annotations-reference.md
+++ b/docs/annotations/annotations-reference.md
@@ -386,7 +386,7 @@ The class exposing the mutation(s) must be declared as a [service](https://symfo
 
 Optional attributes:
 
--   **targetType** : The GraphQL type to attach the field to. It must be a mutation. (by default, it'll be the root Mutation type of the default schema).
+-   **targetType** : The GraphQL type to attach the field to. It must be a mutation. (by default, it'll be the root Mutation type of the default schema. see [Default Schema](../definitions/schema.md#default-schema)).
 
 Example:
 
@@ -436,7 +436,7 @@ The class exposing the query(ies) must be declared as a [service](https://symfon
 
 Optional attributes:
 
--   **targetType** : The GraphQL type to attach the field to (by default, it'll be the root Query type of the default schema).
+-   **targetType** : The GraphQL type to attach the field to (by default, it'll be the root Query type of the default schema. see [Default Schema](../definitions/schema.md#default-schema)).
 
 Example:
 

--- a/docs/definitions/schema.md
+++ b/docs/definitions/schema.md
@@ -111,4 +111,8 @@ overblog_graphql:
 | batch request  | `/graphql/bar/batch` |
 | GraphiQL*      | `/graphiql/bar`      |
 
+### Default schema
+
+The schema considered as the default is the one with the name `default` if it exists, otherwise, it will be the first one defined.  
+
 \* `/graphiql` depends on [OverblogGraphiQLBundle](https://github.com/overblog/GraphiQLBundle)

--- a/src/Config/Parser/AnnotationParser.php
+++ b/src/Config/Parser/AnnotationParser.php
@@ -258,15 +258,15 @@ class AnnotationParser implements PreParserInterface
                 $schemaQuery = $schema['query'] ?? null;
                 $schemaMutation = $schema['mutation'] ?? null;
 
-                if ($schemaQuery && $gqlName === $schemaQuery) {
+                if ($gqlName === $schemaQuery) {
                     $isRoot = true;
-                    if ($defaultSchemaName == $schemaName) {
+                    if ($defaultSchemaName === $schemaName) {
                         $isDefault = true;
                     }
-                } elseif ($schemaMutation && $gqlName === $schemaMutation) {
+                } elseif ($gqlName === $schemaMutation) {
                     $isMutation = true;
                     $isRoot = true;
-                    if ($defaultSchemaName == $schemaName) {
+                    if ($defaultSchemaName === $schemaName) {
                         $isDefault = true;
                     }
                 }

--- a/src/Config/Parser/AnnotationParser.php
+++ b/src/Config/Parser/AnnotationParser.php
@@ -253,19 +253,20 @@ class AnnotationParser implements PreParserInterface
     ): array {
         $isMutation = $isDefault = $isRoot = false;
         if (isset($configs['definitions']['schema'])) {
+            $defaultSchemaName = isset($configs['definitions']['schema']['default']) ? 'default' : array_key_first($configs['definitions']['schema']);
             foreach ($configs['definitions']['schema'] as $schemaName => $schema) {
                 $schemaQuery = $schema['query'] ?? null;
                 $schemaMutation = $schema['mutation'] ?? null;
 
                 if ($schemaQuery && $gqlName === $schemaQuery) {
                     $isRoot = true;
-                    if ('default' == $schemaName) {
+                    if ($defaultSchemaName == $schemaName) {
                         $isDefault = true;
                     }
                 } elseif ($schemaMutation && $gqlName === $schemaMutation) {
                     $isMutation = true;
                     $isRoot = true;
-                    if ('default' == $schemaName) {
+                    if ($defaultSchemaName == $schemaName) {
                         $isDefault = true;
                     }
                 }

--- a/src/DataCollector/GraphQLCollector.php
+++ b/src/DataCollector/GraphQLCollector.php
@@ -65,8 +65,6 @@ class GraphQLCollector extends DataCollector
 
     /**
      * Return the targeted schema.
-     *
-     * @return string|false
      */
     public function getSchema(): ?string
     {

--- a/src/DataCollector/GraphQLCollector.php
+++ b/src/DataCollector/GraphQLCollector.php
@@ -28,7 +28,7 @@ class GraphQLCollector extends DataCollector
     {
         $error = false;
         $count = 0;
-        $schema = false;
+        $schema = null;
         foreach ($this->batches as $batch) {
             if (!$schema) {
                 $schema = $batch['schema'];
@@ -68,9 +68,9 @@ class GraphQLCollector extends DataCollector
      *
      * @return string|false
      */
-    public function getSchema()
+    public function getSchema(): ?string
     {
-        return $this->data['schema'] ?? 'default';
+        return $this->data['schema'];
     }
 
     /**

--- a/src/DataCollector/GraphQLCollector.php
+++ b/src/DataCollector/GraphQLCollector.php
@@ -28,7 +28,11 @@ class GraphQLCollector extends DataCollector
     {
         $error = false;
         $count = 0;
+        $schema = false;
         foreach ($this->batches as $batch) {
+            if (!$schema) {
+                $schema = $batch['schema'];
+            }
             if (isset($batch['error'])) {
                 $error = true;
             }
@@ -36,7 +40,7 @@ class GraphQLCollector extends DataCollector
         }
 
         $this->data = [
-            'schema' => $request->attributes->get('_route_params')['schemaName'] ?? 'default',
+            'schema' => $schema,
             'batches' => $this->batches,
             'count' => $count,
             'error' => $error,
@@ -105,6 +109,7 @@ class GraphQLCollector extends DataCollector
         $result = $event->getResult()->toArray();
 
         $batch = [
+            'schema' => $executorArgument->getSchemaName(),
             'queryString' => $queryString,
             'queryTime' => $queryTime,
             'variables' => $this->cloneVar($variables),

--- a/src/DataCollector/GraphQLCollector.php
+++ b/src/DataCollector/GraphQLCollector.php
@@ -65,8 +65,10 @@ class GraphQLCollector extends DataCollector
 
     /**
      * Return the targeted schema.
+     *
+     * @return string|false
      */
-    public function getSchema(): string
+    public function getSchema()
     {
         return $this->data['schema'] ?? 'default';
     }

--- a/src/Event/ExecutorArgumentsEvent.php
+++ b/src/Event/ExecutorArgumentsEvent.php
@@ -11,6 +11,7 @@ use function microtime;
 
 final class ExecutorArgumentsEvent extends Event
 {
+    private string $schemaName;
     private ExtensibleSchema $schema;
     private string $requestString;
     private ArrayObject $contextValue;
@@ -27,6 +28,7 @@ final class ExecutorArgumentsEvent extends Event
      * @return static
      */
     public static function create(
+        string $schemaName,
         ExtensibleSchema $schema,
         string $requestString,
         ArrayObject $contextValue,
@@ -35,6 +37,7 @@ final class ExecutorArgumentsEvent extends Event
         string $operationName = null
     ): self {
         $instance = new static();
+        $instance->setSchemaName($schemaName);
         $instance->setSchema($schema);
         $instance->setRequestString($requestString);
         $instance->setContextValue($contextValue);
@@ -44,6 +47,11 @@ final class ExecutorArgumentsEvent extends Event
         $instance->setStartTime(microtime(true));
 
         return $instance;
+    }
+
+    public function setSchemaName(string $schemaName): void
+    {
+        $this->schemaName = $schemaName;
     }
 
     public function setOperationName(?string $operationName): void
@@ -82,6 +90,11 @@ final class ExecutorArgumentsEvent extends Event
     public function setStartTime(float $startTime): void
     {
         $this->startTime = $startTime;
+    }
+
+    public function getSchemaName(): string
+    {
+        return $this->schemaName;
     }
 
     public function getSchema(): ExtensibleSchema

--- a/src/Request/Executor.php
+++ b/src/Request/Executor.php
@@ -14,7 +14,6 @@ use GraphQL\Validator\DocumentValidator;
 use GraphQL\Validator\Rules\DisableIntrospection;
 use GraphQL\Validator\Rules\QueryComplexity;
 use GraphQL\Validator\Rules\QueryDepth;
-use Overblog\GraphQLBundle\Definition\Type\ExtensibleSchema;
 use Overblog\GraphQLBundle\Event\Events;
 use Overblog\GraphQLBundle\Event\ExecutorArgumentsEvent;
 use Overblog\GraphQLBundle\Event\ExecutorContextEvent;
@@ -137,6 +136,7 @@ class Executor
         $this->useExperimentalExecutor ? GraphQL::useExperimentalExecutor() : GraphQL::useReferenceExecutor();
 
         $schema = $this->getSchema($schemaName);
+        /** @var string $schemaName */
         $schemaName = array_search($schema, $this->schemas);
 
         $executorArgumentsEvent = $this->preExecute(
@@ -185,7 +185,7 @@ class Executor
         /** @var ExecutorArgumentsEvent $object */
         // @phpstan-ignore-next-line (only for Symfony 4.4)
         $object = $this->dispatcher->dispatch(
-            /** @var ExtensibleSchema $schema */
+            // @phpstan-ignore-next-line
             ExecutorArgumentsEvent::create($schemaName, $schema, $requestString, $contextValue, $rootValue, $variableValue, $operationName),
             Events::PRE_EXECUTOR
         );

--- a/src/Request/Executor.php
+++ b/src/Request/Executor.php
@@ -84,14 +84,13 @@ class Executor
         }
 
         if (null === $name) {
-            // TODO(mcg-web): Replace by array_key_first PHP 7 >= 7.3.0.
-            foreach ($this->schemas as $name => $schema) {
-                break;
-            }
+            $name = isset($this->schemas['default']) ? 'default' : array_key_first($this->schemas);
         }
+
         if (!isset($this->schemas[$name])) {
             throw new NotFoundHttpException(sprintf('Could not found "%s" schema.', $name));
         }
+
         $schema = $this->schemas[$name];
         if (is_callable($schema)) {
             $schema = $schema();
@@ -137,8 +136,12 @@ class Executor
     {
         $this->useExperimentalExecutor ? GraphQL::useExperimentalExecutor() : GraphQL::useReferenceExecutor();
 
+        $schema = $this->getSchema($schemaName);
+        $schemaName = array_search($schema, $this->schemas);
+
         $executorArgumentsEvent = $this->preExecute(
-            $this->getSchema($schemaName),
+            $schemaName,
+            $schema,
             $request[ParserInterface::PARAM_QUERY] ?? null,
             new ArrayObject(),
             $rootValue,
@@ -168,6 +171,7 @@ class Executor
      * @param mixed $rootValue
      */
     private function preExecute(
+        string $schemaName,
         Schema $schema,
         string $requestString,
         ArrayObject $contextValue,
@@ -182,7 +186,7 @@ class Executor
         // @phpstan-ignore-next-line (only for Symfony 4.4)
         $object = $this->dispatcher->dispatch(
             /** @var ExtensibleSchema $schema */
-            ExecutorArgumentsEvent::create($schema, $requestString, $contextValue, $rootValue, $variableValue, $operationName),
+            ExecutorArgumentsEvent::create($schemaName, $schema, $requestString, $contextValue, $rootValue, $variableValue, $operationName),
             Events::PRE_EXECUTOR
         );
 

--- a/src/Resources/views/profiler/graphql.html.twig
+++ b/src/Resources/views/profiler/graphql.html.twig
@@ -114,7 +114,7 @@
                                 {{ result.status_code|default('n/a') }}
                             </span> 
                             <span class="nowrap newline">{{ result.time|date }}</span>
-                            {% if schemas|length > 0 %}
+                            {% if schemas|length > 0 and graphql.schema %}
                                 <span class="label schema-name">schema: {{ graphql.schema }}</span>
                             {% endif %}
                             <a  href="{{ path('_profiler', { token: result.token, panel: 'graphql' }) }}#{{result.token}}">{{ result.token }}</a>

--- a/tests/DataCollector/GraphQLCollectorTest.php
+++ b/tests/DataCollector/GraphQLCollectorTest.php
@@ -22,21 +22,20 @@ class GraphQLCollectorTest extends TestCase
         $collector = new GraphQLCollector();
 
         $request = new Request();
-        $request->attributes->set('_route_params', ['schemaName' => 'myschema']);
 
         $collector->onPostExecutor(new ExecutorResultEvent(
             new ExecutionResult(['res' => 'ok', 'error' => 'my error']),
-            ExecutorArgumentsEvent::create(new ExtensibleSchema([]), 'invalid', new ArrayObject())
+            ExecutorArgumentsEvent::create('test_schema', new ExtensibleSchema([]), 'invalid', new ArrayObject())
         ));
 
         $collector->onPostExecutor(new ExecutorResultEvent(
             new ExecutionResult(['res' => 'ok', 'error' => 'my error']),
-            ExecutorArgumentsEvent::create(new ExtensibleSchema([]), 'query{ myalias: test{field1, field2} }', new ArrayObject(), null, ['variable1' => 'v1'])
+            ExecutorArgumentsEvent::create('test_schema', new ExtensibleSchema([]), 'query{ myalias: test{field1, field2} }', new ArrayObject(), null, ['variable1' => 'v1'])
         ));
 
         $collector->collect($request, new Response());
 
-        $this->assertEquals($collector->getSchema(), 'myschema');
+        $this->assertEquals($collector->getSchema(), 'test_schema');
         $this->assertEquals($collector->getName(), 'graphql');
         $this->assertEquals($collector->getCount(), 1);
         $this->assertTrue($collector->getError());


### PR DESCRIPTION
- Add schemaName in the ExecutorArgumentsEvent
- Make the GraphQL collector retrieve schema from ExecutorArgument instead of routing
- Consider default schema as the one with name 'default' or the first one defined
- Apply same logic to Annotation Parser
- Update doc

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| Fixed tickets | #608, #712
| License       | MIT
