### PR TITLE
fix(ErrorHandler): Argument 3 passed to Overblog\GraphQLBundle\Error\ErrorHandler::__construct() must be of the type string, null given

### DIFF
--- a/src/DependencyInjection/OverblogGraphQLExtension.php
+++ b/src/DependencyInjection/OverblogGraphQLExtension.php
@@ -196,10 +196,12 @@ class OverblogGraphQLExtension extends Extension
             ->setArgument(0, $this->buildExceptionMap($config['errors_handler']['exceptions']))
             ->setArgument(1, $config['errors_handler']['map_exceptions_to_parent']);
 
-        $container->register(ErrorHandler::class)
+        $errorHandlerDefinition = $container->register(ErrorHandler::class)
             ->setArgument(0, new Reference(EventDispatcherInterface::class))
-            ->setArgument(1, new Reference(ExceptionConverterInterface::class))
-            ->setArgument(2, $config['errors_handler']['internal_error_message']);
+            ->setArgument(1, new Reference(ExceptionConverterInterface::class));
+        if (!empty($config['errors_handler']['internal_error_message'])) {
+            $errorHandlerDefinition->setArgument(2, $config['errors_handler']['internal_error_message']);
+        }
 
         $container->register(ErrorHandlerListener::class)
             ->setArgument(0, new Reference(ErrorHandler::class))


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Documented?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->

because, I have the following error during `KernelTerminate` event:

> Argument 3 passed to Overblog\GraphQLBundle\Error\ErrorHandler::__construct() must be of the type string, null given

using the following YAML bundle configuration:
```yaml
overblog_graphql:
    # ...
    errors_handler:
        enabled: true
        internal_error_message: ~
        rethrow_internal_exceptions: true
        debug: true
        log: false
        logger_service: logger
 ```

using Symfony `v4.4.26` and GraphQLBundle `v0.13.6`