### PR TITLE
Revert "Allow to use non-empty constructor for input types"

### DIFF
--- a/src/Transformer/ArgumentsTransformer.php
+++ b/src/Transformer/ArgumentsTransformer.php
@@ -12,7 +12,6 @@ use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use Overblog\GraphQLBundle\Error\InvalidArgumentError;
 use Overblog\GraphQLBundle\Error\InvalidArgumentsError;
-use ReflectionClass;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\Validator\ConstraintViolationList;
@@ -47,7 +46,7 @@ class ArgumentsTransformer
     {
         $classname = isset($this->classesMap[$type]) ? $this->classesMap[$type]['class'] : false;
 
-        return $classname ? (new ReflectionClass($classname))->newInstanceWithoutConstructor() : false;
+        return $classname ? new $classname() : false;
     }
 
     /**


### PR DESCRIPTION
Reverts overblog/GraphQLBundle#656