### PR TITLE
Run PHPStan on 7.4 and 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,12 @@ jobs:
   static-analysis:
     runs-on: ubuntu-20.04
     name: "Static analysis"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php-version: 7.4
+          - php-version: 8.0
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2"
@@ -162,7 +168,7 @@ jobs:
       - name: "Install PHP with coverage"
         uses: "shivammathur/setup-php@v2"
         with:
-          php-version: "7.4"
+          php-version: ${{ matrix.php-version }}
           coverage: "none"
 
       - name: "Cache dependencies installed with composer"


### PR DESCRIPTION
It's important to run PHPStan on all supported PHP versions.
On PHP 8.0 it detects other issues.

When this is merged, we can fix the PHP 8 issues.

See #908 