### PR TITLE
PHPUnit > Disable verbose / debug mode

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
         }
     },
     "scripts": {
-        "test": "bin/phpunit --color=always -v --debug",
+        "test": "bin/phpunit --color=always",
         "static-analysis": [
             "phpstan analyse --ansi --memory-limit=1G"
         ],


### PR DESCRIPTION
This makes the output very noisy. I think this was left over from the migration to GH Actions. Not needed anymore.

Same as https://github.com/overblog/GraphQLBundle/pull/910
