### PR TITLE
Always compile types with `AliasedInterface`

### DIFF
--- a/src/Generator/TypeBuilder.php
+++ b/src/Generator/TypeBuilder.php
@@ -23,6 +23,7 @@ use Murtukov\PHPCodeGenerator\PhpFile;
 use Murtukov\PHPCodeGenerator\Utils;
 use Overblog\GraphQLBundle\Definition\ConfigProcessor;
 use Overblog\GraphQLBundle\Definition\GraphQLServices;
+use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
 use Overblog\GraphQLBundle\Definition\Type\CustomScalarType;
 use Overblog\GraphQLBundle\Definition\Type\GeneratedTypeInterface;
 use Overblog\GraphQLBundle\Error\ResolveErrors;
@@ -120,6 +121,7 @@ class TypeBuilder
             ->setFinal()
             ->setExtends(static::EXTENDS[$type])
             ->addImplements(GeneratedTypeInterface::class)
+            ->addImplements(AliasedInterface::class)
             ->addConst('NAME', $config['name'])
             ->setDocBlock(static::DOCBLOCK_TEXT);
 
@@ -131,6 +133,10 @@ class TypeBuilder
             ->append('$config = ', $this->buildConfig($config))
             ->emptyLine()
             ->append('parent::__construct($configProcessor->process($config))');
+
+        $class->createMethod('getAliases', 'public static', 'array')
+            ->append('return [self::NAME]')
+            ->setDocBlock('{@inheritdoc}');
 
         return $this->file;
     }

--- a/src/Generator/TypeBuilder.php
+++ b/src/Generator/TypeBuilder.php
@@ -120,8 +120,7 @@ class TypeBuilder
         $class = $this->file->createClass($config['class_name'])
             ->setFinal()
             ->setExtends(static::EXTENDS[$type])
-            ->addImplements(GeneratedTypeInterface::class)
-            ->addImplements(AliasedInterface::class)
+            ->addImplements(GeneratedTypeInterface::class, AliasedInterface::class)
             ->addConst('NAME', $config['name'])
             ->setDocBlock(static::DOCBLOCK_TEXT);
 
@@ -134,9 +133,11 @@ class TypeBuilder
             ->emptyLine()
             ->append('parent::__construct($configProcessor->process($config))');
 
-        $class->createMethod('getAliases', 'public static', 'array')
-            ->append('return [self::NAME]')
-            ->setDocBlock('{@inheritdoc}');
+        $class->createMethod('getAliases', 'public')
+            ->setStatic()
+            ->setReturnType('array')
+            ->setDocBlock('{@inheritdoc}')
+            ->append('return [self::NAME]');
 
         return $this->file;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | ?
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | 
| License       | MIT

I noticed that types generated by `graphql:compile` don't include the `AliasedInterface`. This is weird, because in my YAML definition I reference everything with aliases. 
