### PR TITLE
Fix annotation on master

### DIFF
--- a/src/Annotation/Union.php
+++ b/src/Annotation/Union.php
@@ -22,8 +22,6 @@ final class Union implements Annotation
     /**
      * Union types.
      *
-     * @Required
-     *
      * @var array<string>
      */
     public array $types;


### PR DESCRIPTION
`@GQL\Union(types)` isn't required anymore as the `types` can be auto-guessed.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| Tests pass?   | yes