### PR TITLE
Fix DebugCommand dependency injection

### DIFF
--- a/src/Command/DebugCommand.php
+++ b/src/Command/DebugCommand.php
@@ -5,9 +5,6 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Command;
 
 use Overblog\GraphQLBundle\Resolver\FluentResolverInterface;
-use Overblog\GraphQLBundle\Resolver\MutationResolver;
-use Overblog\GraphQLBundle\Resolver\ResolverResolver;
-use Overblog\GraphQLBundle\Resolver\TypeResolver;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -19,24 +16,24 @@ class DebugCommand extends Command
     private static $categories = ['type', 'mutation', 'resolver'];
 
     /**
-     * @var TypeResolver
+     * @var FluentResolverInterface
      */
     private $typeResolver;
 
     /**
-     * @var MutationResolver
+     * @var FluentResolverInterface
      */
     private $mutationResolver;
 
     /**
-     * @var ResolverResolver
+     * @var FluentResolverInterface
      */
     private $resolverResolver;
 
     public function __construct(
-        TypeResolver $typeResolver,
-        MutationResolver $mutationResolver,
-        ResolverResolver $resolverResolver
+        FluentResolverInterface $typeResolver,
+        FluentResolverInterface $mutationResolver,
+        FluentResolverInterface $resolverResolver
     ) {
         parent::__construct();
         $this->typeResolver = $typeResolver;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Documented?   | no
| Fixed tickets | N/A
| License       | MIT

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->

In one of our projects, we decorate `QueryResolver` and `MutationResolver` for our needs.

But currently, the `DebugCommand` depends on concrete implementations instead of interfaces.
So when we run the `bin/console list`, Symfony crash because of the dependency injection.

This PR updates the `DebugCommand` constructor to inject `FluentResolverInterface` instead of concrete implementations.
