### PR TITLE
Fixes #789 - pass the full query to the executor

### DIFF
--- a/src/Controller/GraphController.php
+++ b/src/Controller/GraphController.php
@@ -135,7 +135,7 @@ class GraphController
 
         foreach ($queries as $query) {
             $payload = $this->requestExecutor
-                ->execute($schemaName, ['query' => $query['query'], 'variables' => $query['variables']])
+                ->execute($schemaName, $query)
                 ->toArray();
             if (!$this->useApolloBatchingMethod) {
                 $payload = ['id' => $query['id'], 'payload' => $payload];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | n/a - I haven't been able to do this yet, will try to shortly
| Documented?   | no
| Fixed tickets | #789 
| License       | MIT

The operationName is not passed when using the batch endpoint. It seems the code as it is explicitly passes the query and the variables, and this fix instead passes all elements of the query through. I think this is simpler - but I'm concerned I may be missing something as to why they are explicitly passed. 

The alternative would be as follows:

```
->execute($schemaName, ['query' => $query['query'], 'variables' => $query['variables'], 'operationName' => $query['operationName'])
```

I would welcome feedback from someone who knows the code base better. Thank you.