### PR TITLE
Fix uksort() callback returning bool deprecation

### DIFF
--- a/src/Config/Processor/InheritanceProcessor.php
+++ b/src/Config/Processor/InheritanceProcessor.php
@@ -85,7 +85,7 @@ final class InheritanceProcessor implements ProcessorInterface
 
         // Restore initial order
         \uksort($parentTypes, function ($a, $b) use ($parents) {
-            return \array_search($a, $parents, true) > \array_search($b, $parents, true);
+            return \array_search($a, $parents, true) > \array_search($b, $parents, true) ? 1 : 0;
         });
 
         $mergedParentsConfig = self::mergeConfigs(...\array_column($parentTypes, 'config'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Documented?   | no
| Fixed tickets | #831
| License       | MIT

Fixes a deprecation on PHP 8.0:

> uksort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero

This targets `0.12` as the `uksort()` call was introduced in this branch.

Not sure why all tests fail: failures are unrelated to this commit (I tried reverting it, same result).