### PR TITLE
Do not use container in compiler passes

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -126,6 +126,41 @@ parameters:
 			path: src/DependencyInjection/Compiler/ResolverMapTaggedServiceMappingPass.php
 
 		-
+			message: "#^Parameter \\#1 \\$namespace of class Overblog\\\\GraphQLBundle\\\\Generator\\\\TypeGeneratorOptions constructor expects string, array\\|bool\\|float\\|int\\|string\\|null given\\.$#"
+			count: 1
+			path: src/DependencyInjection/Compiler/TypeGeneratorPass.php
+
+		-
+			message: "#^Parameter \\#1 \\$typeConfigs of class Overblog\\\\GraphQLBundle\\\\Generator\\\\TypeGenerator constructor expects array, array\\|bool\\|float\\|int\\|string\\|null given\\.$#"
+			count: 1
+			path: src/DependencyInjection/Compiler/TypeGeneratorPass.php
+
+		-
+			message: "#^Parameter \\#2 \\$cacheDir of class Overblog\\\\GraphQLBundle\\\\Generator\\\\TypeGeneratorOptions constructor expects string\\|null, array\\|bool\\|float\\|int\\|string\\|null given\\.$#"
+			count: 1
+			path: src/DependencyInjection/Compiler/TypeGeneratorPass.php
+
+		-
+			message: "#^Parameter \\#2 \\$namespace of class Overblog\\\\GraphQLBundle\\\\Generator\\\\TypeBuilder constructor expects string, array\\|bool\\|float\\|int\\|string\\|null given\\.$#"
+			count: 1
+			path: src/DependencyInjection/Compiler/TypeGeneratorPass.php
+
+		-
+			message: "#^Parameter \\#3 \\$useClassMap of class Overblog\\\\GraphQLBundle\\\\Generator\\\\TypeGeneratorOptions constructor expects bool, array\\|bool\\|float\\|int\\|string\\|null given\\.$#"
+			count: 1
+			path: src/DependencyInjection/Compiler/TypeGeneratorPass.php
+
+		-
+			message: "#^Parameter \\#4 \\$cacheBaseDir of class Overblog\\\\GraphQLBundle\\\\Generator\\\\TypeGeneratorOptions constructor expects string\\|null, array\\|bool\\|float\\|int\\|string\\|null given\\.$#"
+			count: 1
+			path: src/DependencyInjection/Compiler/TypeGeneratorPass.php
+
+		-
+			message: "#^Parameter \\#5 \\$cacheDirMask of class Overblog\\\\GraphQLBundle\\\\Generator\\\\TypeGeneratorOptions constructor expects int\\|null, array\\|bool\\|float\\|int\\|string\\|null given\\.$#"
+			count: 1
+			path: src/DependencyInjection/Compiler/TypeGeneratorPass.php
+
+		-
 			message: "#^Method Overblog\\\\GraphQLBundle\\\\Error\\\\ExceptionConverter\\:\\:convertException\\(\\) should return Throwable but returns object\\.$#"
 			count: 1
 			path: src/Error/ExceptionConverter.php

--- a/src/DependencyInjection/Compiler/TypeGeneratorPass.php
+++ b/src/DependencyInjection/Compiler/TypeGeneratorPass.php
@@ -6,10 +6,15 @@ namespace Overblog\GraphQLBundle\DependencyInjection\Compiler;
 
 use Exception;
 use Overblog\GraphQLBundle\Definition\Builder\TypeFactory;
+use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionLanguage;
+use Overblog\GraphQLBundle\Generator\Converter\ExpressionConverter;
+use Overblog\GraphQLBundle\Generator\TypeBuilder;
 use Overblog\GraphQLBundle\Generator\TypeGenerator;
+use Overblog\GraphQLBundle\Generator\TypeGeneratorOptions;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use function preg_replace;
 use function strrchr;
 use function substr;
@@ -21,12 +26,30 @@ class TypeGeneratorPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container): void
     {
+        // We construct the TypeGenerator manually so that we don't have to boot the container
+        // while we are in compilation phase.
+        // See https://github.com/overblog/GraphQLBundle/issues/899
+        $typeGenerator = new TypeGenerator(
+            $container->getParameter('overblog_graphql_types.config'),
+            new TypeBuilder(
+                new ExpressionConverter(new ExpressionLanguage()),
+                $container->getParameter('overblog_graphql.class_namespace')
+            ),
+            new EventDispatcher(),
+            new TypeGeneratorOptions(
+                $container->getParameter('overblog_graphql.class_namespace'),
+                $container->getParameter('overblog_graphql.cache_dir'),
+                $container->getParameter('overblog_graphql.use_classloader_listener'),
+                $container->getParameter('kernel.cache_dir'),
+                $container->getParameter('overblog_graphql.cache_dir_permissions'),
+            )
+        );
+
         /**
          * @var array<class-string, string> $generatedClasses
          * @phpstan-ignore-next-line
          */
-        $generatedClasses = $container->get('overblog_graphql.cache_compiler')
-            ->compile(TypeGenerator::MODE_MAPPING_ONLY);
+        $generatedClasses = $typeGenerator->compile(TypeGenerator::MODE_MAPPING_ONLY);
 
         foreach ($generatedClasses as $class => $file) {
             $portion = strrchr($class, '\\');


### PR DESCRIPTION
By manually constructing the `TypeGenerator` in `TypeGeneratorPass` we gain performance
benefits because we don't have the boot the whole container while we are in fact compiling
the container.

The container should not be used in compiler passes:
> As a rule, only work with services definition in a compiler pass and do not create service instances. In practice, this means using the methods has(), findDefinition(), getDefinition(), setDefinition(), etc. instead of get(), set(), etc.

Fixes 899
