### PR TITLE
Add `allow-plugins` to composer schema

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,11 @@
     },
     "config": {
         "bin-dir": "bin",
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "phpstan/extension-installer": true,
+            "composer/package-versions-deprecated": true
+        }
     },
     "require": {
         "php": "^8.0",


### PR DESCRIPTION
This is a new feature available in Composer 2.2.0-RC1

You need to specify which plugins you allow to run. These are used in this project so we need to add them.