### PR TITLE
Add type on `getContainerExtension` for future compat

### DIFF
--- a/src/OverblogGraphQLBundle.php
+++ b/src/OverblogGraphQLBundle.php
@@ -52,7 +52,7 @@ class OverblogGraphQLBundle extends Bundle
         $container->addCompilerPass(new ResolverTaggedServiceMappingPass(), PassConfig::TYPE_BEFORE_REMOVING);
     }
 
-    public function getContainerExtension()
+    public function getContainerExtension(): ?ExtensionInterface
     {
         if (!$this->extension instanceof ExtensionInterface) {
             $this->extension = new OverblogGraphQLExtension();


### PR DESCRIPTION
Updating to Symfony 5.4 + PHP 8.0, I get the following warning:
```
User Deprecated: Method "Symfony\Component\HttpKernel\Bundle\Bundle::getContainerExtension()" might add "?ExtensionInterface" as a native return type declaration in the future. Do the same in child class "Overblog\GraphQLBundle\OverblogGraphQLBundle" now to avoid errors or add an explicit @return annotation to suppress this message.
```

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | -
| License       | MIT
