### PR TITLE
Make `GraphQLServices::getType` non null

### DIFF
--- a/src/Definition/GraphQLServices.php
+++ b/src/Definition/GraphQLServices.php
@@ -34,9 +34,15 @@ final class GraphQLServices extends ServiceLocator
         return $this->get('mutationResolver')->resolve([$alias, $args]);
     }
 
-    public function getType(string $typeName): ?Type
+    public function getType(string $typeName): Type
     {
-        return $this->get('typeResolver')->resolve($typeName);
+        $type = $this->get('typeResolver')->resolve($typeName);
+        
+        if ($type === null) {
+            throw new \Exception(sprintf('Type "%s" not found.', $typeName));
+        }
+        
+        return $type;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | yes
| Tests pass?   |
| Documented?   | no
| Fixed tickets | 
| License       | MIT

Not sure why this was done, but it makes PHPStan very unhappy when using:
```php
Type::nonNull($services->getType(UriType::class))
// Parameter #1 $wrappedType of static method GraphQL\Type\Definition\Type::nonNull() expects (callable(): mixed)|GraphQL\Type\Definition\NullableType, GraphQL\Type\Definition\Type|null given.
```

Before I finish the todo, I'd like to know if this can be accepted. 

An alternative could be to introduce a new `getTypeOrThrow`.

Will 1.0 target PHP 8? In that case, the syntax can be improved by using `return $this->get('typeResolver')->resolve($typeName) ?? throw \Exception...`

## Todo
- [ ] Introduce specific Exception
- [ ] Add tests
- [ ] Document it
