### PR TITLE
Refactor TypeBuilder and resolve some todos

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -17,6 +17,7 @@ return PhpCsFixer\Config::create()
             'phpdoc_to_comment' => false,
             'no_superfluous_phpdoc_tags' => ['allow_mixed' => true],
             'global_namespace_import' => ['import_functions' => true, 'import_classes' => true, 'import_constants' => true],
+            'phpdoc_summary' => false,
         ]
     )
     ->setFinder($finder)

--- a/src/Error/InvalidArgumentError.php
+++ b/src/Error/InvalidArgumentError.php
@@ -13,8 +13,13 @@ class InvalidArgumentError extends GraphQLUserError
     private string $name;
     private ConstraintViolationListInterface $errors;
 
-    public function __construct(string $name, ConstraintViolationListInterface $errors, $message = '', $code = 0, Exception $previous = null)
-    {
+    public function __construct(
+        string $name,
+        ConstraintViolationListInterface $errors,
+        string $message = '',
+        int $code = 0,
+        Exception $previous = null
+    ) {
         $this->name = $name;
         $this->errors = $errors;
         parent::__construct($message, $code, $previous);

--- a/src/Error/InvalidArgumentsError.php
+++ b/src/Error/InvalidArgumentsError.php
@@ -12,8 +12,12 @@ class InvalidArgumentsError extends GraphQLUserError
     /** @var InvalidArgumentError[] */
     private array $errors;
 
-    public function __construct(array $errors, $message = '', $code = 0, Exception $previous = null)
-    {
+    public function __construct(
+        array $errors,
+        string $message = '',
+        int $code = 0,
+        Exception $previous = null
+    ) {
         $this->errors = $errors;
         parent::__construct($message, $code, $previous);
     }

--- a/src/Error/UserErrors.php
+++ b/src/Error/UserErrors.php
@@ -16,8 +16,12 @@ class UserErrors extends RuntimeException
     /** @var UserError[] */
     private array $errors = [];
 
-    public function __construct(array $errors, $message = '', $code = 0, Exception $previous = null)
-    {
+    public function __construct(
+        array $errors,
+        string $message = '',
+        int $code = 0,
+        Exception $previous = null
+    ) {
         $this->setErrors($errors);
         parent::__construct($message, $code, $previous);
     }

--- a/src/ExpressionLanguage/ExpressionFunction/Security/Helper.php
+++ b/src/ExpressionLanguage/ExpressionFunction/Security/Helper.php
@@ -11,7 +11,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 use function is_object;
 
 /**
- * @deprecated since 0.13 will be remove in 0.14
+ * @deprecated since 0.13 will be remove in 1.0
  * @codeCoverageIgnore
  */
 final class Helper

--- a/src/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/ExpressionLanguage/ExpressionLanguage.php
@@ -44,8 +44,8 @@ class ExpressionLanguage extends BaseExpressionLanguage
      * Argument can be either an Expression object or a string with or
      * without a prefix
      *
-     * @param string            $name       - Name of the searched variable
-     * @param string|Expression $expression - Expression to search in
+     * @param string            $name       - name of the searched variable (needle)
+     * @param string|Expression $expression - expression to search in (haystack)
      *
      * @throws SyntaxError
      */
@@ -76,6 +76,20 @@ class ExpressionLanguage extends BaseExpressionLanguage
         }
 
         return $contained ?? false;
+    }
+
+    /**
+     * Checks if value is a string and has the expression trigger prefix.
+     *
+     * @param mixed $value
+     */
+    public static function isStringWithTrigger($value): bool
+    {
+        if (is_string($value)) {
+            return self::stringHasTrigger($value);
+        }
+
+        return false;
     }
 
     /**

--- a/src/Generator/Converter/ExpressionConverter.php
+++ b/src/Generator/Converter/ExpressionConverter.php
@@ -6,7 +6,6 @@ namespace Overblog\GraphQLBundle\Generator\Converter;
 
 use Murtukov\PHPCodeGenerator\ConverterInterface;
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionLanguage;
-use function is_string;
 
 class ExpressionConverter implements ConverterInterface
 {
@@ -35,10 +34,6 @@ class ExpressionConverter implements ConverterInterface
      */
     public function check($maybeExpression): bool
     {
-        if (is_string($maybeExpression)) {
-            return ExpressionLanguage::stringHasTrigger($maybeExpression);
-        }
-
-        return false;
+        return ExpressionLanguage::isStringWithTrigger($maybeExpression);
     }
 }

--- a/src/Generator/TypeBuilder.php
+++ b/src/Generator/TypeBuilder.php
@@ -208,7 +208,7 @@ class TypeBuilder
      *
      *      fn() => [
      *          'name' => self::NAME,
-     *          'description' => 'Root query tyoe',
+     *          'description' => 'Root query type',
      *          'fields' => fn() => [
      *              'posts' => {@see buildField},
      *              'users' => {@see buildField},
@@ -537,7 +537,7 @@ class TypeBuilder
      *          'constraints' => {@see buildConstraints}
      *      ]
      *
-     * If only constraints provided, build {@see buildConstraints} directly.
+     * If only constraints provided, uses {@see buildConstraints} directly.
      *
      * @param array{
      *     constraints: array,

--- a/src/Generator/TypeBuilder.php
+++ b/src/Generator/TypeBuilder.php
@@ -29,11 +29,10 @@ use Overblog\GraphQLBundle\Definition\LazyConfig;
 use Overblog\GraphQLBundle\Definition\Type\CustomScalarType;
 use Overblog\GraphQLBundle\Definition\Type\GeneratedTypeInterface;
 use Overblog\GraphQLBundle\Error\ResolveErrors;
-use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionLanguage;
+use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionLanguage as EL;
 use Overblog\GraphQLBundle\Generator\Converter\ExpressionConverter;
 use Overblog\GraphQLBundle\Generator\Exception\GeneratorException;
 use Overblog\GraphQLBundle\Validator\InputValidator;
-use RuntimeException;
 use function array_filter;
 use function array_intersect;
 use function array_map;
@@ -57,13 +56,19 @@ use function substr;
 use function trim;
 
 /**
- * TODO (murtukov):
- *  1. Add <code> docblocks for every method
- *  2. Replace hard-coded string types with constants ('object', 'input-object' etc.).
+ * Service that exposes a single method `build` called for each GraphQL
+ * type config to build a PhpFile object.
+ *
+ * {@link https://github.com/murtukov/php-code-generator}
+ *
+ * It's responsible for building all GraphQL types (object, input-object,
+ * interface, union, enum and custom-scalar).
+ *
+ * Every method with prefix 'build' has a render example in it's PHPDoc.
  */
 class TypeBuilder
 {
-    protected const CONSTRAINTS_NAMESPACE = "Symfony\Component\Validator\Constraints";
+    protected const CONSTRAINTS_NAMESPACE = 'Symfony\Component\Validator\Constraints';
     protected const DOCBLOCK_TEXT = 'THIS FILE WAS GENERATED AND SHOULD NOT BE EDITED MANUALLY.';
     protected const BUILT_IN_TYPES = [Type::STRING, Type::INT, Type::FLOAT, Type::BOOLEAN, Type::ID];
 
@@ -113,6 +118,7 @@ class TypeBuilder
      */
     public function build(array $config, string $type): PhpFile
     {
+        // This values should be accessible from every method
         $this->config = $config;
         $this->type = $type;
 
@@ -140,9 +146,17 @@ class TypeBuilder
     }
 
     /**
-     * @return GeneratorInterface|string
+     * Converts a native GraphQL type string into the `webonyx/graphql-php`
+     * type literal.
      *
-     * @throws RuntimeException
+     * Render examples:
+     *
+     *  -   "String"   -> Type::string()
+     *  -   "String!"  -> Type::nonNull(Type::string())
+     *  -   "[String!] -> Type::listOf(Type::nonNull(Type::string()))
+     *  -   "[Post]"   -> Type::listOf($globalVariables->get('typeResolver')->resolve('Post'))
+     *
+     * @return GeneratorInterface|string
      */
     protected function buildType(string $typeDefinition)
     {
@@ -152,11 +166,11 @@ class TypeBuilder
     }
 
     /**
+     * Used by {@see buildType}.
+     *
      * @param mixed $typeNode
      *
      * @return DependencyAwareGenerator|string
-     *
-     * @throws RuntimeException
      */
     protected function wrapTypeRecursive($typeNode)
     {
@@ -187,12 +201,93 @@ class TypeBuilder
     }
 
     /**
+     * Builds an arrow function with an array as the return value. Content of
+     * the array depends on the GraphQL type that is currently being generated.
+     *
+     * Render example (object):
+     *
+     *      fn() => [
+     *          'name' => self::NAME,
+     *          'description' => 'Root query tyoe',
+     *          'fields' => fn() => [
+     *              'posts' => {@see buildField},
+     *              'users' => {@see buildField},
+     *               ...
+     *           ],
+     *           'interfaces' => fn() => [
+     *               $globalVariables->get('typeResolver')->resolve('PostInterface'),
+     *               ...
+     *           ],
+     *           'resolveField' => {@see buildResolveField},
+     *      ]
+     *
+     * Render example (input-object):
+     *
+     *      fn() => [
+     *          'name' => self::NAME,
+     *          'description' => 'Some description.',
+     *          'validation' => {@see buildValidationRules}
+     *          'fields' => fn() => [
+     *              {@see buildField},
+     *               ...
+     *           ],
+     *      ]
+     *
+     * Render example (interface)
+     *
+     *      fn() => [
+     *          'name' => self::NAME,
+     *          'description' => 'Some description.',
+     *          'fields' => fn() => [
+     *              {@see buildField},
+     *               ...
+     *           ],
+     *          'resolveType' => {@see buildResolveType},
+     *      ]
+     *
+     * Render example (union):
+     *
+     *      fn() => [
+     *          'name' => self::NAME,
+     *          'description' => 'Some description.',
+     *          'types' => fn() => [
+     *              $globalVariables->get('typeResolver')->resolve('Photo'),
+     *              ...
+     *          ],
+     *          'resolveType' => {@see buildResolveType},
+     *      ]
+     *
+     * Render example (custom-scalar):
+     *
+     *      fn() => [
+     *          'name' => self::NAME,
+     *          'description' => 'Some description'
+     *          'serialize' => {@see buildScalarCallback},
+     *          'parseValue' => {@see buildScalarCallback},
+     *          'parseLiteral' => {@see buildScalarCallback},
+     *      ]
+     *
+     * Render example (enum):
+     *
+     *      fn() => [
+     *          'name' => self::NAME,
+     *          'values' => [
+     *              'PUBLISHED' => ['value' => 1],
+     *              'DRAFT' => ['value' => 2],
+     *              'STANDBY' => [
+     *                  'value' => 3,
+     *                  'description' => 'Waiting for validation',
+     *              ],
+     *              ...
+     *          ],
+     *      ]
+     *
      * @throws GeneratorException
      * @throws UnrecognizedValueTypeException
      */
     protected function buildConfigLoader(array $config): ArrowFunction
     {
-        // Convert to object for better readability
+        // Convert to an object for a better readability
         $c = (object) $config;
 
         $configLoader = Collection::assoc();
@@ -202,11 +297,12 @@ class TypeBuilder
             $configLoader->addItem('description', $c->description);
         }
 
-        // only by InputType (class level validation)
+        // only by input-object types (for class level validation)
         if (isset($c->validation)) {
             $configLoader->addItem('validation', $this->buildValidationRules($c->validation));
         }
 
+        // only by object, input-object and interface types
         if (!empty($c->fields)) {
             $configLoader->addItem('fields', ArrowFunction::new(
                 Collection::map($c->fields, [$this, 'buildField'])
@@ -231,10 +327,12 @@ class TypeBuilder
             $configLoader->addItem('resolveField', $this->buildResolve($c->resolveField));
         }
 
+        // only by enum types
         if (isset($c->values)) {
             $configLoader->addItem('values', Collection::assoc($c->values));
         }
 
+        // only by custom-scalar types
         if ('custom-scalar' === $this->type) {
             if (isset($c->scalarType)) {
                 $configLoader->addItem('scalarType', $c->scalarType);
@@ -257,11 +355,17 @@ class TypeBuilder
     }
 
     /**
-     * @param callable $callback
+     * Builds an arrow function that calls a static method.
      *
-     * @return ArrowFunction
+     * Render example:
+     *
+     *      fn() => MyClassName::myMethodName(...\func_get_args())
+     *
+     * @param callable $callback - a callable string or a callable array
      *
      * @throws GeneratorException
+     *
+     * @return ArrowFunction
      */
     protected function buildScalarCallback($callback, string $fieldName)
     {
@@ -280,7 +384,7 @@ class TypeBuilder
         $className = Utils::resolveQualifier($class);
 
         if ($className === $this->config['class_name']) {
-            // Create alias if name of serializer is same as type name
+            // Create an alias if name of serializer is same as type name
             $className = 'Base'.$className;
             $this->file->addUse($class, $className);
         } else {
@@ -293,12 +397,46 @@ class TypeBuilder
     }
 
     /**
-     * @param mixed $resolve
+     * Builds a resolver closure that contains the compiled result of user-defined
+     * expression and optionally the validation logic.
      *
-     * @return GeneratorInterface
+     * Render example (no expression language):
+     *
+     *      function ($value, $args, $context, $info) use ($globalVariables) {
+     *          return "Hello, World!";
+     *      }
+     *
+     * Render example (with expression language):
+     *
+     *      function ($value, $args, $context, $info) use ($globalVariables) {
+     *          return $globalVariables->get('mutationResolver')->resolve(["my_resolver", [0 => $args]]);
+     *      }
+     *
+     * Render example (with validation):
+     *
+     *      function ($value, $args, $context, $info) use ($globalVariables) {
+     *          $validator = {@see buildValidatorInstance}
+     *          return $globalVariables->get('mutationResolver')->resolve(["create_post", [0 => $validator]]);
+     *      }
+     *
+     * Render example (with validation, but errors are injected into the user-defined resolver):
+     * {@link https://github.com/overblog/GraphQLBundle/blob/master/docs/validation/index.md#injecting-errors}
+     *
+     *      function ($value, $args, $context, $info) use ($globalVariables) {
+     *          $errors = new ResolveErrors();
+     *          $validator = {@see buildValidatorInstance}
+     *
+     *          $errors->setValidationErrors($validator->validate(null, false))
+     *
+     *          return $globalVariables->get('mutationResolver')->resolve(["create_post", [0 => $errors]]);
+     *      }
+     *
+     * @param mixed $resolve
      *
      * @throws GeneratorException
      * @throws UnrecognizedValueTypeException
+     *
+     * @return GeneratorInterface
      */
     protected function buildResolve($resolve, ?array $validationConfig = null)
     {
@@ -310,18 +448,36 @@ class TypeBuilder
             ->addArguments('value', 'args', 'context', 'info')
             ->bindVar(TypeGenerator::GLOBAL_VARS);
 
-        // TODO (murtukov): replace usage of converter with ExpressionLanguage static method
-        if ($this->expressionConverter->check($resolve)) {
-            $injectErrors = ExpressionLanguage::expressionContainsVar('errors', $resolve);
+        if (EL::isStringWithTrigger($resolve)) {
+            $injectErrors = EL::expressionContainsVar('errors', $resolve);
 
             if ($injectErrors) {
                 $closure->append('$errors = ', Instance::new(ResolveErrors::class));
             }
 
-            $injectValidator = ExpressionLanguage::expressionContainsVar('validator', $resolve);
+            $injectValidator = EL::expressionContainsVar('validator', $resolve);
 
             if (null !== $validationConfig) {
-                $this->buildValidator($closure, $validationConfig, $injectValidator, $injectErrors);
+                $closure->append('$validator = ', $this->buildValidatorInstance($validationConfig));
+
+                // If auto-validation on or errors are injected
+                if (!$injectValidator || $injectErrors) {
+                    if (!empty($validationConfig['validationGroups'])) {
+                        $validationGroups = Collection::numeric($validationConfig['validationGroups']);
+                    } else {
+                        $validationGroups = 'null';
+                    }
+
+                    $closure->emptyLine();
+
+                    if ($injectErrors) {
+                        $closure->append('$errors->setValidationErrors($validator->validate(', $validationGroups, ', false))');
+                    } else {
+                        $closure->append('$validator->validate(', $validationGroups, ')');
+                    }
+
+                    $closure->emptyLine();
+                }
             } elseif (true === $injectValidator) {
                 throw new GeneratorException(
                     'Unable to inject an instance of the InputValidator. No validation constraints provided. '.
@@ -340,7 +496,20 @@ class TypeBuilder
         return $closure;
     }
 
-    protected function buildValidator(Closure $closure, array $mapping, bool $injectValidator, bool $injectErrors): void
+    /**
+     * Render example:
+     *
+     *      new InputValidator(
+     *          \func_get_args(),
+     *          $globalVariables->get('container')->get('validator'),
+     *          $globalVariables->get('validatorFactory'),
+     *          {@see buildProperties},
+     *          {@see buildValidationRules},
+     *      )
+     *
+     * @throws GeneratorException
+     */
+    protected function buildValidatorInstance(array $mapping): Instance
     {
         $validator = Instance::new(InputValidator::class)
             ->setMultiline()
@@ -356,29 +525,20 @@ class TypeBuilder
             $validator->addArgument($this->buildValidationRules($mapping['class']));
         }
 
-        $closure->append('$validator = ', $validator);
-
-        // If auto-validation on or errors are injected
-        if (!$injectValidator || $injectErrors) {
-            if (!empty($mapping['validationGroups'])) {
-                $validationGroups = Collection::numeric($mapping['validationGroups']);
-            } else {
-                $validationGroups = 'null';
-            }
-
-            $closure->emptyLine();
-
-            if ($injectErrors) {
-                $closure->append('$errors->setValidationErrors($validator->validate(', $validationGroups, ', false))');
-            } else {
-                $closure->append('$validator->validate(', $validationGroups, ')');
-            }
-
-            $closure->emptyLine();
-        }
+        return $validator;
     }
 
     /**
+     * Render example:
+     *
+     *      [
+     *          'link' => {@see normalizeLink}
+     *          'cascade' => {@see buildCascade},
+     *          'constraints' => {@see buildConstraints}
+     *      ]
+     *
+     * If only constraints provided, build {@see buildConstraints} directly.
+     *
      * @param array{
      *     constraints: array,
      *     link: string,
@@ -396,7 +556,7 @@ class TypeBuilder
 
         if (!empty($c->link)) {
             if (false === strpos($c->link, '::')) {
-                // e.g.: App\Entity\Droid
+                // e.g. App\Entity\Droid
                 $array->addItem('link', $c->link);
             } else {
                 // e.g. App\Entity\Droid::$id
@@ -420,13 +580,19 @@ class TypeBuilder
     }
 
     /**
-     * <code>
-     * [
-     *     new NotNull(),
-     *     new Length(['min' => 5, 'max' => 10]),
-     *     ...
-     * ]
-     * </code>.
+     * Builds a numeric multiline array with Symfony Constraint instances.
+     * The array is used by {@see InputValidator} during requests.
+     *
+     * Render example:
+     *
+     *      [
+     *          new NotNull(),
+     *          new Length([
+     *              'min' => 5,
+     *              'max' => 10
+     *          ]),
+     *          ...
+     *      ]
      *
      * @throws GeneratorException
      */
@@ -474,6 +640,19 @@ class TypeBuilder
     }
 
     /**
+     * Builds an assoc multiline array with a predefined shape. The array
+     * is used by {@see InputValidator} during requests.
+     *
+     * Possible keys are: 'groups', 'isCollection' and 'referenceType'.
+     *
+     * Render example:
+     *
+     *      [
+     *          'groups' => ['my_group'],
+     *          'isCollection' => true,
+     *          'referenceType' => $globalVariables->get('typeResolver')->resolve('Article')
+     *      ]
+     *
      * @param array{
      *     referenceType: string,
      *     groups:        array,
@@ -486,11 +665,11 @@ class TypeBuilder
     {
         $c = (object) $cascade;
 
-        $result = Collection::assoc()
+        $array = Collection::assoc()
             ->addIfNotEmpty('groups', $c->groups);
 
         if (isset($c->isCollection)) {
-            $result->addItem('isCollection', $c->isCollection);
+            $array->addItem('isCollection', $c->isCollection);
         }
 
         if (isset($c->referenceType)) {
@@ -500,12 +679,23 @@ class TypeBuilder
                 throw new GeneratorException('Cascade validation cannot be applied to built-in types.');
             }
 
-            $result->addItem('referenceType', "$this->globalVars->get('typeResolver')->resolve('$c->referenceType')");
+            $array->addItem('referenceType', "$this->globalVars->get('typeResolver')->resolve('$c->referenceType')");
         }
 
-        return $result; // @phpstan-ignore-line
+        return $array; // @phpstan-ignore-line
     }
 
+    /**
+     * Render example:
+     *
+     *      [
+     *          'firstName' => {@see buildValidationRules},
+     *          'lastName' => {@see buildValidationRules},
+     *          ...
+     *      ]
+     *
+     * @throws GeneratorException
+     */
     protected function buildProperties(array $properties): Collection
     {
         $array = Collection::assoc();
@@ -518,6 +708,21 @@ class TypeBuilder
     }
 
     /**
+     * Render example:
+     *
+     *      [
+     *          'type' => {@see buildType},
+     *          'description' => 'Some description.',
+     *          'deprecationReason' => 'This field will be removed soon.',
+     *          'args' => fn() => [
+     *              {@see buildArg},
+     *              {@see buildArg},
+     *               ...
+     *           ],
+     *          'resolve' => {@see buildResolve},
+     *          'complexity' => {@see buildComplexity},
+     *      ]
+     *
      * @param array{
      *     type:              string,
      *     resolve?:          string,
@@ -528,10 +733,12 @@ class TypeBuilder
      *     validation?:       array,
      * } $fieldConfig
      *
-     * @return GeneratorInterface|Collection|string
+     * @internal
      *
      * @throws GeneratorException
      * @throws UnrecognizedValueTypeException
+     *
+     * @return GeneratorInterface|Collection|string
      */
     public function buildField(array $fieldConfig /*, $fieldname */)
     {
@@ -576,19 +783,35 @@ class TypeBuilder
             $field->addItem('access', $this->buildAccess($c->access));
         }
 
-        if (!empty($c->access) && is_string($c->access) && ExpressionLanguage::expressionContainsVar('object', $c->access)) {
+        if (!empty($c->access) && is_string($c->access) && EL::expressionContainsVar('object', $c->access)) {
             $field->addItem('useStrictAccess', false);
         }
 
         if ('input-object' === $this->type && isset($c->validation)) {
-            $this->restructureInputValidationConfig($fieldConfig);
-            $field->addItem('validation', $this->buildValidationRules($fieldConfig['validation']));
+            // restructure validation config
+            if (!empty($c->validation['cascade'])) {
+                $c->validation['cascade']['isCollection'] = $this->isCollectionType($c->type);
+                $c->validation['cascade']['referenceType'] = trim($c->type, '[]!');
+            }
+
+            $field->addItem('validation', $this->buildValidationRules($c->validation));
         }
 
         return $field;
     }
 
     /**
+     * Render example:
+     *
+     *      [
+     *          'name' => 'username',
+     *          'type' => {@see buildType},
+     *          'description' => 'Some fancy description.',
+     *          'defaultValue' => 'admin',
+     *      ]
+     *
+     * @internal
+     *
      * @param array{
      *     type: string,
      *     description?: string,
@@ -616,16 +839,29 @@ class TypeBuilder
     }
 
     /**
+     * Builds a closure or an arrow function, depending on whether the `args` param is provided.
+     *
+     * Render example (closure):
+     *
+     *      function ($value, $arguments) use ($globalVariables) {
+     *          $args = $globalVariables->get('argumentFactory')->create($arguments);
+     *          return ($args['age'] + 5);
+     *      }
+     *
+     * Render example (arrow function):
+     *
+     *      fn($childrenComplexity) => ($childrenComplexity + 20);
+     *
      * @param mixed $complexity
      *
      * @return Closure|mixed
      */
     protected function buildComplexity($complexity)
     {
-        if ($this->expressionConverter->check($complexity)) {
+        if (EL::isStringWithTrigger($complexity)) {
             $expression = $this->expressionConverter->convert($complexity);
 
-            if (ExpressionLanguage::expressionContainsVar('args', $complexity)) {
+            if (EL::expressionContainsVar('args', $complexity)) {
                 return Closure::new()
                     ->addArgument('childrenComplexity')
                     ->addArgument('arguments', '', [])
@@ -637,7 +873,7 @@ class TypeBuilder
 
             $arrow = ArrowFunction::new(is_string($expression) ? new Literal($expression) : $expression);
 
-            if (ExpressionLanguage::expressionContainsVar('childrenComplexity', $complexity)) {
+            if (EL::expressionContainsVar('childrenComplexity', $complexity)) {
                 $arrow->addArgument('childrenComplexity');
             }
 
@@ -648,21 +884,28 @@ class TypeBuilder
     }
 
     /**
+     * Builds an arrow function from a string with an expression prefix,
+     * otherwise just returns the provided value back untouched.
+     *
+     * Render example (if expression):
+     *
+     *      fn($fieldName, $typeName = self::NAME) => ($fieldName == "name")
+     *
      * @param mixed $public
      *
      * @return ArrowFunction|mixed
      */
     protected function buildPublic($public)
     {
-        if ($this->expressionConverter->check($public)) {
+        if (EL::isStringWithTrigger($public)) {
             $expression = $this->expressionConverter->convert($public);
             $arrow = ArrowFunction::new(Literal::new($expression));
 
-            if (ExpressionLanguage::expressionContainsVar('fieldName', $public)) {
+            if (EL::expressionContainsVar('fieldName', $public)) {
                 $arrow->addArgument('fieldName');
             }
 
-            if (ExpressionLanguage::expressionContainsVar('typeName', $public)) {
+            if (EL::expressionContainsVar('typeName', $public)) {
                 $arrow->addArgument('fieldName');
                 $arrow->addArgument('typeName', '', new Literal('self::NAME'));
             }
@@ -674,13 +917,20 @@ class TypeBuilder
     }
 
     /**
+     * Builds an arrow function from a string with an expression prefix,
+     * otherwise just returns the provided value back untouched.
+     *
+     * Render example (if expression):
+     *
+     *      fn($value, $args, $context, $info, $object) => $globalVariables->get('private_service')->hasAccess()
+     *
      * @param mixed $access
      *
      * @return ArrowFunction|mixed
      */
     protected function buildAccess($access)
     {
-        if ($this->expressionConverter->check($access)) {
+        if (EL::isStringWithTrigger($access)) {
             $expression = $this->expressionConverter->convert($access);
 
             return ArrowFunction::new()
@@ -692,13 +942,20 @@ class TypeBuilder
     }
 
     /**
+     * Builds an arrow function from a string with an expression prefix,
+     * otherwise just returns the provided value back untouched.
+     *
+     * Render example:
+     *
+     *      fn($value, $context, $info) => $globalVariables->get('typeResolver')->resolve($value)
+     *
      * @param mixed $resolveType
      *
      * @return mixed|ArrowFunction
      */
     protected function buildResolveType($resolveType)
     {
-        if ($this->expressionConverter->check($resolveType)) {
+        if (EL::isStringWithTrigger($resolveType)) {
             $expression = $this->expressionConverter->convert($resolveType);
 
             return ArrowFunction::new()
@@ -707,17 +964,6 @@ class TypeBuilder
         }
 
         return $resolveType;
-    }
-
-    // TODO (murtukov): rework this method to use builders
-    protected function restructureInputValidationConfig(array &$fieldConfig): void
-    {
-        if (empty($fieldConfig['validation']['cascade'])) {
-            return;
-        }
-
-        $fieldConfig['validation']['cascade']['isCollection'] = $this->isCollectionType($fieldConfig['type']);
-        $fieldConfig['validation']['cascade']['referenceType'] = trim($fieldConfig['type'], '[]!');
     }
 
     // TODO (murtukov): rework this method to use builders
@@ -776,13 +1022,13 @@ class TypeBuilder
     }
 
     /**
-     * Creates and array from a formatted string, e.g.:.
+     * Creates and array from a formatted string.
      *
-     * ```
-     *    "App\Entity\User::$firstName"  -> ['App\Entity\User', 'firstName', 'property']
-     *    "App\Entity\User::firstName()" -> ['App\Entity\User', 'firstName', 'getter']
-     *    "App\Entity\User::firstName"   -> ['App\Entity\User', 'firstName', 'member']
-     * ```.
+     * Examples:
+     *
+     *      "App\Entity\User::$firstName"  -> ['App\Entity\User', 'firstName', 'property']
+     *      "App\Entity\User::firstName()" -> ['App\Entity\User', 'firstName', 'getter']
+     *      "App\Entity\User::firstName"   -> ['App\Entity\User', 'firstName', 'member']
      */
     protected function normalizeLink(string $link): array
     {

--- a/src/Generator/TypeBuilder.php
+++ b/src/Generator/TypeBuilder.php
@@ -436,7 +436,7 @@ class TypeBuilder
      * @throws GeneratorException
      * @throws UnrecognizedValueTypeException
      *
-     * @return GeneratorInterface
+     * @return GeneratorInterface|string
      */
     protected function buildResolve($resolve, ?array $validationConfig = null)
     {
@@ -444,11 +444,11 @@ class TypeBuilder
             return Collection::numeric($resolve);
         }
 
-        $closure = Closure::new()
-            ->addArguments('value', 'args', 'context', 'info')
-            ->bindVar(TypeGenerator::GLOBAL_VARS);
-
         if (EL::isStringWithTrigger($resolve)) {
+            $closure = Closure::new()
+                ->addArguments('value', 'args', 'context', 'info')
+                ->bindVar(TypeGenerator::GLOBAL_VARS);
+
             $injectErrors = EL::expressionContainsVar('errors', $resolve);
 
             if ($injectErrors) {
@@ -491,9 +491,7 @@ class TypeBuilder
             return $closure;
         }
 
-        $closure->append('return ', Utils::stringify($resolve));
-
-        return $closure;
+        return ArrowFunction::new($resolve);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

- Add extended PHPDocs with code examples to each method of TypeBuilder
- Disable PHP-CS-Fixer rule to add unnecessary dots (they were added even after `:`
- Create static method `ExpressionLanguage::isStringWithTrigger`
- Other minor changes