### PR TITLE
Fix/phpstan

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -426,11 +426,6 @@ parameters:
 			path: src/Generator/TypeBuilder.php
 
 		-
-			message: "#^Undefined variable: .*$#"
-			count: 3
-			path: src/Generator/TypeBuilder.php
-
-		-
 			message: "#^Call to an undefined method Murtukov\\\\PHPCodeGenerator\\\\OOPStructure::createConstructor.*$#"
 			count: 1
 			path: src/Generator/TypeBuilder.php

--- a/src/Config/Parser/Annotation/GraphClass.php
+++ b/src/Config/Parser/Annotation/GraphClass.php
@@ -67,8 +67,10 @@ class GraphClass extends ReflectionClass
             case null === $from:
                 return $this->annotations;
             case $from instanceof ReflectionMethod:
+                // @phpstan-ignore-next-line
                 return self::getAnnotationReader()->getMethodAnnotations($from);
             case $from instanceof ReflectionProperty:
+                // @phpstan-ignore-next-line
                 return self::getAnnotationReader()->getPropertyAnnotations($from);
             default:
                 throw new AnnotationException(sprintf('Unable to retrieve annotations from object of class "%s".', get_class($from)));


### PR DESCRIPTION
Fix little issues after the new release of PHPStan

- Remove all usages of the `extract` function, that PHPStan doesn't understand well
- Suppress some false positive errors
- Remove unused exclude rule from phpstan-baseline.neon