### PR TITLE
Injection of `ResolveInfo` into auto-guessed & arguments transformer

### DIFF
--- a/docs/annotations/arguments-transformer.md
+++ b/docs/annotations/arguments-transformer.md
@@ -100,10 +100,9 @@ class RootMutation {
 
 So, the resolver (the `createUser` method) will receive an instance of the class `UserRegisterInput` instead of an array of data. 
 
-
 ### Special arguments
 
-The arguments transformer is also able to transform some `specials arguments` (see auto-guessing) :
+The arguments transformer is also able to transform some `special arguments` (see auto-guessing) :
 
 - If the type `@info` is specified, it will be replaced by the current `ResolveInfo`
 

--- a/docs/annotations/arguments-transformer.md
+++ b/docs/annotations/arguments-transformer.md
@@ -99,3 +99,48 @@ class RootMutation {
 ```
 
 So, the resolver (the `createUser` method) will receive an instance of the class `UserRegisterInput` instead of an array of data. 
+
+
+### Special arguments
+
+The arguments transformer is also able to transform some `specials arguments` (see auto-guessing) :
+
+- If the type `@info` is specified, it will be replaced by the current `ResolveInfo`
+
+You can use it this way :
+
+```php
+/**
+ * @GQL\Type
+ */
+class RootQuery {
+    /**
+     * @GQL\Field(
+     *   type="[User]",
+     *   args={
+     *     @GQL\Arg(name="ids", type="[Int]"),
+     *     @GQL\Arg(name="info", type="@info")
+     *   },
+     *   resolve="@=call(service('UserRepository').getUser, arguments({ids: '[Int]', info: '@info'}, arg))"
+     * )
+     */
+    public $getUsers;
+}
+```
+
+or with auto-guessing
+
+```php
+/**
+ * @GQL\Provider
+ */
+class UsersResolver {
+    /**
+     * @GQL\Query(type="[User]")
+     */
+    public function getUser(int $id, ResolveInfo $info):array
+    {
+        ...
+    }
+}
+```

--- a/docs/annotations/index.md
+++ b/docs/annotations/index.md
@@ -191,6 +191,34 @@ The GraphQL arguments will be auto-guessed as:
 - `@Arg(name="input", type="MyInput!")`  (The input type corresponding to the `MyInputClass` will be used).
 - `@Arg(name="limit", type="Int", default = 10)`
 
+
+#### Special arguments
+
+In conjonction with the `Arguments transformer`, some arguments with type-hinted classes can also be auto-guessed.  
+The class `GraphQL\Type\Definition\ResolveInfo` will be auto-guessed as the `ResolveInfo` for the resolver.  
+Special arguments are not exposed as GraphQL argument as there are only used internally by the arguments transformer.  
+
+You can inject it as follow: 
+```php
+/**
+ * @GQL\Type
+ */
+class MyType {
+    /**
+     * @GQL\Field(type="[String]!")
+     */
+    public function getSomething(int $amount, ResolveInfo $info) {
+        ...
+    }
+}
+```
+
+The GraphQL arguments will only be: 
+
+- `@Arg(name="amount", type="Int!")`
+
+
+
 ### Limitation of auto-guessing:
 
 When trying to auto-guess a type or args based on PHP Reflection (from type hinted method parameters or type hinted return value), there is a limitation.  

--- a/src/Transformer/ArgumentsTransformer.php
+++ b/src/Transformer/ArgumentsTransformer.php
@@ -174,7 +174,14 @@ class ArgumentsTransformer
 
         foreach ($mapping as $name => $type) {
             try {
-                $value = $this->getInstanceAndValidate($type, $data[$name], $info, $name);
+                switch ($type) {
+                    case '@info':
+                        $value = $info;
+                        break;
+                    default:
+                        $value = $this->getInstanceAndValidate($type, $data[$name], $info, $name);
+                        break;
+                }
                 $args[] = $value;
             } catch (InvalidArgumentError $exception) {
                 $exceptions[] = $exception;

--- a/tests/Config/Parser/AnnotationParserTest.php
+++ b/tests/Config/Parser/AnnotationParserTest.php
@@ -132,6 +132,11 @@ class AnnotationParserTest extends TestCase
                     'args' => ['jediOnly' => ['type' => 'Boolean', 'description' => 'Only Jedi victims']],
                     'resolve' => '@=call(value.getVictims, arguments({jediOnly: "Boolean"}, args))',
                 ],
+                'oldMasters' => [
+                    'type' => '[Character]',
+                    'args' => ['jediOnly' => ['type' => 'Boolean', 'description' => 'Only Jedi victims']],
+                    'resolve' => '@=call(value.getOldMasters, arguments({info: "@info", jediOnly: "Boolean"}, args))',
+                ],
             ],
         ]);
 
@@ -333,7 +338,7 @@ class AnnotationParserTest extends TestCase
                         'away' => ['type' => 'Boolean', 'defaultValue' => false],
                         'maxDistance' => ['type' => 'Float', 'defaultValue' => null],
                     ],
-                    'resolve' => '@=call(value.getCasualties, arguments({areaId: "Int!", raceId: "String!", dayStart: "Int", dayEnd: "Int", nameStartingWith: "String", planet: "PlanetInput", away: "Boolean", maxDistance: "Float"}, args))',
+                    'resolve' => '@=call(value.getCasualties, arguments({areaId: "Int!", raceId: "String!", dayStart: "Int", dayEnd: "Int", nameStartingWith: "String", planet: "PlanetInput", info: "@info", away: "Boolean", maxDistance: "Float"}, args))',
                     'complexity' => '@=childrenComplexity * 5',
                 ],
             ],

--- a/tests/Config/Parser/fixtures/annotations/Type/Battle.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/Battle.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Type;
 
+use GraphQL\Type\Definition\ResolveInfo;
 use Overblog\GraphQLBundle\Annotation as GQL;
 use Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Input\Planet;
 
@@ -27,6 +28,7 @@ class Battle
         int $dayEnd = null,
         string $nameStartingWith = '',
         Planet $planet = null,
+        ResolveInfo $info = null,
         bool $away = false,
         float $maxDistance = null
     ): ?int {

--- a/tests/Config/Parser/fixtures/annotations/Type/Sith.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/Sith.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Type;
 
+use GraphQL\Type\Definition\ResolveInfo;
 use Overblog\GraphQLBundle\Annotation as GQL;
 use Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Union\Killable;
 
@@ -42,6 +43,21 @@ class Sith extends Character implements Killable
      * )
      */
     public function getVictims(bool $jediOnly = false): array
+    {
+        return [];
+    }
+
+    /**
+     * @GQL\Field(
+     *   type="[Character]",
+     *   name="oldMasters",
+     *   args={
+     *     @GQl\Arg(name="info", type="@info"),
+     *     @GQL\Arg(name="jediOnly", type="Boolean", description="Only Jedi victims", default=false)
+     *   }
+     * )
+     */
+    public function getOldMasters(ResolveInfo $info, bool $jediOnly = false): array
     {
         return [];
     }

--- a/tests/Transformer/ArgumentsTransformerTest.php
+++ b/tests/Transformer/ArgumentsTransformerTest.php
@@ -187,6 +187,16 @@ class ArgumentsTransformerTest extends TestCase
         $this->assertEquals('enum1', $res->field3->value);
     }
 
+    public function testSpecialArguments(): void
+    {
+        $transformer = $this->getTransformer([]);
+        $info = $this->getResolveInfo(self::getTypes());
+        $res = $transformer->getArguments(['p1' => 'Int!', 'p2' => '@info'], ['p1' => 12], $info);
+
+        $this->assertEquals($res[0], 12);
+        $this->assertEquals($res[1], $info);
+    }
+
     public function testRaisedErrors(): void
     {
         $violation = new ConstraintViolation('validation_error', 'validation_error', [], 'invalid', 'field2', 'invalid');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| License       | MIT

This PR adds a way to inject the `ResolveInfo` through the `Argument Transformers` and will be able to auto-guessed it based on the class `GraphQL\Type\Definition\ResolveInfo`.

Usage example with auto-guessing:

```php
/**
 * @GQL\Type
 */
class MyType {
    /**
     * @GQL\Field(type="[String]!")
     */
    public function getSomething(int $amount, ResolveInfo $info) {
        ...
    }
}
```

Usage example with `@Arg`

```php
/**
 * @GQL\Type
 */
class RootQuery {
    /**
     * @GQL\Field(
     *   type="[User]",
     *   args={
     *     @GQL\Arg(name="ids", type="[Int]"),
     *     @GQL\Arg(name="info", type="@info")
     *   },
     *   resolve="@=call(service('UserRepository').getUser, arguments({ids: '[Int]', info: '@info'}, arg))"
     * )
     */
    public $getUsers;
}


