### PR TITLE
Make ReactPromiseAdapter compatible with webonyx master

### DIFF
--- a/src/Executor/Promise/Adapter/ReactPromiseAdapter.php
+++ b/src/Executor/Promise/Adapter/ReactPromiseAdapter.php
@@ -19,7 +19,7 @@ class ReactPromiseAdapter extends BaseReactPromiseAdapter implements PromiseAdap
     /**
      * {@inheritdoc}
      */
-    public function isThenable($value)
+    public function isThenable($value): bool
     {
         return parent::isThenable($value instanceof Promise ? $value->adoptedPromise : $value);
     }
@@ -27,7 +27,7 @@ class ReactPromiseAdapter extends BaseReactPromiseAdapter implements PromiseAdap
     /**
      * {@inheritdoc}
      */
-    public function convertThenable($thenable)
+    public function convertThenable($thenable): Promise
     {
         if ($thenable instanceof Promise) {
             return $thenable;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | 
| License       | MIT

See https://github.com/webonyx/graphql-php/blob/master/src/Executor/Promise/Adapter/ReactPromiseAdapter.php
This makes it possible to use the bundle together `dev-master`.
