### PR TITLE
Run Dependabot daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,5 @@ updates:
     - package-ecosystem: composer
       directory: '/'
       schedule:
-          interval: monthly
+          interval: daily
       open-pull-requests-limit: 5


### PR DESCRIPTION
The goal is to let Dependabot bump webonyx/graphql-php daily so that we can track issues upstream.

See:
- https://github.com/overblog/GraphQLBundle/pull/945