### PR TITLE
Fix PHP 8.0 deprecation in uksort

### DIFF
--- a/src/Config/Processor/InheritanceProcessor.php
+++ b/src/Config/Processor/InheritanceProcessor.php
@@ -85,7 +85,7 @@ final class InheritanceProcessor implements ProcessorInterface
 
         // Restore initial order
         \uksort($parentTypes, function ($a, $b) use ($parents) {
-            return (int) \array_search($a, $parents, true) > \array_search($b, $parents, true);
+            return (int) (\array_search($a, $parents, true) > \array_search($b, $parents, true));
         });
 
         $mergedParentsConfig = self::mergeConfigs(...\array_column($parentTypes, 'config'));

--- a/src/Config/Processor/InheritanceProcessor.php
+++ b/src/Config/Processor/InheritanceProcessor.php
@@ -85,7 +85,7 @@ final class InheritanceProcessor implements ProcessorInterface
 
         // Restore initial order
         \uksort($parentTypes, function ($a, $b) use ($parents) {
-            return \array_search($a, $parents, true) > \array_search($b, $parents, true);
+            return (int) \array_search($a, $parents, true) > \array_search($b, $parents, true);
         });
 
         $mergedParentsConfig = self::mergeConfigs(...\array_column($parentTypes, 'config'));


### PR DESCRIPTION
Since PHP 8.0 it is deprecated behaviour for the callback in `uksort` to
return a boolean and it must return an integer.

Fixes #831

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #831
| License       | MIT

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
