### PR TITLE
#896: Removed deprecated compiler pass.

### DIFF
--- a/src/OverblogGraphQLBundle.php
+++ b/src/OverblogGraphQLBundle.php
@@ -48,8 +48,6 @@ class OverblogGraphQLBundle extends Bundle
         $container->addCompilerPass(new TypeTaggedServiceMappingPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $container->addCompilerPass(new QueryTaggedServiceMappingPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $container->addCompilerPass(new MutationTaggedServiceMappingTaggedPass(), PassConfig::TYPE_BEFORE_REMOVING);
-        // TODO: remove next line in 1.0
-        $container->addCompilerPass(new ResolverTaggedServiceMappingPass(), PassConfig::TYPE_BEFORE_REMOVING);
     }
 
     public function getContainerExtension()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | https://github.com/overblog/GraphQLBundle/issues/896
| License       | MIT

This PR solves the issue where our container compilation fails because of a missing compiler pass
