### PR TITLE
Add attributes `targetTypeQuery` and `targetTypeMutation` on `@Provider`

### DIFF
--- a/docs/annotations/annotations-reference.md
+++ b/docs/annotations/annotations-reference.md
@@ -433,8 +433,8 @@ You can use `@Access` and/or `@IsPublic` on a provider class to add default acce
 Optional attributes:
 
 -   **prefix**: A prefix to apply to all field names from this provider
--   **targetTypeQuery**: The default GraphQL type(s) to attach the provider `@Query` to
--   **targetTypeMutation**: The default GraphQL type(s) to attach the provider `@Mutation` to
+-   **targetQueryTypes**: The default GraphQL type(s) to attach the provider `@Query` to
+-   **targetMutationTypes**: The default GraphQL type(s) to attach the provider `@Mutation` to
 
 ## @Query
 

--- a/docs/annotations/annotations-reference.md
+++ b/docs/annotations/annotations-reference.md
@@ -382,9 +382,9 @@ class SecretArea {
 
 This annotation applies on methods for classes tagged with the `@Provider` annotation. It indicates that the method on this class will resolve a Mutation field.  
 The corresponding GraphQL field is added to the GraphQL type(s) following the logic:
-- The type(s) specified in the `targetType` attribute of the `@Mutation` annotation if it's defined.  
+- The type(s) specified in the `targetTypes` attribute of the `@Mutation` annotation if it's defined.  
   or
-- The type(s) specified in the `targetTypeMutation` attribute of the `@Provider` annotation if it's defined.  
+- The type(s) specified in the `targetMutationTypes` attribute of the `@Provider` annotation if it's defined.  
   or
 - The root Query type of the default schema (defined in configuration at key `overblog_graphql.definitions.schema.mutation` or `overblog_graphql.definitions.schema.default.mutation`).  
   
@@ -392,7 +392,7 @@ The class exposing the mutation(s) must be declared as a [service](https://symfo
 
 Optional attributes:
 
--   **targetType** : The GraphQL type(s) to attach the field to. It must be a mutation. (by default, it'll be the root Mutation type of the default schema. see [Default Schema](../definitions/schema.md#default-schema)). You can specify one or multiple target types.
+-   **targetTypes** : The GraphQL type(s) to attach the field to. It must be a mutation. (by default, it'll be the root Mutation type of the default schema. see [Default Schema](../definitions/schema.md#default-schema)). You can specify one or multiple target types.
 
 Example:
 
@@ -440,9 +440,9 @@ Optional attributes:
 
 This annotation applies on methods for classes tagged with the `@Provider` annotation. It indicates that on this class a method will resolve a Query field.  
 The corresponding GraphQL field is added to the GraphQL type(s) following the logic:
-- The type(s) specified in the `targetType` attribute of the `@Query` annotation if it's defined.  
+- The type(s) specified in the `targetTypes` attribute of the `@Query` annotation if it's defined.  
   or
-- The type(s) specified in the `targetTypeQuery` attribute of the `@Provider` annotation if it's defined.  
+- The type(s) specified in the `targetQueryTypes` attribute of the `@Provider` annotation if it's defined.  
   or
 - The root Query type of the default schema (defined in configuration at key `overblog_graphql.definitions.schema.query` or `overblog_graphql.definitions.schema.default.query`).  
   
@@ -450,7 +450,7 @@ The class exposing the query(ies) must be declared as a [service](https://symfon
 
 Optional attributes:
 
--   **targetType** : The GraphQL type(s) to attach the field to (by default, it'll be the root Query type of the default schema. see [Default Schema](../definitions/schema.md#default-schema)). You can specify one or multiple target types.
+-   **targetTypes** : The GraphQL type(s) to attach the field to (by default, it'll be the root Query type of the default schema. see [Default Schema](../definitions/schema.md#default-schema)). You can specify one or multiple target types.
 
 Example:
 

--- a/docs/annotations/annotations-reference.md
+++ b/docs/annotations/annotations-reference.md
@@ -381,12 +381,12 @@ class SecretArea {
 ## @Mutation
 
 This annotation applies on methods for classes tagged with the `@Provider` annotation. It indicates that the method on this class will resolve a Mutation field.  
-The corresponding GraphQL field is added to the GraphQL type(s) following the logic :
-- The type(s) specified in the `targetType` attribute of the `@Mutation` annotation if it defined.  
+The corresponding GraphQL field is added to the GraphQL type(s) following the logic:
+- The type(s) specified in the `targetType` attribute of the `@Mutation` annotation if it's defined.  
   or
-- The type(s) specified in the `targetTypeMutation` attribute of the `@Provider` annotation if it is defined.  
+- The type(s) specified in the `targetTypeMutation` attribute of the `@Provider` annotation if it's defined.  
   or
-- The root Query type of the default schema (define in configuration at key `overblog_graphql.definitions.schema.mutation` or `overblog_graphql.definitions.schema.default.mutation`).  
+- The root Query type of the default schema (defined in configuration at key `overblog_graphql.definitions.schema.mutation` or `overblog_graphql.definitions.schema.default.mutation`).  
   
 The class exposing the mutation(s) must be declared as a [service](https://symfony.com/doc/current/service_container.html).
 
@@ -432,19 +432,19 @@ You can use `@Access` and/or `@IsPublic` on a provider class to add default acce
 
 Optional attributes:
 
--   **prefix** : A prefix to apply to all field names from this provider
--   **targetTypeQuery** : The default GraphQL type(s) to attach the provider `@Query` to
--   **targetTypeMutation** : The default GraphQL type(s) to attach the provider `@Mutation` to
+-   **prefix**: A prefix to apply to all field names from this provider
+-   **targetTypeQuery**: The default GraphQL type(s) to attach the provider `@Query` to
+-   **targetTypeMutation**: The default GraphQL type(s) to attach the provider `@Mutation` to
 
 ## @Query
 
 This annotation applies on methods for classes tagged with the `@Provider` annotation. It indicates that on this class a method will resolve a Query field.  
-The corresponding GraphQL field is added to the GraphQL type(s) following the logic :
-- The type(s) specified in the `targetType` attribute of the `@Query` annotation if it defined.  
+The corresponding GraphQL field is added to the GraphQL type(s) following the logic:
+- The type(s) specified in the `targetType` attribute of the `@Query` annotation if it's defined.  
   or
-- The type(s) specified in the `targetTypeQuery` attribute of the `@Provider` annotation if it is defined.  
+- The type(s) specified in the `targetTypeQuery` attribute of the `@Provider` annotation if it's defined.  
   or
-- The root Query type of the default schema (define in configuration at key `overblog_graphql.definitions.schema.query` or `overblog_graphql.definitions.schema.default.query`).  
+- The root Query type of the default schema (defined in configuration at key `overblog_graphql.definitions.schema.query` or `overblog_graphql.definitions.schema.default.query`).  
   
 The class exposing the query(ies) must be declared as a [service](https://symfony.com/doc/current/service_container.html).
 

--- a/docs/annotations/annotations-reference.md
+++ b/docs/annotations/annotations-reference.md
@@ -381,7 +381,13 @@ class SecretArea {
 ## @Mutation
 
 This annotation applies on methods for classes tagged with the `@Provider` annotation. It indicates that the method on this class will resolve a Mutation field.  
-The resulting field is added to the root Mutation type (defined in configuration at key `overblog_graphql.definitions.schema.mutation`).  
+The corresponding GraphQL field is added to the GraphQL type(s) following the logic :
+- The type(s) specified in the `targetType` attribute of the `@Mutation` annotation if it defined.  
+  or
+- The type(s) specified in the `targetTypeMutation` attribute of the `@Provider` annotation if it is defined.  
+  or
+- The root Query type of the default schema (define in configuration at key `overblog_graphql.definitions.schema.mutation` or `overblog_graphql.definitions.schema.default.mutation`).  
+  
 The class exposing the mutation(s) must be declared as a [service](https://symfony.com/doc/current/service_container.html).
 
 Optional attributes:
@@ -427,11 +433,19 @@ You can use `@Access` and/or `@IsPublic` on a provider class to add default acce
 Optional attributes:
 
 -   **prefix** : A prefix to apply to all field names from this provider
+-   **targetTypeQuery** : The default GraphQL type(s) to attach the provider `@Query` to
+-   **targetTypeMutation** : The default GraphQL type(s) to attach the provider `@Mutation` to
 
 ## @Query
 
 This annotation applies on methods for classes tagged with the `@Provider` annotation. It indicates that on this class a method will resolve a Query field.  
-By default, the resulting field is added to the root Query type (define in configuration at key `overblog_graphql.definitions.schema.query`).  
+The corresponding GraphQL field is added to the GraphQL type(s) following the logic :
+- The type(s) specified in the `targetType` attribute of the `@Query` annotation if it defined.  
+  or
+- The type(s) specified in the `targetTypeQuery` attribute of the `@Provider` annotation if it is defined.  
+  or
+- The root Query type of the default schema (define in configuration at key `overblog_graphql.definitions.schema.query` or `overblog_graphql.definitions.schema.default.query`).  
+  
 The class exposing the query(ies) must be declared as a [service](https://symfony.com/doc/current/service_container.html).
 
 Optional attributes:

--- a/src/Annotation/Mutation.php
+++ b/src/Annotation/Mutation.php
@@ -13,8 +13,9 @@ namespace Overblog\GraphQLBundle\Annotation;
 final class Mutation extends Field
 {
     /**
-     * @deprecated
      * @var array<string>
+     *
+     * @deprecated This property is deprecated since 1.0 and will be removed in 1.1. Use $targetTypes instead.
      */
     public array $targetType;
 

--- a/src/Annotation/Mutation.php
+++ b/src/Annotation/Mutation.php
@@ -13,9 +13,15 @@ namespace Overblog\GraphQLBundle\Annotation;
 final class Mutation extends Field
 {
     /**
+     * @deprecated
+     * @var array<string>
+     */
+    public array $targetType;
+
+    /**
      * The target types to attach this mutation to (useful when multiple schemas are allowed).
      *
      * @var array<string>
      */
-    public array $targetType;
+    public array $targetTypes;
 }

--- a/src/Annotation/Provider.php
+++ b/src/Annotation/Provider.php
@@ -14,8 +14,20 @@ final class Provider implements Annotation
 {
     /**
      * Optionnal prefix for provider fields.
-     *
-     * @var string
      */
     public string $prefix;
+
+    /**
+     * The default target types to attach the provider queries to.
+     *
+     * @var array<string>
+     */
+    public array $targetTypeQuery;
+
+    /**
+     * The default target types to attach the provider mutations to.
+     *
+     * @var array<string>
+     */
+    public array $targetTypeMutation;
 }

--- a/src/Annotation/Provider.php
+++ b/src/Annotation/Provider.php
@@ -24,12 +24,12 @@ final class Provider implements Annotation
      *
      * @var array<string>
      */
-    public array $targetTypeQuery;
+    public array $targetQueryTypes;
 
     /**
      * The default target types to attach the provider mutations to.
      *
      * @var array<string>
      */
-    public array $targetTypeMutation;
+    public array $targetMutationTypes;
 }

--- a/src/Annotation/Provider.php
+++ b/src/Annotation/Provider.php
@@ -14,6 +14,8 @@ final class Provider implements Annotation
 {
     /**
      * Optionnal prefix for provider fields.
+     * 
+     * @var string
      */
     public string $prefix;
 

--- a/src/Annotation/Query.php
+++ b/src/Annotation/Query.php
@@ -13,8 +13,9 @@ namespace Overblog\GraphQLBundle\Annotation;
 final class Query extends Field
 {
     /**
-     * @deprecated
      * @var array<string>
+     *
+     * @deprecated This property is deprecated since 1.0 and will be removed in 1.1. Use $targetTypes instead.
      */
     public array $targetType;
 

--- a/src/Annotation/Query.php
+++ b/src/Annotation/Query.php
@@ -13,9 +13,15 @@ namespace Overblog\GraphQLBundle\Annotation;
 final class Query extends Field
 {
     /**
+     * @deprecated
+     * @var array<string>
+     */
+    public array $targetType;
+
+    /**
      * The target types to attach this query to.
      *
      * @var array<string>
      */
-    public array $targetType;
+    public array $targetTypes;
 }

--- a/src/Config/Parser/AnnotationParser.php
+++ b/src/Config/Parser/AnnotationParser.php
@@ -715,8 +715,7 @@ class AnnotationParser implements PreParserInterface
                 if (null === $annotationTargets) {
                     if ($annotation instanceof GQL\Mutation && isset($providerAnnotation->targetTypeMutation)) {
                         $annotationTargets = $providerAnnotation->targetTypeMutation;
-                    }
-                    if ($annotation instanceof GQL\Query && isset($providerAnnotation->targetTypeQuery)) {
+                    } elseif ($annotation instanceof GQL\Query && isset($providerAnnotation->targetTypeQuery)) {
                         $annotationTargets = $providerAnnotation->targetTypeQuery;
                     }
                 }

--- a/src/Config/Parser/AnnotationParser.php
+++ b/src/Config/Parser/AnnotationParser.php
@@ -710,13 +710,14 @@ class AnnotationParser implements PreParserInterface
                     continue;
                 }
 
-                $annotationTargets = $annotation->targetType ?? null;
+                // TODO: Remove old property check in 1.1
+                $annotationTargets = $annotation->targetTypes ?? $annotation->targetType ?? null;
 
                 if (null === $annotationTargets) {
-                    if ($annotation instanceof GQL\Mutation && isset($providerAnnotation->targetTypeMutation)) {
-                        $annotationTargets = $providerAnnotation->targetTypeMutation;
-                    } elseif ($annotation instanceof GQL\Query && isset($providerAnnotation->targetTypeQuery)) {
-                        $annotationTargets = $providerAnnotation->targetTypeQuery;
+                    if ($annotation instanceof GQL\Mutation && isset($providerAnnotation->targetMutationTypes)) {
+                        $annotationTargets = $providerAnnotation->targetMutationTypes;
+                    } elseif ($annotation instanceof GQL\Query && isset($providerAnnotation->targetQueryTypes)) {
+                        $annotationTargets = $providerAnnotation->targetQueryTypes;
                     }
                 }
 

--- a/src/Config/Parser/AnnotationParser.php
+++ b/src/Config/Parser/AnnotationParser.php
@@ -713,6 +713,15 @@ class AnnotationParser implements PreParserInterface
                 $annotationTargets = $annotation->targetType ?? null;
 
                 if (null === $annotationTargets) {
+                    if ($annotation instanceof GQL\Mutation && isset($providerAnnotation->targetTypeMutation)) {
+                        $annotationTargets = $providerAnnotation->targetTypeMutation;
+                    }
+                    if ($annotation instanceof GQL\Query && isset($providerAnnotation->targetTypeQuery)) {
+                        $annotationTargets = $providerAnnotation->targetTypeQuery;
+                    }
+                }
+
+                if (null === $annotationTargets) {
                     if ($isDefaultTarget) {
                         $annotationTargets = [$targetType];
                         if (!$annotation instanceof $expectedAnnotation) {
@@ -728,7 +737,7 @@ class AnnotationParser implements PreParserInterface
                 }
 
                 if (!$annotation instanceof $expectedAnnotation) {
-                    if (GQL\Mutation::class == $expectedAnnotation) {
+                    if (GQL\Mutation::class === $expectedAnnotation) {
                         $message = sprintf('The provider "%s" try to add a query field on type "%s" (through @Query on method "%s") but "%s" is a mutation.', $providerMetadata->getName(), $targetType, $method->getName(), $targetType);
                     } else {
                         $message = sprintf('The provider "%s" try to add a mutation on type "%s" (through @Mutation on method "%s") but "%s" is not a mutation.', $providerMetadata->getName(), $targetType, $method->getName(), $targetType);

--- a/tests/Config/Parser/AnnotationParserTest.php
+++ b/tests/Config/Parser/AnnotationParserTest.php
@@ -276,6 +276,10 @@ class AnnotationParserTest extends TestCase
                     'access' => '@=default_access',
                     'public' => '@=default_public',
                 ],
+                'countSecretWeapons' => [
+                    'type' => 'Int!',
+                    'resolve' => "@=call(service('Overblog\\\\GraphQLBundle\\\\Tests\\\\Config\\\\Parser\\\\fixtures\\\\annotations\\\\Repository\\\\WeaponRepository').countSecretWeapons, arguments({}, args))",
+                ],
             ],
         ]);
 
@@ -316,6 +320,10 @@ class AnnotationParserTest extends TestCase
                     'access' => '@=default_access',
                     'public' => '@=default_public',
                 ],
+                'hasSecretWeapons' => [
+                    'type' => 'Boolean!',
+                    'resolve' => "@=call(service('Overblog\\\\GraphQLBundle\\\\Tests\\\\Config\\\\Parser\\\\fixtures\\\\annotations\\\\Repository\\\\WeaponRepository').hasSecretWeapons, arguments({}, args))",
+                ],
             ],
         ]);
 
@@ -334,6 +342,10 @@ class AnnotationParserTest extends TestCase
                     'resolve' => "@=call(service('Overblog\\\\GraphQLBundle\\\\Tests\\\\Config\\\\Parser\\\\fixtures\\\\annotations\\\\Repository\\\\PlanetRepository').destroyPlanet, arguments({planetId: \"Int!\"}, args))",
                     'access' => '@=default_access',
                     'public' => '@=default_public',
+                ],
+                'createLightsaber' => [
+                    'type' => 'Boolean!',
+                    'resolve' => "@=call(service('Overblog\\\\GraphQLBundle\\\\Tests\\\\Config\\\\Parser\\\\fixtures\\\\annotations\\\\Repository\\\\WeaponRepository').createLightsaber, arguments({}, args))",
                 ],
             ],
         ]);

--- a/tests/Config/Parser/fixtures/annotations/Repository/PlanetRepository.php
+++ b/tests/Config/Parser/fixtures/annotations/Repository/PlanetRepository.php
@@ -45,7 +45,7 @@ class PlanetRepository
     }
 
     /**
-     * @GQL\Query(type="Planet", targetType="RootQuery2")
+     * @GQL\Query(type="Planet", targetTypes="RootQuery2")
      */
     public function getPlanetSchema2(): ?Planet
     {
@@ -53,7 +53,7 @@ class PlanetRepository
     }
 
     /**
-     * @GQL\Mutation(type="Planet", targetType="RootMutation2", args={
+     * @GQL\Mutation(type="Planet", targetTypes="RootMutation2", args={
      *    @GQL\Arg(type="PlanetInput!", name="planetInput")
      * })
      * @GQL\IsPublic("override_public")
@@ -64,7 +64,7 @@ class PlanetRepository
     }
 
     /**
-     * @GQL\Mutation(targetType={"RootMutation", "RootMutation2"})
+     * @GQL\Mutation(targetTypes={"RootMutation", "RootMutation2"})
      */
     public function destroyPlanet(int $planetId): bool
     {
@@ -72,7 +72,7 @@ class PlanetRepository
     }
 
     /**
-     * @GQL\Query(targetType={"RootQuery", "RootQuery2"})
+     * @GQL\Query(targetTypes={"RootQuery", "RootQuery2"})
      */
     public function isPlanetDestroyed(int $planetId): bool
     {
@@ -80,7 +80,7 @@ class PlanetRepository
     }
 
     /**
-     * @GQL\Query(targetType={"Droid", "Mandalorian"}, name="armorResistance")
+     * @GQL\Query(targetTypes={"Droid", "Mandalorian"}, name="armorResistance")
      */
     public function getArmorResistance(): int
     {

--- a/tests/Config/Parser/fixtures/annotations/Repository/WeaponRepository.php
+++ b/tests/Config/Parser/fixtures/annotations/Repository/WeaponRepository.php
@@ -7,7 +7,7 @@ namespace Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Reposi
 use Overblog\GraphQLBundle\Annotation as GQL;
 
 /**
- * @GQL\Provider(targetTypeQuery={"RootQuery2"}, targetTypeMutation="RootMutation2")
+ * @GQL\Provider(targetQueryTypes={"RootQuery2"}, targetMutationTypes="RootMutation2")
  */
 class WeaponRepository
 {
@@ -20,7 +20,7 @@ class WeaponRepository
     }
 
     /**
-     * @GQL\Query(targetType="RootQuery")
+     * @GQL\Query(targetTypes="RootQuery")
      */
     public function countSecretWeapons(): int
     {

--- a/tests/Config/Parser/fixtures/annotations/Repository/WeaponRepository.php
+++ b/tests/Config/Parser/fixtures/annotations/Repository/WeaponRepository.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Repository;
+
+use Overblog\GraphQLBundle\Annotation as GQL;
+
+/**
+ * @GQL\Provider(targetTypeQuery={"RootQuery2"}, targetTypeMutation="RootMutation2")
+ */
+class WeaponRepository
+{
+    /**
+     * @GQL\Query
+     */
+    public function hasSecretWeapons(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @GQL\Query(targetType="RootQuery")
+     */
+    public function countSecretWeapons(): int
+    {
+        return 2;
+    }
+
+    /**
+     * @GQL\Mutation
+     */
+    public function createLightsaber(): bool
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| License       | MIT

This PR adds attributes `targetTypeQuery` and `targetTypeMutation` on `@Provider`
It will be used as default `targetType` for `@Query` or `@Mutation` if it is not set.