### PR TITLE
Use Flex to require specific Symfony versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
           - '7.4'
           - '8.0'
         symfony-version:
-          - '4.4'
-          - '5.3'
-          - '5.4'
+          - '4.4.*'
+          - '5.3.*'
+          - '5.4.*'
         dependencies:
           - 'lowest'
           - 'highest'
@@ -30,11 +30,11 @@ jobs:
         coverage: [ 'none' ]
         include:
           - php-version: '8.0'
-            symfony-version: '5.3'
+            symfony-version: '5.3.*'
             dependencies: 'lowest'
             remove-dependencies: '--dev symfony/validator doctrine/orm doctrine/annotations'
           - php-version: '8.0'
-            symfony-version: '5.3'
+            symfony-version: '5.3.*'
             dependencies: 'lowest'
             coverage: "pcov"
     steps:
@@ -44,16 +44,13 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
+          tools: flex
           php-version: "${{ matrix.php-version }}"
           coverage: "${{ matrix.coverage }}"
 
       - name: "Change stability"
         if: "matrix.stability != ''"
         run: perl -pi -e 's/^}$/,"minimum-stability":"'"${{ matrix.minimum-stability }}"'"}/' composer.json && cat composer.json
-
-      - name: "Symfony version"
-        if: "matrix.symfony-version != ''"
-        run: perl -pi -e 's#"(symfony/.*)":\s*".*\|\|.*"#"$1":"'"${{ matrix.symfony-version }}.*"'"#' composer.json && cat composer.json
 
       - name: "Webonyx GraphQL version"
         if: "matrix.graphql-version != ''"
@@ -67,6 +64,8 @@ jobs:
         uses: ramsey/composer-install@1.3.0
         with:
           dependency-versions: ${{ matrix.dependencies }}
+        env:
+          SYMFONY_REQUIRE: "${{ matrix.symfony-version }}"
 
       - name: "Run tests"
         run: composer test
@@ -88,6 +87,7 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
+          tools: flex
           php-version: "7.4"
 
       - name: "Install dependencies"


### PR DESCRIPTION
This is the recommended way to pin everything to the same major.minor. 

Without it, it will still install other packages.

