### PR TITLE
Add more native support for php constants in yaml files

### DIFF
--- a/docs/definitions/type-system/enum.md
+++ b/docs/definitions/type-system/enum.md
@@ -19,7 +19,8 @@ Episode:
                 #deprecationReason: "Just because"
             EMPIRE:
                 # We can use a PHP constant to avoid a magic number
-                value: '@=constant("App\\StarWars\\Movies::MOVIE_EMPIRE")'
+                # in previous versions this was done with '@=constant("App\\StarWars\\Movies::MOVIE_EMPIRE")'
+                value: !php/const App\StarWars\Movies::MOVIE_EMPIRE
                 description: "Released in 1980."
             JEDI: 6 # using the short syntax (JEDI value equal to 6)
             FORCEAWAKENS: # in this case FORCEAWAKENS value = FORCEAWAKENS
@@ -35,6 +36,7 @@ Note: At the moment, doctrine annotations on constants are not supported. So if 
 
 namespace AppBundle;
 
+use App\StarWars\Movies;
 use Overblog\GraphQLBundle\Annotation as GQL;
 
 /**
@@ -48,7 +50,7 @@ use Overblog\GraphQLBundle\Annotation as GQL;
 class Episode
 {
     const NEWHOPE = 4;
-    const EMPIRE = 'constant("App\\StarWars\\Movies::MOVIE_EMPIRE")';
+    const EMPIRE = Movies::MOVIE_EMPIRE;
     const JEDI = 6;
     const FORCEAWAKENS = 'FORCEAWAKENS';
     

--- a/src/Config/Parser/YamlParser.php
+++ b/src/Config/Parser/YamlParser.php
@@ -10,6 +10,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Parser;
+use Symfony\Component\Yaml\Yaml;
 use function file_get_contents;
 use function is_array;
 use function sprintf;
@@ -26,7 +27,7 @@ class YamlParser implements ParserInterface
         $container->addResource(new FileResource($file->getRealPath()));
 
         try {
-            $typesConfig = self::$yamlParser->parse(file_get_contents($file->getPathname()));
+            $typesConfig = self::$yamlParser->parse(file_get_contents($file->getPathname()), Yaml::PARSE_CONSTANT);
         } catch (ParseException $e) {
             throw new InvalidArgumentException(sprintf('The file "%s" does not contain valid YAML.', $file), 0, $e);
         }

--- a/tests/Config/Parser/Constants.php
+++ b/tests/Config/Parser/Constants.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Config\Parser;
+
+class Constants
+{
+    public const TWILEK = '4';
+}

--- a/tests/Config/Parser/YamlParserTest.php
+++ b/tests/Config/Parser/YamlParserTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Config\Parser;
+
+use Overblog\GraphQLBundle\Config\Parser\YamlParser;
+use SplFileInfo;
+use const DIRECTORY_SEPARATOR;
+
+class YamlParserTest extends TestCase
+{
+    public function testParseConstants(): void
+    {
+        $fileName = __DIR__.DIRECTORY_SEPARATOR.'fixtures'.DIRECTORY_SEPARATOR.'yaml'.DIRECTORY_SEPARATOR.'constants.yml';
+        $expected = ['value' => Constants::TWILEK];
+
+        $actual = YamlParser::parse(new SplFileInfo($fileName), $this->containerBuilder);
+        $this->assertSame($expected, $actual);
+    }
+}

--- a/tests/Config/Parser/fixtures/annotations/Enum/Race.php
+++ b/tests/Config/Parser/fixtures/annotations/Enum/Race.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Enum;
 
 use Overblog\GraphQLBundle\Annotation as GQL;
+use Overblog\GraphQLBundle\Tests\Config\Parser\Constants;
 
 /**
  * @GQL\Enum(values={
@@ -18,7 +19,7 @@ class Race
     public const HUMAIN = 1;
     public const CHISS = '2';
     public const ZABRAK = '3';
-    public const TWILEK = '4';
+    public const TWILEK = Constants::TWILEK;
 
     /**
      * @var int|string

--- a/tests/Config/Parser/fixtures/yaml/constants.yml
+++ b/tests/Config/Parser/fixtures/yaml/constants.yml
@@ -1,0 +1,1 @@
+value: !php/const Overblog\GraphQLBundle\Tests\Config\Parser\Constants::TWILEK


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| Fixed tickets | #303, #304
| License       | MIT

I would like to add "more native" support for PHP constants in YAML files by enabling the `!php/const` tag. 

I struggled a bit while creating my first GraphQL project today, because I expected this feature to be available. Also this way the constants don‘t need to be fetched during runtime with the PHP function `\constant()`.

This topic was already discussed in #303 but closed because of inactivity.