### PR TITLE
Fix generation of last comma in arrays

### DIFF
--- a/src/Generator/TypeGenerator.php
+++ b/src/Generator/TypeGenerator.php
@@ -626,7 +626,8 @@ CODE;
                 .$this->stringifyValue($value, $offset)
             ;
 
-            if ($value !== \end($array)) {
+            \end($array);
+            if ($key !== \key($array)) {
                 $code .= ', ';
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #744 

Fix the bug described in issue #744 
