### PR TITLE
Fix error handler configuration example

### DIFF
--- a/docs/error-handling/index.md
+++ b/docs/error-handling/index.md
@@ -140,7 +140,7 @@ You can custom the default errors handler using configuration:
 overblog_graphql:
     errors_handler:
         enabled: true # false will totally disabled errors handling
-        internal_error_message: ~ # custom generic error message
+        internal_error_message: 'Internal error occured' # custom generic error message
         rethrow_internal_exceptions: false # re-throw internal exception
         debug: false # will add trace stack and debugMessage to error
         log: true # false will disabled the default logging behavior

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -92,7 +92,7 @@ class Configuration implements ConfigurationInterface
             ->addDefaultsIfNotSet()
             ->children()
                 ->booleanNode('enabled')->defaultTrue()->end()
-                ->scalarNode('internal_error_message')->defaultValue(ErrorHandler::DEFAULT_ERROR_MESSAGE)->end()
+                ->scalarNode('internal_error_message')->defaultValue(ErrorHandler::DEFAULT_ERROR_MESSAGE)->cannotBeEmpty()->end()
                 ->booleanNode('rethrow_internal_exceptions')->defaultFalse()->end()
                 ->booleanNode('debug')->defaultValue($this->debug)->end()
                 ->booleanNode('log')->defaultTrue()->end()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| License       | MIT

Since https://github.com/overblog/GraphQLBundle/pull/803, the example here results in runtime error due to the fact that internal_error_message in `ErrorHandler::__construct` is non-nullable.
