### PR TITLE
Make it possible for scalar annotation to register Doctrine and PHP types to map

### DIFF
--- a/src/Annotation/Scalar.php
+++ b/src/Annotation/Scalar.php
@@ -22,4 +22,14 @@ final class Scalar implements Annotation
      * @var string
      */
     public string $scalarType;
+
+    /**
+     * @var string
+     */
+    public string $doctrineType;
+
+    /**
+     * @var string
+     */
+    public string $phpType;
 }

--- a/src/Config/Parser/AnnotationParser.php
+++ b/src/Config/Parser/AnnotationParser.php
@@ -93,6 +93,7 @@ class AnnotationParser implements PreParserInterface
         self::$classesMap = [];
         self::$providers = [];
         self::$graphClassCache = [];
+        self::$doctrineMapping = [];
     }
 
     /**
@@ -102,7 +103,7 @@ class AnnotationParser implements PreParserInterface
      */
     private static function processFile(SplFileInfo $file, ContainerBuilder $container, array $configs, bool $preProcess): array
     {
-        self::$doctrineMapping = $configs['doctrine']['types_mapping'];
+        self::$doctrineMapping += $configs['doctrine']['types_mapping'];
         $container->addResource(new FileResource($file->getRealPath()));
 
         try {
@@ -189,6 +190,16 @@ class AnnotationParser implements PreParserInterface
                 $gqlType = self::GQL_SCALAR;
                 if (!$preProcess) {
                     $gqlConfiguration = self::scalarAnnotationToGQLConfiguration($graphClass, $classAnnotation);
+                } else {
+                    if (isset($classAnnotation->doctrineType)) {
+                        $gqlName = $classAnnotation->name ?? $graphClass->getShortName();
+                        self::$doctrineMapping[$classAnnotation->doctrineType] = $gqlName;
+                    }
+                    if (isset($classAnnotation->phpType)) {
+                        self::$classesMap[$gqlName] = ['type' => $gqlType, 'class' => $classAnnotation->phpType];
+
+                        return $gqlTypes;
+                    }
                 }
                 break;
 

--- a/tests/Config/Parser/AnnotationParserTest.php
+++ b/tests/Config/Parser/AnnotationParserTest.php
@@ -426,6 +426,16 @@ class AnnotationParserTest extends TestCase
         ]);
     }
 
+    public function testScalarRegisterType(): void
+    {
+        $this->expect('CustomScalarType', 'object', [
+            'fields' => [
+                'doctrineDatetime' => ['type' => 'ScalarWithTypeMapping'],
+                'phpDatetime' => ['type' => 'ScalarWithTypeMapping!'],
+            ],
+        ]);
+    }
+
     public function testInvalidParamGuessing(): void
     {
         try {

--- a/tests/Config/Parser/fixtures/annotations/Scalar/ScalarWithTypeMapping.php
+++ b/tests/Config/Parser/fixtures/annotations/Scalar/ScalarWithTypeMapping.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Scalar;
+
+use Overblog\GraphQLBundle\Annotation as GQL;
+
+/**
+ * @GQL\Scalar(doctrineType="datetime", phpType=\DateTime::class)
+ */
+class ScalarWithTypeMapping
+{
+}

--- a/tests/Config/Parser/fixtures/annotations/Type/CustomScalarType.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/CustomScalarType.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Type;
+
+use DateTime;
+use Doctrine\ORM\Mapping as ORM;
+use Overblog\GraphQLBundle\Annotation as GQL;
+
+/**
+ * @GQL\Type
+ */
+class CustomScalarType
+{
+    /**
+     * @ORM\Column(type="datetime", nullable=true)
+     * @GQL\Field
+     */
+    // @phpstan-ignore-next-line
+    protected $doctrineDatetime;
+
+    /**
+     * @GQL\Field
+     */
+    protected DateTime $phpDatetime;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | not yet
| License       | MIT

When creating a scalar class it should be easy to also tell which types always map to this scalar. When the idea is accepted i will also update the documentation.
