### PR TITLE
Allow interfaces implement interfaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "symfony/framework-bundle": "^4.4 || ^5.0",
         "symfony/options-resolver": "^4.4 || ^5.0",
         "symfony/property-access": "^4.4 || ^5.0",
-        "webonyx/graphql-php": "^14.0.1"
+        "webonyx/graphql-php": ">=14.5"
     },
     "suggest": {
         "nelmio/cors-bundle": "For more flexibility when using CORS prefight",

--- a/src/Config/InterfaceTypeDefinition.php
+++ b/src/Config/InterfaceTypeDefinition.php
@@ -13,12 +13,16 @@ class InterfaceTypeDefinition extends TypeWithOutputFieldsDefinition
         /** @var ArrayNodeDefinition $node */
         $node = self::createNode('_interface_config');
 
+        /** @phpstan-ignore-next-line */
         $node
             ->children()
                 ->append($this->nameSection())
                 ->append($this->outputFieldsSection())
                 ->append($this->resolveTypeSection())
                 ->append($this->descriptionSection())
+                ->arrayNode('interfaces')
+                    ->prototype('scalar')->info('One of internal or custom interface types.')->end()
+                ->end()
             ->end();
 
         return $node;

--- a/tests/Functional/App/config/global/config.yml
+++ b/tests/Functional/App/config/global/config.yml
@@ -15,6 +15,7 @@ overblog_graphql:
         schema:
             query: Query
             mutation: ~
+            types: [User, Photo, Post]
         mappings:
             types:
                 -

--- a/tests/Functional/Command/fixtures/schema.descriptions.json
+++ b/tests/Functional/Command/fixtures/schema.descriptions.json
@@ -782,7 +782,7 @@
                     },
                     {
                         "name": "INTERFACE",
-                        "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
+                        "description": "Indicates this type is an interface. `fields`, `interfaces`, and `possibleTypes` are valid fields.",
                         "isDeprecated": false,
                         "deprecationReason": null
                     },

--- a/tests/Functional/Relay/Node/GlobalTest.php
+++ b/tests/Functional/Relay/Node/GlobalTest.php
@@ -16,19 +16,18 @@ class GlobalTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-
         static::bootKernel(['test_case' => 'global']);
     }
 
     public function testGlobalIdFields(): void
     {
         $query = <<<'EOF'
-{
-  allObjects {
-    id
-  }
-}
-EOF;
+        {
+          allObjects {
+            id
+          }
+        }
+        EOF;
 
         $expectedData = [
             'allObjects' => [
@@ -59,28 +58,29 @@ EOF;
     public function testReFetchesTheIds(): void
     {
         $query = <<<'EOF'
-{
-      user: node(id: "VXNlcjox") {
-        id
-        ... on User {
-          name
+        {
+          user: node(id: "VXNlcjox") {
+            id
+            ... on User {
+              name
+            }
+          },
+          photo: node(id: "UGhvdG86MQ==") {
+            id
+            ... on Photo {
+              width
+            }
+          },
+          post: node(id: "UG9zdDox") {
+            id
+            ... on Post {
+              text
+              status
+            }
+          }
         }
-      },
-      photo: node(id: "UGhvdG86MQ==") {
-        id
-        ... on Photo {
-          width
-        }
-      },
-      post: node(id: "UG9zdDox") {
-        id
-        ... on Post {
-          text
-          status
-        }
-      }
-    }
-EOF;
+        EOF;
+
         $expectedData = [
             'user' => [
                 'id' => 'VXNlcjox',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | https://github.com/graphql/graphql-spec/pull/373

According to the GraphQL Specification update, interfaces can implement other interfaces. The webonyx/graphql-php already implemented it in 14.5.0 (https://github.com/webonyx/graphql-php/pull/740). This PR makes corresponding changes.
