### PR TITLE
Fix annotation for non-nullable array of non-nullable values as query argument

### DIFF
--- a/src/Transformer/ArgumentsTransformer.php
+++ b/src/Transformer/ArgumentsTransformer.php
@@ -132,7 +132,12 @@ class ArgumentsTransformer
     {
         $isRequired = '!' === $argType[strlen($argType) - 1];
         $isMultiple = '[' === $argType[0];
-        $endIndex = ($isRequired ? 1 : 0) + ($isMultiple ? 1 : 0);
+        $isStrictMultiple = false;
+        if ($isMultiple) {
+            $isStrictMultiple = '!' === $argType[strpos($argType, ']') - 1];
+        }
+
+        $endIndex = ($isRequired ? 1 : 0) + ($isMultiple ? 1 : 0) + ($isStrictMultiple ? 1 : 0);
         $type = substr($argType, $isMultiple ? 1 : 0, $endIndex > 0 ? -$endIndex : strlen($argType));
 
         $result = $this->populateObject($this->getType($type, $info), $data, $isMultiple, $info);

--- a/tests/Transformer/ArgumentsTransformerTest.php
+++ b/tests/Transformer/ArgumentsTransformerTest.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Tests\Transformer;
 
 use Exception;
+use Generator;
 use GraphQL\Type\Definition\EnumType;
 use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\ListOfType;
+use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
@@ -299,5 +302,76 @@ class ArgumentsTransformerTest extends TestCase
 
             $this->assertEquals($e->toState(), $expected);
         }
+    }
+
+    public function getWrappedInputObject(): Generator
+    {
+        $inputObject = new InputObjectType([
+            'name' => 'InputType1',
+            'fields' => [
+                'field1' => Type::string(),
+                'field2' => Type::int(),
+                'field3' => Type::boolean(),
+            ],
+        ]);
+        yield [$inputObject, false];
+        yield [new NonNull($inputObject), false];
+    }
+
+    /** @dataProvider getWrappedInputObject */
+    public function testInputObjectWithWrappingType(Type $type): void
+    {
+        $transformer = $this->getTransformer([
+                'InputType1' => ['type' => 'input', 'class' => InputType1::class],
+            ], new ConstraintViolationList()
+        );
+        $info = $this->getResolveInfo(self::getTypes());
+
+        $data = ['field1' => 'hello', 'field2' => 12, 'field3' => true];
+
+        $inputValue = $transformer->getInstanceAndValidate($type->toString(), $data, $info, 'input1');
+
+        /** @var InputType1 $inputValue */
+        $this->assertInstanceOf(InputType1::class, $inputValue);
+        $this->assertEquals($inputValue->field1, $data['field1']);
+        $this->assertEquals($inputValue->field2, $data['field2']);
+        $this->assertEquals($inputValue->field3, $data['field3']);
+    }
+
+    public function getWrappedInputObjectList(): Generator
+    {
+        $inputObject = new InputObjectType([
+            'name' => 'InputType1',
+            'fields' => [
+                'field1' => Type::string(),
+                'field2' => Type::int(),
+                'field3' => Type::boolean(),
+            ],
+        ]);
+        yield [new ListOfType($inputObject)];
+        yield [new ListOfType(new NonNull($inputObject))];
+        yield [new NonNull(new ListOfType($inputObject))];
+        yield [new NonNull(new ListOfType(new NonNull($inputObject)))];
+    }
+
+    /** @dataProvider getWrappedInputObjectList */
+    public function testInputObjectWithWrappingTypeList(Type $type): void
+    {
+        $transformer = $this->getTransformer(
+            ['InputType1' => ['type' => 'input', 'class' => InputType1::class]],
+            new ConstraintViolationList()
+        );
+        $info = $this->getResolveInfo(self::getTypes());
+
+        $data = ['field1' => 'hello', 'field2' => 12, 'field3' => true];
+
+        $inputValue = $transformer->getInstanceAndValidate($type->toString(), [$data], $info, 'input1');
+        $inputValue = reset($inputValue);
+
+        /** @var InputType1 $inputValue */
+        $this->assertInstanceOf(InputType1::class, $inputValue);
+        $this->assertEquals($inputValue->field1, $data['field1']);
+        $this->assertEquals($inputValue->field2, $data['field2']);
+        $this->assertEquals($inputValue->field3, $data['field3']);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| RFC? | yes
| Version       | 0.13.5

When i use annotation to map argument as "Non-nullable array of non-nullable values" the scheme is built correctly. But i got error during query execution:

`GraphQL\Error\InvariantViolation: Type loader is expected to return type "Int!", but it returned ""[0]`


Example of mapping:
```php
/**
 * @GQL\Query(type="[Order]", name="order",
 *     args={
 *         @GQL\Arg(name="orderIds", type="[Int!]!"),
 *     }
 * )
 */
public function getOrders(array $orderIds): Promise
{
    ...
}
```