### PR TITLE
[0.13] Make sure that internal_error_message is used during ErrorHandler initialization

### DIFF
--- a/src/DependencyInjection/OverblogGraphQLExtension.php
+++ b/src/DependencyInjection/OverblogGraphQLExtension.php
@@ -207,7 +207,8 @@ class OverblogGraphQLExtension extends Extension
 
         $container->register(ErrorHandler::class)
             ->setArgument(0, new Reference(EventDispatcherInterface::class))
-            ->setArgument(1, new Reference(ExceptionConverterInterface::class));
+            ->setArgument(1, new Reference(ExceptionConverterInterface::class))
+            ->setArgument(2, $config['errors_handler']['internal_error_message']);
 
         $container->register(ErrorHandlerListener::class)
             ->setArgument(0, new Reference(ErrorHandler::class))


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #802
| License       | MIT

The third argument for `Overblog\GraphQLBundle\Error\ErrorHandler` is the default
message to use when an error happens. As described in the documentation
`overblog_graphql.errors_handler.internal_error_message` can be used to set a
custom message.

