### PR TITLE
fix(field-resolver): re-add support for isser methods

### DIFF
--- a/UPGRADE-0.13.md
+++ b/UPGRADE-0.13.md
@@ -23,7 +23,7 @@ The new `default_field_resolver` config entry accepts callable service id.
 Stop using internally `symfony/property-access` package
 since it was a bottleneck to performance for large schema.
 
-Array access and camelize getter are supported but isser, hasser,
+Array access and camelize getter/isser are supported but hasser,
 jQuery style (e.g. `last()`) and "can" property accessors
 are no more supported out-of-the-box,
 please implement a custom resolver if these accessors are needed.

--- a/src/Resolver/FieldResolver.php
+++ b/src/Resolver/FieldResolver.php
@@ -24,6 +24,8 @@ class FieldResolver
         } elseif (\is_object($objectOrArray)) {
             if (null !== $getter = self::guessObjectMethod($objectOrArray, $fieldName, 'get')) {
                 $value = $objectOrArray->$getter();
+            } elseif (null !== $getter = self::guessObjectMethod($objectOrArray, $fieldName, 'is')) {
+                $value = $objectOrArray->$getter();
             } elseif (isset($objectOrArray->$fieldName)) {
                 $value = $objectOrArray->$fieldName;
             }

--- a/tests/Resolver/ResolverFieldTest.php
+++ b/tests/Resolver/ResolverFieldTest.php
@@ -38,7 +38,7 @@ class ResolverFieldTest extends TestCase
             ['private_property_with_getter2', $object, Toto::PRIVATE_PROPERTY_WITH_GETTER2_VALUE],
             ['not_object_or_array', 'String', null],
             ['name', $object, $object->name],
-            ['enabled', $object, $object->isEnabled()]
+            ['enabled', $object, $object->isEnabled()],
         ];
     }
 }

--- a/tests/Resolver/ResolverFieldTest.php
+++ b/tests/Resolver/ResolverFieldTest.php
@@ -38,6 +38,7 @@ class ResolverFieldTest extends TestCase
             ['private_property_with_getter2', $object, Toto::PRIVATE_PROPERTY_WITH_GETTER2_VALUE],
             ['not_object_or_array', 'String', null],
             ['name', $object, $object->name],
+            ['enabled', $object, $object->isEnabled()]
         ];
     }
 }

--- a/tests/Resolver/Toto.php
+++ b/tests/Resolver/Toto.php
@@ -47,7 +47,8 @@ class Toto
     /**
      * @return bool
      */
-    public function isEnabled() {
+    public function isEnabled()
+    {
         return $this->enabled;
     }
 }

--- a/tests/Resolver/Toto.php
+++ b/tests/Resolver/Toto.php
@@ -14,6 +14,7 @@ class Toto
     private $privatePropertyWithGetter = self::PRIVATE_PROPERTY_WITH_GETTER_VALUE;
     private $private_property_with_getter2 = self::PRIVATE_PROPERTY_WITH_GETTER2_VALUE;
     public $name = 'public';
+    private $enabled = true;
 
     /**
      * @return string
@@ -41,5 +42,12 @@ class Toto
     public function resolve()
     {
         return \func_get_args();
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnabled() {
+        return $this->enabled;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes/no
| Tests pass?   | yes
| Documented?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

I'm updating from 0.11 to 0.13 on our big app at work, and we have a lot of errors on fields which depend of isser methods.

Isser methods support has been removed in 0.13, because the Symfony PropertyAccessor has been removed too, due to performance issue for large schema.
 
However, I think it can be nice to re-add a basic support out-of-the-box for issers.

What do you think?
Thanks!
