### PR TITLE
Replace deprecated `NamedArgumentConstructorAnnotation` with `@NamedArgumentConstructor` + Address one PHP 8.1 deprecation

### DIFF
--- a/src/Annotation/Access.php
+++ b/src/Annotation/Access.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Annotation;
 
 use Attribute;
-use Doctrine\Common\Annotations\NamedArgumentConstructorAnnotation;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * Annotation for GraphQL access on fields.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({"CLASS", "PROPERTY", "METHOD"})
  */
 #[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY)]
-final class Access extends Annotation implements NamedArgumentConstructorAnnotation
+final class Access extends Annotation
 {
     /**
      * Field access.

--- a/src/Annotation/Arg.php
+++ b/src/Annotation/Arg.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Annotation;
 
 use Attribute;
-use Doctrine\Common\Annotations\NamedArgumentConstructorAnnotation;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * Annotation for GraphQL argument.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({"ANNOTATION","PROPERTY","METHOD"})
  */
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
-final class Arg extends Annotation implements NamedArgumentConstructorAnnotation
+final class Arg extends Annotation
 {
     /**
      * Argument name.

--- a/src/Annotation/ArgsBuilder.php
+++ b/src/Annotation/ArgsBuilder.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Annotation;
 
 use Attribute;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * Annotation for GraphQL args builders.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({"PROPERTY", "METHOD"})
  */
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD)]

--- a/src/Annotation/Builder.php
+++ b/src/Annotation/Builder.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Annotation;
 
 use Attribute;
-use Doctrine\Common\Annotations\NamedArgumentConstructorAnnotation;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * Annotation for GraphQL builders
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({"PROPERTY", "METHOD"})
  */
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD)]
-abstract class Builder extends Annotation implements NamedArgumentConstructorAnnotation
+abstract class Builder extends Annotation
 {
     /**
      * Builder name.

--- a/src/Annotation/Deprecated.php
+++ b/src/Annotation/Deprecated.php
@@ -5,22 +5,23 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Annotation;
 
 use \Attribute;
-use Doctrine\Common\Annotations\NamedArgumentConstructorAnnotation;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * Annotation for GraphQL to mark a field as deprecated.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({"METHOD", "PROPERTY"})
  */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER | Attribute::TARGET_CLASS_CONSTANT)]
-final class Deprecated extends Annotation implements NamedArgumentConstructorAnnotation
+final class Deprecated extends Annotation
 {
     /**
      * The deprecation reason.
      *
      * @Required
-     * 
+     *
      * @var string
      */
     public string $value;

--- a/src/Annotation/Description.php
+++ b/src/Annotation/Description.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Annotation;
 
 use Attribute;
-use Doctrine\Common\Annotations\NamedArgumentConstructorAnnotation;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * Annotation for GraphQL to set a type or field description.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({"CLASS", "METHOD", "PROPERTY"})
  */
 #[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER | Attribute::TARGET_CLASS_CONSTANT)]
-final class Description extends Annotation implements NamedArgumentConstructorAnnotation
+final class Description extends Annotation
 {
     /**
      * The object description.

--- a/src/Annotation/Enum.php
+++ b/src/Annotation/Enum.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Annotation;
 
 use Attribute;
-use Doctrine\Common\Annotations\NamedArgumentConstructorAnnotation;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * Annotation for GraphQL enum.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("CLASS")
  */
 #[Attribute(Attribute::TARGET_CLASS)]
-final class Enum extends Annotation implements NamedArgumentConstructorAnnotation
+final class Enum extends Annotation
 {
     /**
      * Enum name.

--- a/src/Annotation/EnumValue.php
+++ b/src/Annotation/EnumValue.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Annotation;
 
-use Doctrine\Common\Annotations\NamedArgumentConstructorAnnotation;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * Annotation for GraphQL enum value.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({"ANNOTATION", "CLASS"})
  */
-final class EnumValue extends Annotation implements NamedArgumentConstructorAnnotation
+final class EnumValue extends Annotation
 {
     /**
      * @var string

--- a/src/Annotation/Field.php
+++ b/src/Annotation/Field.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Annotation;
 
 use Attribute;
-use Doctrine\Common\Annotations\NamedArgumentConstructorAnnotation;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * Annotation for GraphQL field.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({"PROPERTY", "METHOD"})
  */
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD)]
-class Field extends Annotation implements NamedArgumentConstructorAnnotation
+class Field extends Annotation
 {
     /**
      * The field name.

--- a/src/Annotation/FieldBuilder.php
+++ b/src/Annotation/FieldBuilder.php
@@ -5,15 +5,16 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Annotation;
 
 use Attribute;
-use Doctrine\Common\Annotations\NamedArgumentConstructorAnnotation;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * Annotation for GraphQL field builders.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({"PROPERTY", "METHOD"})
  */
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD)]
-final class FieldBuilder extends Builder implements NamedArgumentConstructorAnnotation
+final class FieldBuilder extends Builder
 {
 }

--- a/src/Annotation/FieldsBuilder.php
+++ b/src/Annotation/FieldsBuilder.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Annotation;
 
 use Attribute;
-use Doctrine\Common\Annotations\NamedArgumentConstructorAnnotation;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * Annotation for GraphQL fields builders.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({"ANNOTATION", "CLASS"})
  */
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
-final class FieldsBuilder extends Builder implements NamedArgumentConstructorAnnotation
+final class FieldsBuilder extends Builder
 {
     public function __construct(string $name = null, array $config = null, string $builder = null, array $builderConfig = null)
     {

--- a/src/Annotation/Input.php
+++ b/src/Annotation/Input.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Annotation;
 
 use Attribute;
-use Doctrine\Common\Annotations\NamedArgumentConstructorAnnotation;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * Annotation for GraphQL input type.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("CLASS")
  */
 #[Attribute(Attribute::TARGET_CLASS)]
-final class Input extends Annotation implements NamedArgumentConstructorAnnotation
+final class Input extends Annotation
 {
     /**
      * Type name.

--- a/src/Annotation/IsPublic.php
+++ b/src/Annotation/IsPublic.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Annotation;
 
 use Attribute;
-use Doctrine\Common\Annotations\NamedArgumentConstructorAnnotation;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * Annotation for GraphQL public on fields.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({"CLASS", "METHOD", "PROPERTY"})
  */
 #[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY)]
-final class IsPublic extends Annotation implements NamedArgumentConstructorAnnotation
+final class IsPublic extends Annotation
 {
     /**
      * Field publicity.

--- a/src/Annotation/Mutation.php
+++ b/src/Annotation/Mutation.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Annotation;
 
 use Attribute;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * Annotation for GraphQL mutation.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({"METHOD"})
  */
 #[Attribute(Attribute::TARGET_METHOD)]

--- a/src/Annotation/Provider.php
+++ b/src/Annotation/Provider.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Annotation;
 
 use Attribute;
-use Doctrine\Common\Annotations\NamedArgumentConstructorAnnotation;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * Annotation for operations provider.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({"CLASS"})
  */
 #[Attribute(Attribute::TARGET_CLASS)]
-final class Provider extends Annotation implements NamedArgumentConstructorAnnotation
+final class Provider extends Annotation
 {
     /**
      * Optionnal prefix for provider fields.

--- a/src/Annotation/Query.php
+++ b/src/Annotation/Query.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Annotation;
 
 use Attribute;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * Annotation for GraphQL query.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({"METHOD"})
  */
 #[Attribute(Attribute::TARGET_METHOD)]

--- a/src/Annotation/Relay/Connection.php
+++ b/src/Annotation/Relay/Connection.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Annotation\Relay;
 
 use Attribute;
-use Doctrine\Common\Annotations\NamedArgumentConstructorAnnotation;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 use Overblog\GraphQLBundle\Annotation\Annotation;
 use Overblog\GraphQLBundle\Annotation\Type;
 
@@ -13,10 +13,11 @@ use Overblog\GraphQLBundle\Annotation\Type;
  * Annotation for GraphQL relay connection.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("CLASS")
  */
 #[Attribute(Attribute::TARGET_CLASS)]
-final class Connection extends Type implements NamedArgumentConstructorAnnotation
+final class Connection extends Type
 {
     /**
      * Connection Edge type.

--- a/src/Annotation/Relay/Edge.php
+++ b/src/Annotation/Relay/Edge.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Annotation\Relay;
 
 use Attribute;
-use Doctrine\Common\Annotations\NamedArgumentConstructorAnnotation;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 use Overblog\GraphQLBundle\Annotation\Annotation;
 use Overblog\GraphQLBundle\Annotation\Type;
 
@@ -13,10 +13,11 @@ use Overblog\GraphQLBundle\Annotation\Type;
  * Annotation for GraphQL connection edge.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("CLASS")
  */
 #[Attribute(Attribute::TARGET_CLASS)]
-final class Edge extends Type implements NamedArgumentConstructorAnnotation
+final class Edge extends Type
 {
     /**
      * Edge Node type.

--- a/src/Annotation/Scalar.php
+++ b/src/Annotation/Scalar.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Annotation;
 
 use Attribute;
-use Doctrine\Common\Annotations\NamedArgumentConstructorAnnotation;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * Annotation for GraphQL scalar.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("CLASS")
  */
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
-final class Scalar extends Annotation implements NamedArgumentConstructorAnnotation
+final class Scalar extends Annotation
 {
     public ?string $name;
 

--- a/src/Annotation/Type.php
+++ b/src/Annotation/Type.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Annotation;
 
 use Attribute;
-use Doctrine\Common\Annotations\NamedArgumentConstructorAnnotation;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * Annotation for GraphQL type.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("CLASS")
  */
 #[Attribute(Attribute::TARGET_CLASS)]
-class Type extends Annotation implements NamedArgumentConstructorAnnotation
+class Type extends Annotation
 {
     /**
      * Type name.

--- a/src/Annotation/TypeInterface.php
+++ b/src/Annotation/TypeInterface.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Annotation;
 
 use Attribute;
-use Doctrine\Common\Annotations\NamedArgumentConstructorAnnotation;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * Annotation for GraphQL interface.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("CLASS")
  */
 #[Attribute(Attribute::TARGET_CLASS)]
-final class TypeInterface extends Annotation implements NamedArgumentConstructorAnnotation
+final class TypeInterface extends Annotation
 {
     /**
      * Interface name.

--- a/src/Annotation/TypeInterface.php
+++ b/src/Annotation/TypeInterface.php
@@ -31,8 +31,12 @@ final class TypeInterface extends Annotation
      * @param string|null $name        The GraphQL name of the interface
      * @param string      $resolveType The express resolve type
      */
-    public function __construct(string $name = null, string $resolveType)
+    public function __construct(string $name = null, string $resolveType = null)
     {
+        // TODO: 1.0: Remove optionality for both parameters.
+        // Previously, only the name was optional, but resolveType was always required
+        // But in PHP 8.1 you cannot define an optional parameter before a required one.
+        // To not break BC we now also make the resolveType optional.
         $this->name = $name;
         $this->resolveType = $resolveType;
     }

--- a/src/Annotation/Union.php
+++ b/src/Annotation/Union.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Annotation;
 
 use Attribute;
-use Doctrine\Common\Annotations\NamedArgumentConstructorAnnotation;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * Annotation for GraphQL union.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("CLASS")
  */
 #[Attribute(Attribute::TARGET_CLASS)]
-final class Union extends Annotation implements NamedArgumentConstructorAnnotation
+final class Union extends Annotation
 {
     /**
      * Union name.


### PR DESCRIPTION
Also fixed a problem that will pop-up in PHP 8.1 with the `TypeInterface`:

In PHP 8.1 optional parameters cannot be defined before required parameters.

Because `string name = null` is optional, we also have to make `string $resolveType` optional. This way it works on PHP 8.1 without breaking BC.

In 1.0, we should change the order.