### PR TITLE
Fix Profiler bug

### DIFF
--- a/src/Controller/ProfilerController.php
+++ b/src/Controller/ProfilerController.php
@@ -55,8 +55,10 @@ class ProfilerController
 
         $tokens = array_map(function ($tokenData) {
             $profile = $this->profiler->loadProfile($tokenData['token']);
-            $graphql = $profile ? $profile->getCollector('graphql') : null;
-            $tokenData['graphql'] = $graphql;
+            if (!$profile->hasCollector('graphql')) {
+                return false;
+            }
+            $tokenData['graphql'] = $profile->getCollector('graphql');
 
             return $tokenData;
         }, $this->profiler->find(null, $this->queryMatch ?: $this->endpointUrl, '100', 'POST', null, null, null)); // @phpstan-ignore-line
@@ -69,7 +71,7 @@ class ProfilerController
         return new Response($this->twig->render('@OverblogGraphQL/profiler/graphql.html.twig', [
             'request' => $request,
             'profile' => $profile,
-            'tokens' => $tokens,
+            'tokens' => array_filter($tokens),
             'token' => $token,
             'panel' => null,
             'schemas' => $schemas,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

[Symfony Profiler](https://symfony.com/doc/current/profiler.html) generates and saves profiles on every request. Every profile object contains a list of `DataCollector`'s, that were used to create it. If for some reason your project contains a profile, that was generated before the `GraphQLCollector` was introduced, it will throw an error, when you open the GraphQL tab in the Profiler, because it tries to iterate over all generated profiles and use a GraphQLCollector object, which doesn't exist.

This PR also replaces deprecated test methods with new ones.