### PR TITLE
Fix 0.13 calling preg_replace_callback with a NULL argument in PHP 8

### DIFF
--- a/lib/generator/src/ClassUtils.php
+++ b/lib/generator/src/ClassUtils.php
@@ -29,6 +29,10 @@ abstract class ClassUtils
 
     public static function shortenClassFromCode($code, callable $callback = null)
     {
+        if (null === $code) {
+            return '';
+        }
+
         if (null === $callback) {
             $callback = function ($matches) {
                 return static::shortenClassName($matches[1]);

--- a/lib/generator/tests/ClassUtilsTest.php
+++ b/lib/generator/tests/ClassUtilsTest.php
@@ -33,6 +33,7 @@ class ClassUtilsTest extends TestCase
         return [
             ['$toto, \Toto\Tata $test', '$toto, Tata $test'],
             ['\Tata $test', 'Tata $test'],
+            [null, ''],
         ];
     }
 }


### PR DESCRIPTION
PHP 8 has a stricter type definition for the third argument of `preg_replace_callback`:
`preg_replace_callback(): Argument #3 ($subject) must be of type array|string, null given`

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Documented?   | no
| License       | MIT

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
