### PR TITLE
Enable MonologBundle in functional tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: "Symfony version"
         if: "matrix.symfony-version != ''"
-        run: perl -pi -e 's#"(symfony/.*)":\s*"\^.*"#"$1":"'"${{ matrix.symfony-version }}.*"'"#' composer.json && cat composer.json
+        run: perl -pi -e 's#"(symfony/.*)":\s*".*\|\|.*"#"$1":"'"${{ matrix.symfony-version }}.*"'"#' composer.json && cat composer.json
 
       - name: "Webonyx GraphQL version"
         if: "matrix.graphql-version != ''"

--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
         "symfony/browser-kit": "^4.4 || ^5.2",
         "symfony/console": "^4.4 || ^5.2",
         "symfony/css-selector": "^4.4 || ^5.2",
+        "symfony/monolog-bundle": "^3.7",
         "symfony/phpunit-bridge": "^4.4 || ^5.2",
         "symfony/process": "^4.4 || ^5.2",
         "symfony/security-bundle": "^4.4 || ^5.2",

--- a/tests/Functional/App/TestKernel.php
+++ b/tests/Functional/App/TestKernel.php
@@ -6,6 +6,7 @@ namespace Overblog\GraphQLBundle\Tests\Functional\App;
 
 use Overblog\GraphQLBundle\OverblogGraphQLBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\MonologBundle\MonologBundle;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -25,6 +26,7 @@ final class TestKernel extends Kernel implements CompilerPassInterface
     {
         yield new FrameworkBundle();
         yield new SecurityBundle();
+        yield new MonologBundle();
         yield new OverblogGraphQLBundle();
     }
 


### PR DESCRIPTION
This disables the default HttpKernel Logger that writes to stdout.

Gives a much cleaner output.
