### PR TITLE
Fixed a bug on validating fields when validation is cascade

### DIFF
--- a/src/Validator/InputValidator.php
+++ b/src/Validator/InputValidator.php
@@ -210,7 +210,7 @@ class InputValidator
         $propertiesMapping = [];
 
         foreach ($type->getFields() as $fieldName => $inputField) {
-            $propertiesMapping[$fieldName] = $inputField->config['validation'];
+            $propertiesMapping[$fieldName] = $inputField->config['validation'] ?? [];
         }
 
         return $this->buildValidationTree(


### PR DESCRIPTION
I was having this example:

```yaml
Mutation:
  type: object
  config:
    fields:
      create:
        type: "Ladder!"
        resolve: "@=mutation('LadderCreate', [args, context, validator])"
        access: '@=isAuthenticated()'
        args:
          input:
            type: "LadderInput!"
            validation: cascade

LadderInput:
  type: input-object
  config:
    fields:
      name:
        type: String!
        validation:
          - NotBlank: ~
          - Length:
              min: 10
              max: 100
      matchesSystem:
        type: "[MatchesSystemEnum!]!"
```

I.e. the `matchesSystem` field in `LadderInput` had no `validation`, so the `InputValidator.php` was crashing as it had no `$inputField->config['validation']`. Probably the default value should be an empty array.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| License       | MIT
