### PR TITLE
Update generated types

### DIFF
--- a/tests/Resolver/TypeResolverTest.php
+++ b/tests/Resolver/TypeResolverTest.php
@@ -4,11 +4,8 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Tests\Resolver;
 
-use GraphQL\Type\Definition\ListOfType;
-use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
-use GraphQL\Type\Definition\WrappingType;
 use Overblog\GraphQLBundle\Resolver\TypeResolver;
 use Overblog\GraphQLBundle\Resolver\UnresolvableException;
 use Overblog\GraphQLBundle\Resolver\UnsupportedResolverException;
@@ -58,72 +55,6 @@ class TypeResolverTest extends AbstractResolverTest
     {
         $this->expectException(UnresolvableException::class);
         $this->resolver->resolve('Fake');
-    }
-
-    public function testWrongListOfWrappingType(): void
-    {
-        $this->expectException(UnresolvableException::class);
-        $this->expectExceptionMessage('Malformed ListOf wrapper type "[Tata" expected "]" but got ""a"".');
-        $this->resolver->resolve('[Tata');
-    }
-
-    public function testResolveWithListOfWrapper(): void
-    {
-        /** @var WrappingType $type */
-        $type = $this->resolver->resolve('[Tata]');
-
-        $this->assertInstanceOf(ListOfType::class, $type);
-        $this->assertSame('Tata', $type->getWrappedType()->name);
-    }
-
-    public function testResolveWithNonNullWrapper(): void
-    {
-        /** @var WrappingType $type */
-        $type = $this->resolver->resolve('Toto!');
-
-        $this->assertInstanceOf(NonNull::class, $type);
-        $this->assertSame('Toto', $type->getWrappedType()->name);
-    }
-
-    public function testResolveWithNonNullListOfWrapper(): void
-    {
-        /** @var NonNull $type */
-        $type = $this->resolver->resolve('[Toto]!');
-
-        $this->assertInstanceOf(NonNull::class, $type);
-        $this->assertInstanceOf(ListOfType::class, $type->getWrappedType());
-        $this->assertSame('Toto', $type->getWrappedType()->getWrappedType()->name);
-    }
-
-    public function testResolveWitListOfNonNullWrapper(): void
-    {
-        /** @var ListOfType $type */
-        $type = $this->resolver->resolve('[Toto!]');
-
-        $this->assertInstanceOf(ListOfType::class, $type);
-        $this->assertInstanceOf(NonNull::class, $type->getWrappedType());
-        $this->assertSame('Toto', $type->getWrappedType()->getWrappedType()->name);
-    }
-
-    public function testResolveWitNonNullListOfNonNullWrapper(): void
-    {
-        /** @var NonNull $type */
-        $type = $this->resolver->resolve('[Toto!]!');
-
-        $this->assertInstanceOf(NonNull::class, $type);
-        $this->assertInstanceOf(ListOfType::class, $type->getWrappedType());
-        $this->assertInstanceOf(NonNull::class, $type->getWrappedType()->getWrappedType());
-        $this->assertSame('Toto', $type->getWrappedType()->getWrappedType()->getWrappedType()->name);
-    }
-
-    public function testResolveWitListOfListOfWrapper(): void
-    {
-        /** @var ListOfType $type */
-        $type = $this->resolver->resolve('[[Toto]]');
-
-        $this->assertInstanceOf(ListOfType::class, $type);
-        $this->assertInstanceOf(ListOfType::class, $type->getWrappedType());
-        $this->assertSame('Toto', $type->getWrappedType()->getWrappedType()->name);
     }
 
     public function testAliases(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | webonyx/graphql-php#425, webonyx/graphql-php#557

As described here webonyx/graphql-php#425, instantiating schemas with many types can hit performance. It was suggested (and implemented) to wrap field type definitions into a closure for [lazy loading](https://en.wikipedia.org/wiki/Lazy_loading).

This PR updates the `TypeBuilder` class to generate proper field types. It wraps only user-defined types into a closure.

Example:
```php
$config = [
    'fields' => fn() => [
        'street' => Type::nonNull(Type::string()),
        'city' => Type::nonNull(Type::string()),
        'zipCode' => Type::nonNull(Type::int()),
        'period' => fn() => Type::nonNull($globalVariables->get('typeResolver')->resolve('Period')),
    ],
];
```
---
Also some unused methods were removed from `TypeResolver`, as `TypeGenerator` never generates references like this:
```php
$globalVariables->get('typeResolver')->resolve('[Address]');
```
but generates this instead:
```php
Type::listOf($globalVariables->get('typeResolver')->resolve('Address'));
```