### PR TITLE
Expose `request` in context

### DIFF
--- a/src/EventListener/RequestFilesListener.php
+++ b/src/EventListener/RequestFilesListener.php
@@ -26,6 +26,7 @@ final class RequestFilesListener
         }
 
         $context = $event->getExecutorContext();
+        $context['request'] = $request;
         $context['request_files'] = $request->files;
     }
 }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    |no
| Deprecations? |no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | 
| License       | MIT

Since all GraphQL operations are (mostly) always bound to a request lifecycle it makes sense to expose the request in the context.
This saves implementors from querying the RequestStack to get the request.
