### PR TITLE
Make everything final

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -11,6 +11,8 @@ UPGRADE FROM 0.14 to 1.0
 * Removed deprecated `values` from `Enum`
 * Removed deprecated `resolver_maps` configuration option
 * Removed `request_files` from context, use `request` object instead
+* All classes are now final. If you need an extension point, try to use composition, 
+  implementing the interface or raise an issue.
 
 UPGRADE FROM 0.13 to 0.14
 =========================

--- a/src/CacheWarmer/CompileCacheWarmer.php
+++ b/src/CacheWarmer/CompileCacheWarmer.php
@@ -7,7 +7,7 @@ namespace Overblog\GraphQLBundle\CacheWarmer;
 use Overblog\GraphQLBundle\Generator\TypeGenerator;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 
-class CompileCacheWarmer implements CacheWarmerInterface
+final class CompileCacheWarmer implements CacheWarmerInterface
 {
     private TypeGenerator $typeGenerator;
     private bool $compiled;

--- a/src/Command/DebugCommand.php
+++ b/src/Command/DebugCommand.php
@@ -20,7 +20,7 @@ use function sort;
 use function sprintf;
 use function ucfirst;
 
-class DebugCommand extends Command
+final class DebugCommand extends Command
 {
     private static array $categories = ['type', 'mutation', 'query'];
 

--- a/src/Config/CustomScalarTypeDefinition.php
+++ b/src/Config/CustomScalarTypeDefinition.php
@@ -6,7 +6,7 @@ namespace Overblog\GraphQLBundle\Config;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 
-class CustomScalarTypeDefinition extends TypeDefinition
+final class CustomScalarTypeDefinition extends TypeDefinition
 {
     public function getDefinition(): ArrayNodeDefinition
     {

--- a/src/Config/EnumTypeDefinition.php
+++ b/src/Config/EnumTypeDefinition.php
@@ -9,7 +9,7 @@ use function array_key_exists;
 use function is_array;
 use function is_null;
 
-class EnumTypeDefinition extends TypeDefinition
+final class EnumTypeDefinition extends TypeDefinition
 {
     public function getDefinition(): ArrayNodeDefinition
     {

--- a/src/Config/InputObjectTypeDefinition.php
+++ b/src/Config/InputObjectTypeDefinition.php
@@ -7,7 +7,7 @@ namespace Overblog\GraphQLBundle\Config;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use function is_string;
 
-class InputObjectTypeDefinition extends TypeDefinition
+final class InputObjectTypeDefinition extends TypeDefinition
 {
     public function getDefinition(): ArrayNodeDefinition
     {

--- a/src/Config/InterfaceTypeDefinition.php
+++ b/src/Config/InterfaceTypeDefinition.php
@@ -6,7 +6,7 @@ namespace Overblog\GraphQLBundle\Config;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 
-class InterfaceTypeDefinition extends TypeWithOutputFieldsDefinition
+final class InterfaceTypeDefinition extends TypeWithOutputFieldsDefinition
 {
     public function getDefinition(): ArrayNodeDefinition
     {

--- a/src/Config/ObjectTypeDefinition.php
+++ b/src/Config/ObjectTypeDefinition.php
@@ -8,7 +8,7 @@ use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use function array_key_exists;
 
-class ObjectTypeDefinition extends TypeWithOutputFieldsDefinition
+final class ObjectTypeDefinition extends TypeWithOutputFieldsDefinition
 {
     public function getDefinition(): ArrayNodeDefinition
     {

--- a/src/Config/Parser/AnnotationParser.php
+++ b/src/Config/Parser/AnnotationParser.php
@@ -17,7 +17,7 @@ use Symfony\Component\Cache\Adapter\ApcuAdapter;
 use Symfony\Component\Cache\Adapter\PhpFilesAdapter;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
-class AnnotationParser extends MetadataParser
+final class AnnotationParser extends MetadataParser
 {
     public const METADATA_FORMAT = '@%s';
 

--- a/src/Config/Parser/AttributeParser.php
+++ b/src/Config/Parser/AttributeParser.php
@@ -12,7 +12,7 @@ use ReflectionMethod;
 use ReflectionProperty;
 use Reflector;
 
-class AttributeParser extends MetadataParser
+final class AttributeParser extends MetadataParser
 {
     public const METADATA_FORMAT = '#[%s]';
 

--- a/src/Config/Parser/GraphQL/ASTConverter/CustomScalarNode.php
+++ b/src/Config/Parser/GraphQL/ASTConverter/CustomScalarNode.php
@@ -7,7 +7,7 @@ namespace Overblog\GraphQLBundle\Config\Parser\GraphQL\ASTConverter;
 use GraphQL\Language\AST\Node;
 use RuntimeException;
 
-class CustomScalarNode implements NodeInterface
+final class CustomScalarNode implements NodeInterface
 {
     public static function toConfig(Node $node): array
     {

--- a/src/Config/Parser/GraphQL/ASTConverter/DescriptionNode.php
+++ b/src/Config/Parser/GraphQL/ASTConverter/DescriptionNode.php
@@ -8,7 +8,7 @@ use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\StringValueNode;
 use function trim;
 
-class DescriptionNode implements NodeInterface
+final class DescriptionNode implements NodeInterface
 {
     public static function toConfig(Node $node): array
     {

--- a/src/Config/Parser/GraphQL/ASTConverter/DirectiveNode.php
+++ b/src/Config/Parser/GraphQL/ASTConverter/DirectiveNode.php
@@ -7,7 +7,7 @@ namespace Overblog\GraphQLBundle\Config\Parser\GraphQL\ASTConverter;
 use GraphQL\Language\AST\Node;
 use GraphQL\Type\Definition\Directive;
 
-class DirectiveNode implements NodeInterface
+final class DirectiveNode implements NodeInterface
 {
     public static function toConfig(Node $node): array
     {

--- a/src/Config/Parser/GraphQL/ASTConverter/EnumNode.php
+++ b/src/Config/Parser/GraphQL/ASTConverter/EnumNode.php
@@ -6,7 +6,7 @@ namespace Overblog\GraphQLBundle\Config\Parser\GraphQL\ASTConverter;
 
 use GraphQL\Language\AST\Node;
 
-class EnumNode implements NodeInterface
+final class EnumNode implements NodeInterface
 {
     public static function toConfig(Node $node): array
     {

--- a/src/Config/Parser/GraphQL/ASTConverter/FieldsNode.php
+++ b/src/Config/Parser/GraphQL/ASTConverter/FieldsNode.php
@@ -7,7 +7,7 @@ namespace Overblog\GraphQLBundle\Config\Parser\GraphQL\ASTConverter;
 use GraphQL\Language\AST\Node;
 use GraphQL\Utils\AST;
 
-class FieldsNode implements NodeInterface
+final class FieldsNode implements NodeInterface
 {
     public static function toConfig(Node $node, string $property = 'fields'): array
     {

--- a/src/Config/Parser/GraphQL/ASTConverter/InputObjectNode.php
+++ b/src/Config/Parser/GraphQL/ASTConverter/InputObjectNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Config\Parser\GraphQL\ASTConverter;
 
-class InputObjectNode extends ObjectNode
+final class InputObjectNode extends ObjectNode
 {
     protected const TYPENAME = 'input-object';
 }

--- a/src/Config/Parser/GraphQL/ASTConverter/InterfaceNode.php
+++ b/src/Config/Parser/GraphQL/ASTConverter/InterfaceNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Config\Parser\GraphQL\ASTConverter;
 
-class InterfaceNode extends ObjectNode
+final class InterfaceNode extends ObjectNode
 {
     protected const TYPENAME = 'interface';
 }

--- a/src/Config/Parser/GraphQL/ASTConverter/TypeNode.php
+++ b/src/Config/Parser/GraphQL/ASTConverter/TypeNode.php
@@ -7,7 +7,7 @@ namespace Overblog\GraphQLBundle\Config\Parser\GraphQL\ASTConverter;
 use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\NodeKind;
 
-class TypeNode implements NodeInterface
+final class TypeNode implements NodeInterface
 {
     public static function toConfig(Node $node): array
     {

--- a/src/Config/Parser/GraphQL/ASTConverter/UnionNode.php
+++ b/src/Config/Parser/GraphQL/ASTConverter/UnionNode.php
@@ -6,7 +6,7 @@ namespace Overblog\GraphQLBundle\Config\Parser\GraphQL\ASTConverter;
 
 use GraphQL\Language\AST\Node;
 
-class UnionNode implements NodeInterface
+final class UnionNode implements NodeInterface
 {
     public static function toConfig(Node $node): array
     {

--- a/src/Config/Parser/GraphQLParser.php
+++ b/src/Config/Parser/GraphQLParser.php
@@ -27,7 +27,7 @@ use function sprintf;
 use function trim;
 use function ucfirst;
 
-class GraphQLParser implements ParserInterface
+final class GraphQLParser implements ParserInterface
 {
     private const DEFINITION_TYPE_MAPPING = [
         NodeKind::OBJECT_TYPE_DEFINITION => 'object',

--- a/src/Config/Parser/MetadataParser/ClassesTypesMap.php
+++ b/src/Config/Parser/MetadataParser/ClassesTypesMap.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Config\Parser\MetadataParser;
 
-class ClassesTypesMap
+final class ClassesTypesMap
 {
     /**
      * @var array<string, array{class: string, type: string}>
      */
-    protected array $classesMap = [];
+    private array $classesMap = [];
 
     public function hasType(string $gqlType): bool
     {

--- a/src/Config/Parser/MetadataParser/TypeGuesser/DocBlockTypeGuesser.php
+++ b/src/Config/Parser/MetadataParser/TypeGuesser/DocBlockTypeGuesser.php
@@ -21,7 +21,7 @@ use ReflectionProperty;
 use Reflector;
 use function sprintf;
 
-class DocBlockTypeGuesser extends PhpTypeGuesser
+final class DocBlockTypeGuesser extends PhpTypeGuesser
 {
     protected ?DocBlockFactory $factory;
 

--- a/src/Config/Parser/MetadataParser/TypeGuesser/DoctrineTypeGuesser.php
+++ b/src/Config/Parser/MetadataParser/TypeGuesser/DoctrineTypeGuesser.php
@@ -18,7 +18,7 @@ use ReflectionMethod;
 use ReflectionProperty;
 use Reflector;
 
-class DoctrineTypeGuesser extends TypeGuesser
+final class DoctrineTypeGuesser extends TypeGuesser
 {
     protected array $doctrineMapping = [];
 

--- a/src/Config/Parser/MetadataParser/TypeGuesser/TypeHintTypeGuesser.php
+++ b/src/Config/Parser/MetadataParser/TypeGuesser/TypeHintTypeGuesser.php
@@ -11,7 +11,7 @@ use ReflectionParameter;
 use ReflectionProperty;
 use Reflector;
 
-class TypeHintTypeGuesser extends PhpTypeGuesser
+final class TypeHintTypeGuesser extends PhpTypeGuesser
 {
     public function getName(): string
     {

--- a/src/Config/Parser/YamlParser.php
+++ b/src/Config/Parser/YamlParser.php
@@ -15,7 +15,7 @@ use function file_get_contents;
 use function is_array;
 use function sprintf;
 
-class YamlParser implements ParserInterface
+final class YamlParser implements ParserInterface
 {
     private static Parser $yamlParser;
 

--- a/src/Config/Processor.php
+++ b/src/Config/Processor.php
@@ -10,7 +10,7 @@ use Overblog\GraphQLBundle\Config\Processor\NamedConfigProcessor;
 use Overblog\GraphQLBundle\Config\Processor\ProcessorInterface;
 use Overblog\GraphQLBundle\Config\Processor\RelayProcessor;
 
-class Processor implements ProcessorInterface
+final class Processor implements ProcessorInterface
 {
     public const BEFORE_NORMALIZATION = 0;
     public const NORMALIZATION = 2;

--- a/src/Config/UnionTypeDefinition.php
+++ b/src/Config/UnionTypeDefinition.php
@@ -6,7 +6,7 @@ namespace Overblog\GraphQLBundle\Config;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 
-class UnionTypeDefinition extends TypeDefinition
+final class UnionTypeDefinition extends TypeDefinition
 {
     public function getDefinition(): ArrayNodeDefinition
     {

--- a/src/Controller/GraphController.php
+++ b/src/Controller/GraphController.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use function in_array;
 
-class GraphController
+final class GraphController
 {
     private BatchParser $batchParser;
     private Executor $requestExecutor;

--- a/src/Controller/ProfilerController.php
+++ b/src/Controller/ProfilerController.php
@@ -17,7 +17,7 @@ use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
 use function array_map;
 
-class ProfilerController
+final class ProfilerController
 {
     private ?Profiler $profiler;
     private ?Environment $twig;

--- a/src/DataCollector/GraphQLCollector.php
+++ b/src/DataCollector/GraphQLCollector.php
@@ -17,7 +17,7 @@ use Throwable;
 use function count;
 use function microtime;
 
-class GraphQLCollector extends DataCollector
+final class GraphQLCollector extends DataCollector
 {
     /**
      * GraphQL Batches executed.

--- a/src/Definition/Argument.php
+++ b/src/Definition/Argument.php
@@ -7,7 +7,7 @@ namespace Overblog\GraphQLBundle\Definition;
 use function array_key_exists;
 use function count;
 
-class Argument implements ArgumentInterface
+final class Argument implements ArgumentInterface
 {
     private array $rawArguments = [];
 

--- a/src/Definition/ArgumentFactory.php
+++ b/src/Definition/ArgumentFactory.php
@@ -7,7 +7,7 @@ namespace Overblog\GraphQLBundle\Definition;
 use Closure;
 use function func_get_args;
 
-class ArgumentFactory
+final class ArgumentFactory
 {
     private string $className;
 

--- a/src/Definition/Builder/SchemaBuilder.php
+++ b/src/Definition/Builder/SchemaBuilder.php
@@ -11,7 +11,7 @@ use Overblog\GraphQLBundle\Definition\Type\SchemaExtension\ValidatorExtension;
 use Overblog\GraphQLBundle\Resolver\TypeResolver;
 use function array_map;
 
-class SchemaBuilder
+final class SchemaBuilder
 {
     private TypeResolver $typeResolver;
     private bool $enableValidation;

--- a/src/Definition/ResolverArgs.php
+++ b/src/Definition/ResolverArgs.php
@@ -7,7 +7,7 @@ namespace Overblog\GraphQLBundle\Definition;
 use ArrayObject;
 use GraphQL\Type\Definition\ResolveInfo;
 
-class ResolverArgs
+final class ResolverArgs
 {
     public ArgumentInterface $args;
     public ResolveInfo $info;

--- a/src/DependencyInjection/Compiler/ConfigParserPass.php
+++ b/src/DependencyInjection/Compiler/ConfigParserPass.php
@@ -33,7 +33,7 @@ use function is_a;
 use function is_dir;
 use function sprintf;
 
-class ConfigParserPass implements CompilerPassInterface
+final class ConfigParserPass implements CompilerPassInterface
 {
     /**
      * @var array<string, string>

--- a/src/DependencyInjection/Compiler/MutationTaggedServiceMappingTaggedPass.php
+++ b/src/DependencyInjection/Compiler/MutationTaggedServiceMappingTaggedPass.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\DependencyInjection\Compiler;
 
-class MutationTaggedServiceMappingTaggedPass extends QueryTaggedServiceMappingPass
+final class MutationTaggedServiceMappingTaggedPass extends QueryTaggedServiceMappingPass
 {
     protected function getTagName(): string
     {

--- a/src/DependencyInjection/Compiler/TypeGeneratorPass.php
+++ b/src/DependencyInjection/Compiler/TypeGeneratorPass.php
@@ -19,7 +19,7 @@ use function preg_replace;
 use function strrchr;
 use function substr;
 
-class TypeGeneratorPass implements CompilerPassInterface
+final class TypeGeneratorPass implements CompilerPassInterface
 {
     /**
      * @throws Exception

--- a/src/DependencyInjection/Compiler/TypeTaggedServiceMappingPass.php
+++ b/src/DependencyInjection/Compiler/TypeTaggedServiceMappingPass.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\DependencyInjection\Compiler;
 
-class TypeTaggedServiceMappingPass extends TaggedServiceMappingPass
+final class TypeTaggedServiceMappingPass extends TaggedServiceMappingPass
 {
     public const TAG_NAME = 'overblog_graphql.type';
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -26,7 +26,7 @@ use function is_numeric;
 use function is_string;
 use function sprintf;
 
-class Configuration implements ConfigurationInterface
+final class Configuration implements ConfigurationInterface
 {
     public const NAME = 'overblog_graphql';
 

--- a/src/DependencyInjection/OverblogGraphQLExtension.php
+++ b/src/DependencyInjection/OverblogGraphQLExtension.php
@@ -33,7 +33,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use function realpath;
 use function sprintf;
 
-class OverblogGraphQLExtension extends Extension
+final class OverblogGraphQLExtension extends Extension
 {
     public function load(array $configs, ContainerBuilder $container): void
     {

--- a/src/DependencyInjection/TypesConfiguration.php
+++ b/src/DependencyInjection/TypesConfiguration.php
@@ -19,7 +19,7 @@ use function preg_match;
 use function sprintf;
 use function str_replace;
 
-class TypesConfiguration implements ConfigurationInterface
+final class TypesConfiguration implements ConfigurationInterface
 {
     private static array $types = [
         'object',

--- a/src/Error/InvalidArgumentError.php
+++ b/src/Error/InvalidArgumentError.php
@@ -8,7 +8,7 @@ use Exception;
 use GraphQL\Error\UserError as GraphQLUserError;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 
-class InvalidArgumentError extends GraphQLUserError
+final class InvalidArgumentError extends GraphQLUserError
 {
     private string $name;
     private ConstraintViolationListInterface $errors;

--- a/src/Error/InvalidArgumentsError.php
+++ b/src/Error/InvalidArgumentsError.php
@@ -7,7 +7,7 @@ namespace Overblog\GraphQLBundle\Error;
 use Exception;
 use GraphQL\Error\UserError as GraphQLUserError;
 
-class InvalidArgumentsError extends GraphQLUserError
+final class InvalidArgumentsError extends GraphQLUserError
 {
     /** @var InvalidArgumentError[] */
     private array $errors;

--- a/src/Error/ResolveErrors.php
+++ b/src/Error/ResolveErrors.php
@@ -6,7 +6,7 @@ namespace Overblog\GraphQLBundle\Error;
 
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 
-class ResolveErrors
+final class ResolveErrors
 {
     private ?ConstraintViolationListInterface $validationErrors = null;
 

--- a/src/Error/UserError.php
+++ b/src/Error/UserError.php
@@ -6,9 +6,6 @@ namespace Overblog\GraphQLBundle\Error;
 
 use GraphQL\Error\UserError as BaseUserError;
 
-/**
- * Class UserError.
- */
 class UserError extends BaseUserError
 {
 }

--- a/src/Error/UserErrors.php
+++ b/src/Error/UserErrors.php
@@ -11,7 +11,7 @@ use function is_object;
 use function is_string;
 use function sprintf;
 
-class UserErrors extends RuntimeException
+final class UserErrors extends RuntimeException
 {
     /** @var UserError[] */
     private array $errors = [];

--- a/src/Executor/Executor.php
+++ b/src/Executor/Executor.php
@@ -14,7 +14,7 @@ use function func_get_args;
 use function method_exists;
 use function sprintf;
 
-class Executor implements ExecutorInterface
+final class Executor implements ExecutorInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Executor/Promise/Adapter/ReactPromiseAdapter.php
+++ b/src/Executor/Promise/Adapter/ReactPromiseAdapter.php
@@ -14,7 +14,7 @@ use React\Promise\PromiseInterface;
 use function sprintf;
 use function usleep;
 
-class ReactPromiseAdapter extends BaseReactPromiseAdapter implements PromiseAdapterInterface
+final class ReactPromiseAdapter extends BaseReactPromiseAdapter implements PromiseAdapterInterface
 {
     /**
      * {@inheritdoc}

--- a/src/ExpressionLanguage/Exception/EvaluatorIsNotAllowedException.php
+++ b/src/ExpressionLanguage/Exception/EvaluatorIsNotAllowedException.php
@@ -7,7 +7,7 @@ namespace Overblog\GraphQLBundle\ExpressionLanguage\Exception;
 use Exception;
 use Throwable;
 
-class EvaluatorIsNotAllowedException extends Exception
+final class EvaluatorIsNotAllowedException extends Exception
 {
     public function __construct(string $expressionFunctionName, int $code = 0, Throwable $previous = null)
     {

--- a/src/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/ExpressionLanguage/ExpressionLanguage.php
@@ -14,7 +14,7 @@ use function strlen;
 use function strpos;
 use function substr;
 
-class ExpressionLanguage extends BaseExpressionLanguage
+final class ExpressionLanguage extends BaseExpressionLanguage
 {
     // TODO (murtukov): make names conditional
     public const KNOWN_NAMES = ['value', 'args', 'context', 'info', 'object', 'validator', 'errors', 'childrenComplexity', 'typeName', 'fieldName'];

--- a/src/Generator/Collection.php
+++ b/src/Generator/Collection.php
@@ -10,7 +10,7 @@ use Overblog\GraphQLBundle\Generator\Converter\ExpressionConverter;
 /**
  * Extends the default Collection to properly convert expressions.
  */
-class Collection extends BaseCollection
+final class Collection extends BaseCollection
 {
     /**
      * Mark converters to be used by convertion of array values.

--- a/src/Generator/Converter/ExpressionConverter.php
+++ b/src/Generator/Converter/ExpressionConverter.php
@@ -7,7 +7,7 @@ namespace Overblog\GraphQLBundle\Generator\Converter;
 use Murtukov\PHPCodeGenerator\ConverterInterface;
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionLanguage;
 
-class ExpressionConverter implements ConverterInterface
+final class ExpressionConverter implements ConverterInterface
 {
     private ExpressionLanguage $expressionLanguage;
 

--- a/src/Generator/Exception/GeneratorException.php
+++ b/src/Generator/Exception/GeneratorException.php
@@ -6,6 +6,6 @@ namespace Overblog\GraphQLBundle\Generator\Exception;
 
 use Exception;
 
-class GeneratorException extends Exception
+final class GeneratorException extends Exception
 {
 }

--- a/src/Generator/TypeBuilder.php
+++ b/src/Generator/TypeBuilder.php
@@ -59,13 +59,13 @@ use function substr;
  *
  * Every method with prefix 'build' has a render example in it's PHPDoc.
  */
-class TypeBuilder
+final class TypeBuilder
 {
-    protected const CONSTRAINTS_NAMESPACE = 'Symfony\Component\Validator\Constraints';
-    protected const DOCBLOCK_TEXT = 'THIS FILE WAS GENERATED AND SHOULD NOT BE EDITED MANUALLY.';
-    protected const BUILT_IN_TYPES = [Type::STRING, Type::INT, Type::FLOAT, Type::BOOLEAN, Type::ID];
+    private const CONSTRAINTS_NAMESPACE = 'Symfony\Component\Validator\Constraints';
+    private const DOCBLOCK_TEXT = 'THIS FILE WAS GENERATED AND SHOULD NOT BE EDITED MANUALLY.';
+    private const BUILT_IN_TYPES = [Type::STRING, Type::INT, Type::FLOAT, Type::BOOLEAN, Type::ID];
 
-    protected const EXTENDS = [
+    private const EXTENDS = [
         'object' => ObjectType::class,
         'input-object' => InputObjectType::class,
         'interface' => InterfaceType::class,
@@ -74,13 +74,13 @@ class TypeBuilder
         'custom-scalar' => CustomScalarType::class,
     ];
 
-    protected ExpressionConverter $expressionConverter;
-    protected PhpFile $file;
-    protected string $namespace;
-    protected array $config;
-    protected string $type;
-    protected string $currentField;
-    protected string $gqlServices = '$'.TypeGenerator::GRAPHQL_SERVICES;
+    private ExpressionConverter $expressionConverter;
+    private PhpFile $file;
+    private string $namespace;
+    private array $config;
+    private string $type;
+    private string $currentField;
+    private string $gqlServices = '$'.TypeGenerator::GRAPHQL_SERVICES;
 
     public function __construct(ExpressionConverter $expressionConverter, string $namespace)
     {
@@ -156,7 +156,7 @@ class TypeBuilder
      *
      * @return GeneratorInterface|string
      */
-    protected function buildType(string $typeDefinition)
+    private function buildType(string $typeDefinition)
     {
         $typeNode = Parser::parseType($typeDefinition);
 
@@ -179,7 +179,7 @@ class TypeBuilder
      *
      * @return Literal|string
      */
-    protected function wrapTypeRecursive($typeNode, bool &$isReference)
+    private function wrapTypeRecursive($typeNode, bool &$isReference)
     {
         switch ($typeNode->kind) {
             case NodeKind::NON_NULL_TYPE:
@@ -292,7 +292,7 @@ class TypeBuilder
      *
      * @throws GeneratorException
      */
-    protected function buildConfig(array $config): Collection
+    private function buildConfig(array $config): Collection
     {
         // Convert to an object for a better readability
         $c = (object) $config;
@@ -374,7 +374,7 @@ class TypeBuilder
      *
      * @return ArrowFunction
      */
-    protected function buildScalarCallback($callback, string $fieldName)
+    private function buildScalarCallback($callback, string $fieldName)
     {
         if (!is_callable($callback)) {
             throw new GeneratorException("Value of '$fieldName' is not callable.");
@@ -444,7 +444,7 @@ class TypeBuilder
      *
      * @return GeneratorInterface|string
      */
-    protected function buildResolve($resolve, ?array $groups = null)
+    private function buildResolve($resolve, ?array $groups = null)
     {
         if (is_callable($resolve) && is_array($resolve)) {
             return Collection::numeric($resolve);
@@ -538,7 +538,7 @@ class TypeBuilder
      *
      * @throws GeneratorException
      */
-    protected function buildValidationRules(array $config): GeneratorInterface
+    private function buildValidationRules(array $config): GeneratorInterface
     {
         // Convert to object for better readability
         $c = (object) $config;
@@ -606,7 +606,7 @@ class TypeBuilder
      *
      * @return ArrowFunction|Collection
      */
-    protected function buildConstraints(array $constraints = [], bool $inClosure = true)
+    private function buildConstraints(array $constraints = [], bool $inClosure = true)
     {
         $result = Collection::numeric()->setMultiline();
 
@@ -816,7 +816,7 @@ class TypeBuilder
      *
      * @return Closure|mixed
      */
-    protected function buildComplexity($complexity)
+    private function buildComplexity($complexity)
     {
         if (EL::isStringWithTrigger($complexity)) {
             $expression = $this->expressionConverter->convert($complexity);
@@ -855,7 +855,7 @@ class TypeBuilder
      *
      * @return ArrowFunction|mixed
      */
-    protected function buildPublic($public)
+    private function buildPublic($public)
     {
         if (EL::isStringWithTrigger($public)) {
             $expression = $this->expressionConverter->convert($public);
@@ -888,7 +888,7 @@ class TypeBuilder
      *
      * @return ArrowFunction|mixed
      */
-    protected function buildAccess($access)
+    private function buildAccess($access)
     {
         if (EL::isStringWithTrigger($access)) {
             $expression = $this->expressionConverter->convert($access);
@@ -913,7 +913,7 @@ class TypeBuilder
      *
      * @return mixed|ArrowFunction
      */
-    protected function buildResolveType($resolveType)
+    private function buildResolveType($resolveType)
     {
         if (EL::isStringWithTrigger($resolveType)) {
             $expression = $this->expressionConverter->convert($resolveType);
@@ -935,7 +935,7 @@ class TypeBuilder
      *      "App\Entity\User::firstName()" -> ['App\Entity\User', 'firstName', 'getter']
      *      "App\Entity\User::firstName"   -> ['App\Entity\User', 'firstName', 'member']
      */
-    protected function normalizeLink(string $link): array
+    private function normalizeLink(string $link): array
     {
         [$fqcn, $classMember] = explode('::', $link);
 

--- a/src/Generator/TypeGeneratorOptions.php
+++ b/src/Generator/TypeGeneratorOptions.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Generator;
 
-class TypeGeneratorOptions
+final class TypeGeneratorOptions
 {
     /**
      * PSR-4 namespace for generated GraphQL classes.

--- a/src/OverblogGraphQLBundle.php
+++ b/src/OverblogGraphQLBundle.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class OverblogGraphQLBundle extends Bundle
+final class OverblogGraphQLBundle extends Bundle
 {
     public function boot(): void
     {

--- a/src/Relay/Builder/RelayConnectionFieldsBuilder.php
+++ b/src/Relay/Builder/RelayConnectionFieldsBuilder.php
@@ -9,7 +9,7 @@ use Overblog\GraphQLBundle\Definition\Builder\MappingInterface;
 use function is_string;
 use function sprintf;
 
-class RelayConnectionFieldsBuilder implements MappingInterface
+final class RelayConnectionFieldsBuilder implements MappingInterface
 {
     public function toMappingDefinition(array $config): array
     {

--- a/src/Relay/Builder/RelayEdgeFieldsBuilder.php
+++ b/src/Relay/Builder/RelayEdgeFieldsBuilder.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
 use Overblog\GraphQLBundle\Definition\Builder\MappingInterface;
 use function is_string;
 
-class RelayEdgeFieldsBuilder implements MappingInterface
+final class RelayEdgeFieldsBuilder implements MappingInterface
 {
     public function toMappingDefinition(array $config): array
     {

--- a/src/Relay/Connection/ConnectionBuilder.php
+++ b/src/Relay/Connection/ConnectionBuilder.php
@@ -26,25 +26,25 @@ use function str_replace;
  *
  * https://github.com/graphql/graphql-relay-js/blob/master/src/connection/arrayconnection.js
  */
-class ConnectionBuilder
+final class ConnectionBuilder
 {
     public const PREFIX = 'arrayconnection:';
 
-    protected CursorEncoderInterface $cursorEncoder;
+    private CursorEncoderInterface $cursorEncoder;
 
     /**
      * If set, used to generate the connection object.
      *
      * @var callable|null
      */
-    protected $connectionCallback;
+    private $connectionCallback;
 
     /**
      * If set, used to generate the edge object.
      *
      * @var ?callable
      */
-    protected $edgeCallback;
+    private $edgeCallback;
 
     public function __construct(?CursorEncoderInterface $cursorEncoder = null, callable $connectionCallback = null, callable $edgeCallback = null)
     {

--- a/src/Relay/Connection/Output/PageInfo.php
+++ b/src/Relay/Connection/Output/PageInfo.php
@@ -6,7 +6,7 @@ namespace Overblog\GraphQLBundle\Relay\Connection\Output;
 
 use Overblog\GraphQLBundle\Relay\Connection\PageInfoInterface;
 
-class PageInfo implements PageInfoInterface
+final class PageInfo implements PageInfoInterface
 {
     use DeprecatedPropertyPublicAccessTrait;
 

--- a/src/Relay/Connection/Paginator.php
+++ b/src/Relay/Connection/Paginator.php
@@ -14,7 +14,7 @@ use function is_callable;
 use function is_numeric;
 use function max;
 
-class Paginator
+final class Paginator
 {
     public const MODE_REGULAR = false;
     public const MODE_PROMISE = true;

--- a/src/Relay/Node/GlobalId.php
+++ b/src/Relay/Node/GlobalId.php
@@ -11,7 +11,7 @@ use function explode;
 use function is_string;
 use function sprintf;
 
-class GlobalId
+final class GlobalId
 {
     public const SEPARATOR = ':';
 

--- a/src/Request/BatchParser.php
+++ b/src/Request/BatchParser.php
@@ -15,7 +15,7 @@ use function json_last_error;
 use function sprintf;
 use const JSON_ERROR_NONE;
 
-class BatchParser implements ParserInterface
+final class BatchParser implements ParserInterface
 {
     use UploadParserTrait;
 

--- a/src/Request/Parser.php
+++ b/src/Request/Parser.php
@@ -13,7 +13,7 @@ use function json_decode;
 use function json_last_error;
 use const JSON_ERROR_NONE;
 
-class Parser implements ParserInterface
+final class Parser implements ParserInterface
 {
     use UploadParserTrait;
 

--- a/src/Resolver/AccessResolver.php
+++ b/src/Resolver/AccessResolver.php
@@ -17,7 +17,7 @@ use function array_map;
 use function call_user_func_array;
 use function is_iterable;
 
-class AccessResolver
+final class AccessResolver
 {
     private PromiseAdapter $promiseAdapter;
 

--- a/src/Resolver/FieldResolver.php
+++ b/src/Resolver/FieldResolver.php
@@ -11,7 +11,7 @@ use function is_callable;
 use function is_object;
 use function str_replace;
 
-class FieldResolver
+final class FieldResolver
 {
     /**
      * Allowed method prefixes

--- a/src/Resolver/UnresolvableException.php
+++ b/src/Resolver/UnresolvableException.php
@@ -6,6 +6,6 @@ namespace Overblog\GraphQLBundle\Resolver;
 
 use InvalidArgumentException;
 
-class UnresolvableException extends InvalidArgumentException
+final class UnresolvableException extends InvalidArgumentException
 {
 }

--- a/src/Resolver/UnsupportedResolverException.php
+++ b/src/Resolver/UnsupportedResolverException.php
@@ -6,6 +6,6 @@ namespace Overblog\GraphQLBundle\Resolver;
 
 use InvalidArgumentException;
 
-class UnsupportedResolverException extends InvalidArgumentException
+final class UnsupportedResolverException extends InvalidArgumentException
 {
 }

--- a/src/Transformer/ArgumentsTransformer.php
+++ b/src/Transformer/ArgumentsTransformer.php
@@ -24,11 +24,11 @@ use function sprintf;
 use function strlen;
 use function substr;
 
-class ArgumentsTransformer
+final class ArgumentsTransformer
 {
-    protected PropertyAccessor $accessor;
-    protected ?ValidatorInterface $validator;
-    protected array $classesMap;
+    private PropertyAccessor $accessor;
+    private ?ValidatorInterface $validator;
+    private array $classesMap;
 
     public function __construct(ValidatorInterface $validator = null, array $classesMap = [])
     {

--- a/src/Upload/Type/GraphQLUploadType.php
+++ b/src/Upload/Type/GraphQLUploadType.php
@@ -12,7 +12,7 @@ use function gettype;
 use function is_object;
 use function sprintf;
 
-class GraphQLUploadType extends ScalarType
+final class GraphQLUploadType extends ScalarType
 {
     /**
      * @param string $name

--- a/src/Validator/Constraints/ExpressionValidator.php
+++ b/src/Validator/Constraints/ExpressionValidator.php
@@ -12,7 +12,7 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Expression;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
-class ExpressionValidator extends \Symfony\Component\Validator\Constraints\ExpressionValidator
+final class ExpressionValidator extends \Symfony\Component\Validator\Constraints\ExpressionValidator
 {
     private ExpressionLanguage $expressionLanguage;
 

--- a/src/Validator/Exception/ArgumentsValidationException.php
+++ b/src/Validator/Exception/ArgumentsValidationException.php
@@ -9,7 +9,7 @@ use GraphQL\Error\ClientAware;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Throwable;
 
-class ArgumentsValidationException extends Exception implements ClientAware
+final class ArgumentsValidationException extends Exception implements ClientAware
 {
     private ConstraintViolationListInterface $violations;
 

--- a/src/Validator/Formatter.php
+++ b/src/Validator/Formatter.php
@@ -14,7 +14,7 @@ use Overblog\GraphQLBundle\Validator\Exception\ArgumentsValidationException;
  *
  * @see https://github.com/overblog/GraphQLBundle/blob/master/docs/validation/index.md#error-messages
  */
-class Formatter
+final class Formatter
 {
     public function onErrorFormatting(ErrorFormattingEvent $event): void
     {

--- a/src/Validator/InputValidator.php
+++ b/src/Validator/InputValidator.php
@@ -29,7 +29,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use function in_array;
 
-class InputValidator
+final class InputValidator
 {
     private const TYPE_PROPERTY = 'property';
     private const TYPE_GETTER = 'getter';
@@ -127,7 +127,7 @@ class InputValidator
      * Creates a composition of ValidationNode objects from args
      * and simultaneously applies to them validation constraints.
      */
-    protected function buildValidationTree(ValidationNode $rootObject, array $fields, array $classValidation, array $inputData): ValidationNode
+    private function buildValidationTree(ValidationNode $rootObject, array $fields, array $classValidation, array $inputData): ValidationNode
     {
         $metadata = new ObjectMetadata($rootObject);
 

--- a/src/Validator/InputValidatorFactory.php
+++ b/src/Validator/InputValidatorFactory.php
@@ -10,7 +10,7 @@ use Symfony\Component\Validator\ConstraintValidatorFactoryInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class InputValidatorFactory
+final class InputValidatorFactory
 {
     private ?ValidatorInterface $defaultValidator;
     private ?ConstraintValidatorFactoryInterface $constraintValidatorFactory;

--- a/src/Validator/Mapping/MetadataFactory.php
+++ b/src/Validator/Mapping/MetadataFactory.php
@@ -8,7 +8,7 @@ use Overblog\GraphQLBundle\Validator\ValidationNode;
 use Symfony\Component\Validator\Exception\NoSuchMetadataException;
 use Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface;
 
-class MetadataFactory implements MetadataFactoryInterface
+final class MetadataFactory implements MetadataFactoryInterface
 {
     private array $metadataPool;
 

--- a/src/Validator/Mapping/ObjectMetadata.php
+++ b/src/Validator/Mapping/ObjectMetadata.php
@@ -9,7 +9,7 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\PropertyMetadataInterface;
 
-class ObjectMetadata extends ClassMetadata
+final class ObjectMetadata extends ClassMetadata
 {
     public function __construct(ValidationNode $object)
     {

--- a/src/Validator/Mapping/PropertyMetadata.php
+++ b/src/Validator/Mapping/PropertyMetadata.php
@@ -8,7 +8,7 @@ use ReflectionException;
 use ReflectionProperty;
 use Symfony\Component\Validator\Mapping\MemberMetadata;
 
-class PropertyMetadata extends MemberMetadata
+final class PropertyMetadata extends MemberMetadata
 {
     public function __construct(string $name)
     {

--- a/src/Validator/ValidationNode.php
+++ b/src/Validator/ValidationNode.php
@@ -23,7 +23,7 @@ use function in_array;
  * It also contains variables of the resolver context, in which this class was
  * instantiated.
  */
-class ValidationNode
+final class ValidationNode
 {
     private const KNOWN_VAR_NAMES = ['value', 'args', 'context', 'info'];
 

--- a/tests/Config/Parser/AnnotationParserTest.php
+++ b/tests/Config/Parser/AnnotationParserTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 /**
  * @group legacy
  */
-class AnnotationParserTest extends MetadataParserTest
+final class AnnotationParserTest extends MetadataParserTest
 {
     public function setUp(): void
     {

--- a/tests/Config/Parser/AttributeParserTest.php
+++ b/tests/Config/Parser/AttributeParserTest.php
@@ -10,7 +10,7 @@ use Overblog\GraphQLBundle\Config\Parser\AttributeParser;
  * @group legacy
  * @requires PHP 8.
  */
-class AttributeParserTest extends MetadataParserTest
+final class AttributeParserTest extends MetadataParserTest
 {
     public function parser(string $method, ...$args)
     {

--- a/tests/Config/Parser/Constants.php
+++ b/tests/Config/Parser/Constants.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Tests\Config\Parser;
 
-class Constants
+final class Constants
 {
     public const TWILEK = '4';
 }

--- a/tests/Config/Parser/GraphQLParserTest.php
+++ b/tests/Config/Parser/GraphQLParserTest.php
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use function sprintf;
 use const DIRECTORY_SEPARATOR;
 
-class GraphQLParserTest extends TestCase
+final class GraphQLParserTest extends TestCase
 {
     public function testParse(): void
     {

--- a/tests/Config/Parser/MetadataParser/TypeGuesser/DocBlockTypeGuesserTest.php
+++ b/tests/Config/Parser/MetadataParser/TypeGuesser/DocBlockTypeGuesserTest.php
@@ -13,7 +13,7 @@ use ReflectionMethod;
 use ReflectionProperty;
 use function sprintf;
 
-class DocBlockTypeGuesserTest extends TestCase
+final class DocBlockTypeGuesserTest extends TestCase
 {
     protected array $reflectors = [
         ReflectionProperty::class => 'var',

--- a/tests/Config/Parser/MetadataParser/TypeGuesser/DoctrineTypeGuesserTest.php
+++ b/tests/Config/Parser/MetadataParser/TypeGuesser/DoctrineTypeGuesserTest.php
@@ -11,7 +11,7 @@ use Overblog\GraphQLBundle\Config\Parser\MetadataParser\TypeGuesser\DoctrineType
 use Overblog\GraphQLBundle\Config\Parser\MetadataParser\TypeGuesser\TypeGuessingException;
 use ReflectionClass;
 
-class DoctrineTypeGuesserTest extends TestCase
+final class DoctrineTypeGuesserTest extends TestCase
 {
     // @phpstan-ignore-next-line
     protected $property;

--- a/tests/Config/Parser/YamlParserTest.php
+++ b/tests/Config/Parser/YamlParserTest.php
@@ -8,7 +8,7 @@ use Overblog\GraphQLBundle\Config\Parser\YamlParser;
 use SplFileInfo;
 use const DIRECTORY_SEPARATOR;
 
-class YamlParserTest extends TestCase
+final class YamlParserTest extends TestCase
 {
     public function testParseConstants(): void
     {

--- a/tests/Config/Parser/fixtures/annotations/Enum/Race.php
+++ b/tests/Config/Parser/fixtures/annotations/Enum/Race.php
@@ -15,7 +15,7 @@ use Overblog\GraphQLBundle\Tests\Config\Parser\Constants;
  */
 #[GQL\Enum]
 #[GQL\Description('The list of races!')]
-class Race
+final class Race
 {
     public const HUMAIN = 1;
 

--- a/tests/Config/Parser/fixtures/annotations/Input/Planet.php
+++ b/tests/Config/Parser/fixtures/annotations/Input/Planet.php
@@ -12,51 +12,51 @@ use Overblog\GraphQLBundle\Annotation as GQL;
  */
 #[GQL\Input]
 #[GQL\Description('Planet Input type description')]
-class Planet
+final class Planet
 {
     /**
      * @GQL\Field(resolve="...")
      */
     #[GQL\Field(resolve: '...')]
-    protected string $skipField;
+    private string $skipField;
 
     /**
      * @GQL\Field(type="String!")
      */
     #[GQL\Field(type: 'String!')]
-    protected string $name;
+    private string $name;
 
     /**
      * @GQL\Field(type="Int!")
      */
     #[GQL\Field(type: 'Int!')]
-    protected string $population;
+    private string $population;
 
     /**
      * @GQL\Field
      */
     #[GQL\Field]
-    protected string $description;
+    private string $description;
 
     /**
      * @GQL\Field
      */
     #[GQL\Field]
     // @phpstan-ignore-next-line
-    protected ?int $diameter;
+    private ?int $diameter;
 
     /**
      * @GQL\Field
      */
     #[GQL\Field]
-    protected int $variable;
+    private int $variable;
 
     // @phpstan-ignore-next-line
-    protected $dummy;
+    private $dummy;
 
     /**
      * @GQL\Field(type="[String]!")
      */
     #[GQL\Field(type: '[String]!')]
-    protected array $tags;
+    private array $tags;
 }

--- a/tests/Config/Parser/fixtures/annotations/Invalid/InvalidAccess.php
+++ b/tests/Config/Parser/fixtures/annotations/Invalid/InvalidAccess.php
@@ -10,11 +10,11 @@ use Overblog\GraphQLBundle\Annotation as GQL;
  * @GQL\Type
  */
 #[GQL\Type]
-class InvalidAccess
+final class InvalidAccess
 {
     /**
      * @GQL\Access("access")
      */
     #[GQL\Access('access')]
-    protected string $field;
+    private string $field;
 }

--- a/tests/Config/Parser/fixtures/annotations/Invalid/InvalidArgumentGuessing.php
+++ b/tests/Config/Parser/fixtures/annotations/Invalid/InvalidArgumentGuessing.php
@@ -10,7 +10,7 @@ use Overblog\GraphQLBundle\Annotation as GQL;
  * @GQL\Type
  */
 #[GQL\Type]
-class InvalidArgumentGuessing
+final class InvalidArgumentGuessing
 {
     /**
      * @GQL\Field(name="guessFailed")

--- a/tests/Config/Parser/fixtures/annotations/Invalid/InvalidDoctrineRelationGuessing.php
+++ b/tests/Config/Parser/fixtures/annotations/Invalid/InvalidDoctrineRelationGuessing.php
@@ -11,12 +11,12 @@ use Overblog\GraphQLBundle\Annotation as GQL;
  * @GQL\Type
  */
 #[GQL\Type]
-class InvalidDoctrineRelationGuessing
+final class InvalidDoctrineRelationGuessing
 {
     /**
      * @ORM\OneToOne(targetEntity="MissingType")
      * @GQL\Field
      */
     #[GQL\Field]
-    protected object $myRelation;
+    private object $myRelation;
 }

--- a/tests/Config/Parser/fixtures/annotations/Invalid/InvalidDoctrineTypeGuessing.php
+++ b/tests/Config/Parser/fixtures/annotations/Invalid/InvalidDoctrineTypeGuessing.php
@@ -11,7 +11,7 @@ use Overblog\GraphQLBundle\Annotation as GQL;
  * @GQL\Type
  */
 #[GQL\Type]
-class InvalidDoctrineTypeGuessing
+final class InvalidDoctrineTypeGuessing
 {
     /**
      * @ORM\Column(type="invalidType")
@@ -20,5 +20,5 @@ class InvalidDoctrineTypeGuessing
      * @var mixed
      */
     #[GQL\Field]
-    protected $myRelation;
+    private $myRelation;
 }

--- a/tests/Config/Parser/fixtures/annotations/Invalid/InvalidPrivateMethod.php
+++ b/tests/Config/Parser/fixtures/annotations/Invalid/InvalidPrivateMethod.php
@@ -10,13 +10,13 @@ use Overblog\GraphQLBundle\Annotation as GQL;
  * @GQL\Type
  */
 #[GQL\Type]
-class InvalidPrivateMethod
+final class InvalidPrivateMethod
 {
     /**
      * @GQL\Field
      */
     #[GQL\Field]
-    protected function gql(): string
+    private function gql(): string
     {
         return 'invalid';
     }

--- a/tests/Config/Parser/fixtures/annotations/Invalid/InvalidProvider.php
+++ b/tests/Config/Parser/fixtures/annotations/Invalid/InvalidProvider.php
@@ -10,7 +10,7 @@ use Overblog\GraphQLBundle\Annotation as GQL;
  * @GQL\Provider
  */
 #[GQL\Provider]
-class InvalidProvider
+final class InvalidProvider
 {
     /**
      * @GQL\Query(type="Int", targetTypes="RootMutation2")

--- a/tests/Config/Parser/fixtures/annotations/Invalid/InvalidReturnTypeGuessing.php
+++ b/tests/Config/Parser/fixtures/annotations/Invalid/InvalidReturnTypeGuessing.php
@@ -10,7 +10,7 @@ use Overblog\GraphQLBundle\Annotation as GQL;
  * @GQL\Type
  */
 #[GQL\Type]
-class InvalidReturnTypeGuessing
+final class InvalidReturnTypeGuessing
 {
     /**
      * @GQL\Field(name="guessFailed")

--- a/tests/Config/Parser/fixtures/annotations/Invalid/InvalidUnion.php
+++ b/tests/Config/Parser/fixtures/annotations/Invalid/InvalidUnion.php
@@ -10,6 +10,6 @@ use Overblog\GraphQLBundle\Annotation as GQL;
  * @GQL\Union(types={"Hero", "Droid", "Sith"})
  */
 #[GQL\Union(types: ['Hero', 'Droid', 'Sith'])]
-class InvalidUnion
+final class InvalidUnion
 {
 }

--- a/tests/Config/Parser/fixtures/annotations/Relay/EnemiesConnection.php
+++ b/tests/Config/Parser/fixtures/annotations/Relay/EnemiesConnection.php
@@ -11,6 +11,6 @@ use Overblog\GraphQLBundle\Relay\Connection\Output\Connection;
  * @GQL\Relay\Connection(node="Character")
  */
 #[GQL\Relay\Connection(node: 'Character')]
-class EnemiesConnection extends Connection
+final class EnemiesConnection extends Connection
 {
 }

--- a/tests/Config/Parser/fixtures/annotations/Relay/FriendsConnection.php
+++ b/tests/Config/Parser/fixtures/annotations/Relay/FriendsConnection.php
@@ -11,6 +11,6 @@ use Overblog\GraphQLBundle\Relay\Connection\Output\Connection;
  * @GQL\Relay\Connection(edge="FriendsConnectionEdge")
  */
 #[GQL\Relay\Connection(edge: 'FriendsConnectionEdge')]
-class FriendsConnection extends Connection
+final class FriendsConnection extends Connection
 {
 }

--- a/tests/Config/Parser/fixtures/annotations/Relay/FriendsConnectionEdge.php
+++ b/tests/Config/Parser/fixtures/annotations/Relay/FriendsConnectionEdge.php
@@ -11,6 +11,6 @@ use Overblog\GraphQLBundle\Relay\Connection\Output\Edge;
  * @GQL\Relay\Edge(node="Character")
  */
 #[GQL\Relay\Edge(node: 'Character')]
-class FriendsConnectionEdge extends Edge
+final class FriendsConnectionEdge extends Edge
 {
 }

--- a/tests/Config/Parser/fixtures/annotations/Repository/PlanetRepository.php
+++ b/tests/Config/Parser/fixtures/annotations/Repository/PlanetRepository.php
@@ -15,7 +15,7 @@ use Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Type\Planet;
 #[GQL\Provider(prefix: 'planet_')]
 #[GQL\Access('default_access')]
 #[GQL\IsPublic('default_public')]
-class PlanetRepository
+final class PlanetRepository
 {
     /**
      * @GQL\Query(type="[Planet]")

--- a/tests/Config/Parser/fixtures/annotations/Repository/WeaponRepository.php
+++ b/tests/Config/Parser/fixtures/annotations/Repository/WeaponRepository.php
@@ -10,7 +10,7 @@ use Overblog\GraphQLBundle\Annotation as GQL;
  * @GQL\Provider(targetQueryTypes={"RootQuery2"}, targetMutationTypes="RootMutation2")
  */
 #[GQL\Provider(targetQueryTypes: ['RootQuery2'], targetMutationTypes: 'RootMutation2')]
-class WeaponRepository
+final class WeaponRepository
 {
     /**
      * @GQL\Query

--- a/tests/Config/Parser/fixtures/annotations/Scalar/GalaxyCoordinates.php
+++ b/tests/Config/Parser/fixtures/annotations/Scalar/GalaxyCoordinates.php
@@ -16,7 +16,7 @@ use function implode;
  */
 #[GQL\Scalar]
 #[GQL\Description('The galaxy coordinates scalar')]
-class GalaxyCoordinates
+final class GalaxyCoordinates
 {
     /**
      * @return string

--- a/tests/Config/Parser/fixtures/annotations/Scalar/MyScalar2.php
+++ b/tests/Config/Parser/fixtures/annotations/Scalar/MyScalar2.php
@@ -10,6 +10,6 @@ use Overblog\GraphQLBundle\Annotation as GQL;
  * @GQL\Scalar(name="MyScalar", scalarType="newObject('App\\Type\\EmailType')")
  */
 #[GQL\Scalar(name: 'MyScalar', scalarType: "newObject('App\\Type\\EmailType')")]
-class MyScalar2
+final class MyScalar2
 {
 }

--- a/tests/Config/Parser/fixtures/annotations/Type/Battle.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/Battle.php
@@ -11,13 +11,13 @@ use Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Input\Planet
  * @GQL\Type
  */
 #[GQL\Type]
-class Battle
+final class Battle
 {
     /**
      * @GQL\Field(type="Planet", complexity="100 + childrenComplexity")
      */
     #[GQL\Field(type: 'Planet', complexity: '100 + childrenComplexity')]
-    protected object $planet;
+    private object $planet;
 
     /**
      * @GQL\Field(name="casualties", complexity="childrenComplexity * 5")

--- a/tests/Config/Parser/fixtures/annotations/Type/Cat.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/Cat.php
@@ -12,7 +12,7 @@ use Overblog\GraphQLBundle\Annotation as GQL;
  */
 #[GQL\Type]
 #[GQL\Description('The Cat type')]
-class Cat extends Animal
+final class Cat extends Animal
 {
     /**
      * @GQL\Field(type="Int!")

--- a/tests/Config/Parser/fixtures/annotations/Type/Crystal.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/Crystal.php
@@ -12,11 +12,11 @@ use Overblog\GraphQLBundle\Annotation as GQL;
  */
 #[GQL\Type]
 #[GQL\FieldsBuilder(name: 'MyFieldsBuilder', config: ['param1' => 'val1'])]
-class Crystal
+final class Crystal
 {
     /**
      * @GQL\Field(type="String!")
      */
     #[GQL\Field(type: 'String!')]
-    protected string $color;
+    private string $color;
 }

--- a/tests/Config/Parser/fixtures/annotations/Type/Droid.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/Droid.php
@@ -12,7 +12,7 @@ use Overblog\GraphQLBundle\Annotation as GQL;
  */
 #[GQL\Type(isTypeOf: "@=isTypeOf('App\Entity\Droid')")]
 #[GQL\Description('The Droid type')]
-class Droid extends Character
+final class Droid extends Character
 {
     /**
      * @GQL\Field

--- a/tests/Config/Parser/fixtures/annotations/Type/Hero.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/Hero.php
@@ -14,7 +14,7 @@ use Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Union\Killab
  */
 #[GQL\Type(interfaces: ['Character'])]
 #[GQL\Description('The Hero type')]
-class Hero extends Character implements Killable
+final class Hero extends Character implements Killable
 {
     /**
      * @GQL\Field(type="Race")

--- a/tests/Config/Parser/fixtures/annotations/Type/Lightsaber.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/Lightsaber.php
@@ -12,7 +12,7 @@ use Overblog\GraphQLBundle\Annotation as GQL;
  * @ORM\Entity
  */
 #[GQL\Type]
-class Lightsaber
+final class Lightsaber
 {
     /**
      * @ORM\Column
@@ -20,7 +20,7 @@ class Lightsaber
      */
     #[GQL\Field]
     // @phpstan-ignore-next-line
-    protected $color;
+    private $color;
 
     /**
      * @ORM\Column(type="text")
@@ -28,7 +28,7 @@ class Lightsaber
      */
     #[GQL\Field]
     // @phpstan-ignore-next-line
-    protected $text;
+    private $text;
 
     /**
      * @ORM\Column(type="string")
@@ -36,7 +36,7 @@ class Lightsaber
      */
     #[GQL\Field]
     // @phpstan-ignore-next-line
-    protected $string;
+    private $string;
 
     /**
      * @ORM\Column(type="integer", nullable=true)
@@ -44,7 +44,7 @@ class Lightsaber
      */
     #[GQL\Field]
     // @phpstan-ignore-next-line
-    protected $size;
+    private $size;
 
     /**
      * @ORM\OneToMany(targetEntity="Hero")
@@ -52,7 +52,7 @@ class Lightsaber
      */
     #[GQL\Field]
     // @phpstan-ignore-next-line
-    protected $holders;
+    private $holders;
 
     /**
      * @ORM\ManyToOne(targetEntity="Hero")
@@ -60,7 +60,7 @@ class Lightsaber
      */
     #[GQL\Field]
     // @phpstan-ignore-next-line
-    protected $creator;
+    private $creator;
 
     /**
      * @ORM\OneToOne(targetEntity="Crystal")
@@ -68,7 +68,7 @@ class Lightsaber
      */
     #[GQL\Field]
     // @phpstan-ignore-next-line
-    protected $crystal;
+    private $crystal;
 
     /**
      * @ORM\ManyToMany(targetEntity="Battle")
@@ -76,7 +76,7 @@ class Lightsaber
      */
     #[GQL\Field]
     // @phpstan-ignore-next-line
-    protected $battles;
+    private $battles;
 
     /**
      * @GQL\Field
@@ -85,7 +85,7 @@ class Lightsaber
      */
     #[GQL\Field]
     // @phpstan-ignore-next-line
-    protected $currentHolder;
+    private $currentHolder;
 
     /**
      * @GQL\Field
@@ -94,7 +94,7 @@ class Lightsaber
      */
     #[GQL\Field]
     #[GQL\Deprecated('No more tags on lightsabers')]
-    protected array $tags;
+    private array $tags;
 
     /**
      * @ORM\Column(type="float")
@@ -102,7 +102,7 @@ class Lightsaber
      */
     #[GQL\Field]
     // @phpstan-ignore-next-line
-    protected $float;
+    private $float;
 
     /**
      * @ORM\Column(type="decimal")
@@ -110,7 +110,7 @@ class Lightsaber
      */
     #[GQL\Field]
     // @phpstan-ignore-next-line
-    protected $decimal;
+    private $decimal;
 
     /**
      * @ORM\Column(type="bool")
@@ -118,7 +118,7 @@ class Lightsaber
      */
     #[GQL\Field]
     // @phpstan-ignore-next-line
-    protected $bool;
+    private $bool;
 
     /**
      * @ORM\Column(type="boolean")
@@ -126,5 +126,5 @@ class Lightsaber
      */
     #[GQL\Field]
     // @phpstan-ignore-next-line
-    protected $boolean;
+    private $boolean;
 }

--- a/tests/Config/Parser/fixtures/annotations/Type/Mandalorian.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/Mandalorian.php
@@ -11,6 +11,6 @@ use Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Union\Killab
  * @GQL\Type
  */
 #[GQL\Type]
-class Mandalorian extends Character implements Killable, Armored
+final class Mandalorian extends Character implements Killable, Armored
 {
 }

--- a/tests/Config/Parser/fixtures/annotations/Type/Planet.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/Planet.php
@@ -13,25 +13,25 @@ use Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Scalar\Galax
  */
 #[GQL\Type]
 #[GQL\Description('The Planet type')]
-class Planet
+final class Planet
 {
     /**
      * @GQL\Field(type="String!")
      */
     #[GQL\Field(type: 'String!')]
-    protected string $name;
+    private string $name;
 
     /**
      * @GQL\Field(type="GalaxyCoordinates")
      */
     #[GQL\Field(type: 'GalaxyCoordinates')]
-    protected GalaxyCoordinates $location;
+    private GalaxyCoordinates $location;
 
     /**
      * @GQL\Field(type="Int!")
      */
     #[GQL\Field(type: 'Int!')]
-    protected int $population;
+    private int $population;
 
     /**
      * @GQL\Field

--- a/tests/Config/Parser/fixtures/annotations/Type/RootMutation.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/RootMutation.php
@@ -10,6 +10,6 @@ use Overblog\GraphQLBundle\Annotation as GQL;
  * @GQL\Type
  */
 #[GQL\Type]
-class RootMutation
+final class RootMutation
 {
 }

--- a/tests/Config/Parser/fixtures/annotations/Type/RootMutation2.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/RootMutation2.php
@@ -10,6 +10,6 @@ use Overblog\GraphQLBundle\Annotation as GQL;
  * @GQL\Type
  */
 #[GQL\Type]
-class RootMutation2
+final class RootMutation2
 {
 }

--- a/tests/Config/Parser/fixtures/annotations/Type/RootQuery.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/RootQuery.php
@@ -10,6 +10,6 @@ use Overblog\GraphQLBundle\Annotation as GQL;
  * @GQL\Type
  */
 #[GQL\Type]
-class RootQuery
+final class RootQuery
 {
 }

--- a/tests/Config/Parser/fixtures/annotations/Type/RootQuery2.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/RootQuery2.php
@@ -10,6 +10,6 @@ use Overblog\GraphQLBundle\Annotation as GQL;
  * @GQL\Type
  */
 #[GQL\Type]
-class RootQuery2
+final class RootQuery2
 {
 }

--- a/tests/Config/Parser/fixtures/annotations/Type/Sith.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/Sith.php
@@ -17,7 +17,7 @@ use Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Union\Killab
 #[GQL\Description('The Sith type')]
 #[GQL\Access('isAuthenticated()')]
 #[GQL\IsPublic('isAuthenticated()')]
-class Sith extends Character implements Killable
+final class Sith extends Character implements Killable
 {
     /**
      * @GQL\Field(type="String!")

--- a/tests/Config/Parser/fixtures/annotations/Union/SearchResult.php
+++ b/tests/Config/Parser/fixtures/annotations/Union/SearchResult.php
@@ -12,6 +12,6 @@ use Overblog\GraphQLBundle\Annotation as GQL;
  */
 #[GQL\Union('ResultSearch', types: ['Hero', 'Droid', 'Sith'], resolveType: 'value.getType()')]
 #[GQL\Description('A search result')]
-class SearchResult
+final class SearchResult
 {
 }

--- a/tests/Config/Parser/fixtures/annotations/Union/SearchResult2.php
+++ b/tests/Config/Parser/fixtures/annotations/Union/SearchResult2.php
@@ -12,7 +12,7 @@ use Overblog\GraphQLBundle\Resolver\TypeResolver;
  * @GQL\Union(types={"Hero", "Droid", "Sith"})
  */
 #[GQL\Union(types: ['Hero', 'Droid', 'Sith'])]
-class SearchResult2
+final class SearchResult2
 {
     public static function resolveType(TypeResolver $typeResolver, bool $value): ?Type
     {

--- a/tests/Config/Processor/BuilderProcessorTest.php
+++ b/tests/Config/Processor/BuilderProcessorTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 use stdClass;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
-class BuilderProcessorTest extends TestCase
+final class BuilderProcessorTest extends TestCase
 {
     /**
      * @dataProvider apiAbuseProvider

--- a/tests/Config/Processor/InheritanceProcessorTest.php
+++ b/tests/Config/Processor/InheritanceProcessorTest.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
 use Overblog\GraphQLBundle\Config\Processor\InheritanceProcessor;
 use PHPUnit\Framework\TestCase;
 
-class InheritanceProcessorTest extends TestCase
+final class InheritanceProcessorTest extends TestCase
 {
     private array $fixtures = [
         'foo' => [InheritanceProcessor::INHERITS_KEY => ['bar', 'baz'], 'type' => 'object', 'config' => []],

--- a/tests/Controller/ProfilerControllerTest.php
+++ b/tests/Controller/ProfilerControllerTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpKernel\Profiler\Profiler;
 use Symfony\Component\Routing\Router;
 use Twig\Environment;
 
-class ProfilerControllerTest extends TestCase
+final class ProfilerControllerTest extends TestCase
 {
     /**
      * @return Router&MockObject

--- a/tests/DataCollector/GraphQLCollectorTest.php
+++ b/tests/DataCollector/GraphQLCollectorTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\VarDumper\Cloner\Data;
 
-class GraphQLCollectorTest extends TestCase
+final class GraphQLCollectorTest extends TestCase
 {
     public function testCollect(): void
     {

--- a/tests/Definition/ArgumentTest.php
+++ b/tests/Definition/ArgumentTest.php
@@ -7,7 +7,7 @@ namespace Overblog\GraphQLBundle\Tests\Definition;
 use Overblog\GraphQLBundle\Definition\Argument;
 use PHPUnit\Framework\TestCase;
 
-class ArgumentTest extends TestCase
+final class ArgumentTest extends TestCase
 {
     /** @var array */
     private $rawArgs;

--- a/tests/Definition/Type/CustomScalarTypeTest.php
+++ b/tests/Definition/Type/CustomScalarTypeTest.php
@@ -17,7 +17,7 @@ use stdClass;
 use function sprintf;
 use function uniqid;
 
-class CustomScalarTypeTest extends TestCase
+final class CustomScalarTypeTest extends TestCase
 {
     public function testScalarTypeConfig(): void
     {

--- a/tests/DependencyInjection/Builder/BoxFields.php
+++ b/tests/DependencyInjection/Builder/BoxFields.php
@@ -6,7 +6,7 @@ namespace Overblog\GraphQLBundle\Tests\DependencyInjection\Builder;
 
 use Overblog\GraphQLBundle\Definition\Builder\MappingInterface;
 
-class BoxFields implements MappingInterface
+final class BoxFields implements MappingInterface
 {
     public function toMappingDefinition(array $config): array
     {

--- a/tests/DependencyInjection/Builder/PagerArgs.php
+++ b/tests/DependencyInjection/Builder/PagerArgs.php
@@ -6,7 +6,7 @@ namespace Overblog\GraphQLBundle\Tests\DependencyInjection\Builder;
 
 use Overblog\GraphQLBundle\Definition\Builder\MappingInterface;
 
-class PagerArgs implements MappingInterface
+final class PagerArgs implements MappingInterface
 {
     public function toMappingDefinition(array $config): array
     {

--- a/tests/DependencyInjection/Builder/RawIdField.php
+++ b/tests/DependencyInjection/Builder/RawIdField.php
@@ -6,7 +6,7 @@ namespace Overblog\GraphQLBundle\Tests\DependencyInjection\Builder;
 
 use Overblog\GraphQLBundle\Definition\Builder\MappingInterface;
 
-class RawIdField implements MappingInterface
+final class RawIdField implements MappingInterface
 {
     public function toMappingDefinition(array $config): array
     {

--- a/tests/DependencyInjection/Builder/TimestampFields.php
+++ b/tests/DependencyInjection/Builder/TimestampFields.php
@@ -6,7 +6,7 @@ namespace Overblog\GraphQLBundle\Tests\DependencyInjection\Builder;
 
 use Overblog\GraphQLBundle\Definition\Builder\MappingInterface;
 
-class TimestampFields implements MappingInterface
+final class TimestampFields implements MappingInterface
 {
     public function toMappingDefinition(array $config = null): array
     {

--- a/tests/DependencyInjection/Compiler/ConfigParserPassTest.php
+++ b/tests/DependencyInjection/Compiler/ConfigParserPassTest.php
@@ -25,7 +25,7 @@ use function preg_quote;
 use function sprintf;
 use const DIRECTORY_SEPARATOR;
 
-class ConfigParserPassTest extends TestCase
+final class ConfigParserPassTest extends TestCase
 {
     private ContainerBuilder $container;
     private ConfigParserPass $compilerPass;

--- a/tests/DependencyInjection/Compiler/FakeCompilerPass.php
+++ b/tests/DependencyInjection/Compiler/FakeCompilerPass.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\Reference;
 /**
  * Class FakeCompilerPass.
  */
-class FakeCompilerPass implements CompilerPassInterface
+final class FakeCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/tests/DependencyInjection/Compiler/FakeInjectedService.php
+++ b/tests/DependencyInjection/Compiler/FakeInjectedService.php
@@ -7,7 +7,7 @@ namespace Overblog\GraphQLBundle\Tests\DependencyInjection\Compiler;
 /**
  * Class FakeInjectedService.
  */
-class FakeInjectedService
+final class FakeInjectedService
 {
     public function doSomething(): bool
     {

--- a/tests/DependencyInjection/Compiler/GraphQLServicesPassTest.php
+++ b/tests/DependencyInjection/Compiler/GraphQLServicesPassTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 use stdClass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class GraphQLServicesPassTest extends TestCase
+final class GraphQLServicesPassTest extends TestCase
 {
     /**
      * @param mixed $invalidAlias

--- a/tests/DependencyInjection/Compiler/ResolverTestService.php
+++ b/tests/DependencyInjection/Compiler/ResolverTestService.php
@@ -10,7 +10,7 @@ use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 /**
  * Class ResolverTestService.
  */
-class ResolverTestService implements ContainerAwareInterface
+final class ResolverTestService implements ContainerAwareInterface
 {
     use ContainerAwareTrait;
 

--- a/tests/DependencyInjection/mapping/annotation/Type.php
+++ b/tests/DependencyInjection/mapping/annotation/Type.php
@@ -9,6 +9,6 @@ use Overblog\GraphQLBundle\Annotation as GQL;
 /**
  * @GQL\Type
  */
-class Type
+final class Type
 {
 }

--- a/tests/EventListener/TypeDecoratorListenerTest.php
+++ b/tests/EventListener/TypeDecoratorListenerTest.php
@@ -22,7 +22,7 @@ use Overblog\GraphQLBundle\Resolver\ResolverMapInterface;
 use PHPUnit\Framework\TestCase;
 use function substr;
 
-class TypeDecoratorListenerTest extends TestCase
+final class TypeDecoratorListenerTest extends TestCase
 {
     /**
      * @param string $fieldName

--- a/tests/EventListener/ValidationErrorsListenerTest.php
+++ b/tests/EventListener/ValidationErrorsListenerTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Validation;
 use function class_exists;
 
-class ValidationErrorsListenerTest extends TestCase
+final class ValidationErrorsListenerTest extends TestCase
 {
     /** @var ValidationErrorsListener */
     private $listener;

--- a/tests/Executor/ExecutorTest.php
+++ b/tests/Executor/ExecutorTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use function sprintf;
 
-class ExecutorTest extends TestCase
+final class ExecutorTest extends TestCase
 {
     public function testInvalidExecutorAdapterPromise(): void
     {

--- a/tests/Executor/Promise/Adapter/ReactPromiseAdapterTest.php
+++ b/tests/Executor/Promise/Adapter/ReactPromiseAdapterTest.php
@@ -15,7 +15,7 @@ use stdClass;
 use Symfony\Component\Process\PhpProcess;
 use function sprintf;
 
-class ReactPromiseAdapterTest extends TestCase
+final class ReactPromiseAdapterTest extends TestCase
 {
     private ReactPromiseAdapter $adapter;
 

--- a/tests/ExpressionLanguage/ExpressionFunction/CallTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/CallTest.php
@@ -9,7 +9,7 @@ use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 use function sprintf;
 use function str_replace;
 
-class CallTest extends TestCase
+final class CallTest extends TestCase
 {
     protected function getFunctions(): array
     {
@@ -30,7 +30,7 @@ class CallTest extends TestCase
     {
         // Compile
         $this->assertEquals('AA', eval('
-            $class = new '.self::class.'(); 
+            $class = new '.self::class.'();
             return '.$this->expressionLanguage->compile('call(class.method, ["A"])', ['class']).';
          '));
 

--- a/tests/ExpressionLanguage/ExpressionFunction/DependencyInjection/ParameterTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/DependencyInjection/ParameterTest.php
@@ -8,7 +8,7 @@ use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\DependencyInjec
 use Overblog\GraphQLBundle\Generator\TypeGenerator;
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 
-class ParameterTest extends TestCase
+final class ParameterTest extends TestCase
 {
     protected function getFunctions()
     {

--- a/tests/ExpressionLanguage/ExpressionFunction/DependencyInjection/ServiceTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/DependencyInjection/ServiceTest.php
@@ -9,7 +9,7 @@ use Overblog\GraphQLBundle\Generator\TypeGenerator;
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 use stdClass;
 
-class ServiceTest extends TestCase
+final class ServiceTest extends TestCase
 {
     protected function getFunctions()
     {

--- a/tests/ExpressionLanguage/ExpressionFunction/GraphQL/ArgumentsTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/GraphQL/ArgumentsTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Validator\Validator\RecursiveValidator;
 use function class_exists;
 use function count;
 
-class ArgumentsTest extends TestCase
+final class ArgumentsTest extends TestCase
 {
     public function setUp(): void
     {

--- a/tests/ExpressionLanguage/ExpressionFunction/GraphQL/IsTypeOfTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/GraphQL/IsTypeOfTest.php
@@ -8,7 +8,7 @@ use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\GraphQL\IsTypeO
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 use stdClass;
 
-class IsTypeOfTest extends TestCase
+final class IsTypeOfTest extends TestCase
 {
     protected function getFunctions()
     {

--- a/tests/ExpressionLanguage/ExpressionFunction/GraphQL/MutationTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/GraphQL/MutationTest.php
@@ -8,7 +8,7 @@ use Overblog\GraphQLBundle\ExpressionLanguage\Exception\EvaluatorIsNotAllowedExc
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\GraphQL\Mutation;
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 
-class MutationTest extends TestCase
+final class MutationTest extends TestCase
 {
     protected function getFunctions()
     {

--- a/tests/ExpressionLanguage/ExpressionFunction/GraphQL/QueryTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/GraphQL/QueryTest.php
@@ -8,7 +8,7 @@ use Overblog\GraphQLBundle\ExpressionLanguage\Exception\EvaluatorIsNotAllowedExc
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\GraphQL\Query;
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 
-class QueryTest extends TestCase
+final class QueryTest extends TestCase
 {
     protected function getFunctions()
     {

--- a/tests/ExpressionLanguage/ExpressionFunction/GraphQL/Relay/FromGlobalIDTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/GraphQL/Relay/FromGlobalIDTest.php
@@ -7,7 +7,7 @@ namespace Overblog\GraphQLBundle\Tests\ExpressionLanguage\ExpressionFunction\Gra
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\GraphQL\Relay\FromGlobalID;
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 
-class FromGlobalIDTest extends TestCase
+final class FromGlobalIDTest extends TestCase
 {
     protected function getFunctions()
     {

--- a/tests/ExpressionLanguage/ExpressionFunction/GraphQL/Relay/GlobalIDTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/GraphQL/Relay/GlobalIDTest.php
@@ -7,7 +7,7 @@ namespace Overblog\GraphQLBundle\Tests\ExpressionLanguage\ExpressionFunction\Gra
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\GraphQL\Relay\GlobalID;
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 
-class GlobalIDTest extends TestCase
+final class GlobalIDTest extends TestCase
 {
     protected function getFunctions()
     {

--- a/tests/ExpressionLanguage/ExpressionFunction/GraphQL/Relay/IdFetcherCallbackTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/GraphQL/Relay/IdFetcherCallbackTest.php
@@ -8,7 +8,7 @@ use Overblog\GraphQLBundle\ExpressionLanguage\Exception\EvaluatorIsNotAllowedExc
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\GraphQL\Relay\IdFetcherCallback;
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 
-class IdFetcherCallbackTest extends TestCase
+final class IdFetcherCallbackTest extends TestCase
 {
     protected function getFunctions()
     {

--- a/tests/ExpressionLanguage/ExpressionFunction/GraphQL/Relay/MutateAndGetPayloadCallbackTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/GraphQL/Relay/MutateAndGetPayloadCallbackTest.php
@@ -8,7 +8,7 @@ use Overblog\GraphQLBundle\ExpressionLanguage\Exception\EvaluatorIsNotAllowedExc
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\GraphQL\Relay\MutateAndGetPayloadCallback;
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 
-class MutateAndGetPayloadCallbackTest extends TestCase
+final class MutateAndGetPayloadCallbackTest extends TestCase
 {
     protected function getFunctions()
     {

--- a/tests/ExpressionLanguage/ExpressionFunction/GraphQL/Relay/ResolveSingleInputCallbackTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/GraphQL/Relay/ResolveSingleInputCallbackTest.php
@@ -8,7 +8,7 @@ use Overblog\GraphQLBundle\ExpressionLanguage\Exception\EvaluatorIsNotAllowedExc
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\GraphQL\Relay\ResolveSingleInputCallback;
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 
-class ResolveSingleInputCallbackTest extends TestCase
+final class ResolveSingleInputCallbackTest extends TestCase
 {
     protected function getFunctions()
     {

--- a/tests/ExpressionLanguage/ExpressionFunction/NewObjectTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/NewObjectTest.php
@@ -7,7 +7,7 @@ namespace Overblog\GraphQLBundle\Tests\ExpressionLanguage\ExpressionFunction;
 use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\NewObject;
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 
-class NewObjectTest extends TestCase
+final class NewObjectTest extends TestCase
 {
     protected function getFunctions()
     {

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/GetUserTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/GetUserTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\User;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-class GetUserTest extends TestCase
+final class GetUserTest extends TestCase
 {
     protected function getFunctions()
     {

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/HasAnyPermissionTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/HasAnyPermissionTest.php
@@ -9,7 +9,7 @@ use Overblog\GraphQLBundle\Generator\TypeGenerator;
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 use stdClass;
 
-class HasAnyPermissionTest extends TestCase
+final class HasAnyPermissionTest extends TestCase
 {
     private string $testedExpression = 'hasAnyPermission(object,["OWNER", "WRITER"])';
 

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/HasAnyRoleTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/HasAnyRoleTest.php
@@ -8,7 +8,7 @@ use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\Security\HasAny
 use Overblog\GraphQLBundle\Generator\TypeGenerator;
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 
-class HasAnyRoleTest extends TestCase
+final class HasAnyRoleTest extends TestCase
 {
     protected function getFunctions()
     {

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/HasPermissionTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/HasPermissionTest.php
@@ -9,7 +9,7 @@ use Overblog\GraphQLBundle\Generator\TypeGenerator;
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 use stdClass;
 
-class HasPermissionTest extends TestCase
+final class HasPermissionTest extends TestCase
 {
     private string $testedExpression = 'hasPermission(object,"OWNER")';
 

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/HasRoleTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/HasRoleTest.php
@@ -8,7 +8,7 @@ use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\Security\HasRol
 use Overblog\GraphQLBundle\Generator\TypeGenerator;
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 
-class HasRoleTest extends TestCase
+final class HasRoleTest extends TestCase
 {
     protected function getFunctions()
     {

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/IsAnonymousTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/IsAnonymousTest.php
@@ -8,7 +8,7 @@ use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\Security\IsAnon
 use Overblog\GraphQLBundle\Generator\TypeGenerator;
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 
-class IsAnonymousTest extends TestCase
+final class IsAnonymousTest extends TestCase
 {
     protected function getFunctions()
     {

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/IsAuthenticatedTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/IsAuthenticatedTest.php
@@ -8,7 +8,7 @@ use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\Security\IsAuth
 use Overblog\GraphQLBundle\Generator\TypeGenerator;
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 
-class IsAuthenticatedTest extends TestCase
+final class IsAuthenticatedTest extends TestCase
 {
     protected function getFunctions()
     {

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/IsFullyAuthenticatedTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/IsFullyAuthenticatedTest.php
@@ -8,7 +8,7 @@ use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\Security\IsFull
 use Overblog\GraphQLBundle\Generator\TypeGenerator;
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 
-class IsFullyAuthenticatedTest extends TestCase
+final class IsFullyAuthenticatedTest extends TestCase
 {
     protected function getFunctions()
     {

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/IsGrantedTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/IsGrantedTest.php
@@ -8,7 +8,7 @@ use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\Security\IsGran
 use Overblog\GraphQLBundle\Generator\TypeGenerator;
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 
-class IsGrantedTest extends TestCase
+final class IsGrantedTest extends TestCase
 {
     protected function getFunctions()
     {

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/IsRememberMeTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/IsRememberMeTest.php
@@ -8,7 +8,7 @@ use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\Security\IsReme
 use Overblog\GraphQLBundle\Generator\TypeGenerator;
 use Overblog\GraphQLBundle\Tests\ExpressionLanguage\TestCase;
 
-class IsRememberMeTest extends TestCase
+final class IsRememberMeTest extends TestCase
 {
     protected function getFunctions()
     {

--- a/tests/ExpressionLanguage/ExpressionLanguageTest.php
+++ b/tests/ExpressionLanguage/ExpressionLanguageTest.php
@@ -8,7 +8,7 @@ use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionLanguage;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\ExpressionLanguage\Expression;
 
-class ExpressionLanguageTest extends TestCase
+final class ExpressionLanguageTest extends TestCase
 {
     /**
      * @dataProvider expressionContainsVarProvider

--- a/tests/Functional/App/Exception/ExampleException.php
+++ b/tests/Functional/App/Exception/ExampleException.php
@@ -6,7 +6,7 @@ namespace Overblog\GraphQLBundle\Tests\Functional\App\Exception;
 
 use InvalidArgumentException;
 
-class ExampleException
+final class ExampleException
 {
     public function __invoke(): void
     {

--- a/tests/Functional/App/Mutation/InputValidatorMutation.php
+++ b/tests/Functional/App/Mutation/InputValidatorMutation.php
@@ -11,7 +11,7 @@ use Overblog\GraphQLBundle\Error\ResolveErrors;
 use Overblog\GraphQLBundle\Validator\Exception\ArgumentsValidationException;
 use Overblog\GraphQLBundle\Validator\InputValidator;
 
-class InputValidatorMutation implements MutationInterface
+final class InputValidatorMutation implements MutationInterface
 {
     /**
      * @throws ArgumentsValidationException

--- a/tests/Functional/App/Mutation/SimpleMutationWithThunkFieldsMutation.php
+++ b/tests/Functional/App/Mutation/SimpleMutationWithThunkFieldsMutation.php
@@ -6,7 +6,7 @@ namespace Overblog\GraphQLBundle\Tests\Functional\App\Mutation;
 
 use Overblog\GraphQLBundle\Definition\ArgumentInterface;
 
-class SimpleMutationWithThunkFieldsMutation
+final class SimpleMutationWithThunkFieldsMutation
 {
     private static bool $hasMutate = false;
 

--- a/tests/Functional/App/Mutation/SimplePromiseMutation.php
+++ b/tests/Functional/App/Mutation/SimplePromiseMutation.php
@@ -7,7 +7,7 @@ namespace Overblog\GraphQLBundle\Tests\Functional\App\Mutation;
 use GraphQL\Executor\Promise\Promise;
 use GraphQL\Executor\Promise\PromiseAdapter;
 
-class SimplePromiseMutation
+final class SimplePromiseMutation
 {
     private PromiseAdapter $promiseAdapter;
 

--- a/tests/Functional/App/Resolver/Characters.php
+++ b/tests/Functional/App/Resolver/Characters.php
@@ -6,7 +6,7 @@ namespace Overblog\GraphQLBundle\Tests\Functional\App\Resolver;
 
 use function array_filter;
 
-class Characters
+final class Characters
 {
     public const TYPE_HUMAN = 'human';
     public const TYPE_DIREWOLF = 'direwolf';

--- a/tests/Functional/App/Resolver/ConnectionResolver.php
+++ b/tests/Functional/App/Resolver/ConnectionResolver.php
@@ -15,7 +15,7 @@ use Overblog\GraphQLBundle\Relay\Connection\Output\Edge;
 use React\Promise\Promise as ReactPromise;
 use function count;
 
-class ConnectionResolver
+final class ConnectionResolver
 {
     private array $allUsers = [
         [

--- a/tests/Functional/App/Resolver/GlobalResolver.php
+++ b/tests/Functional/App/Resolver/GlobalResolver.php
@@ -9,7 +9,7 @@ use Overblog\GraphQLBundle\Relay\Node\GlobalId;
 use Overblog\GraphQLBundle\Resolver\TypeResolver;
 use function array_values;
 
-class GlobalResolver
+final class GlobalResolver
 {
     private TypeResolver $typeResolver;
 

--- a/tests/Functional/App/Resolver/NodeResolver.php
+++ b/tests/Functional/App/Resolver/NodeResolver.php
@@ -8,7 +8,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-class NodeResolver implements ContainerAwareInterface
+final class NodeResolver implements ContainerAwareInterface
 {
     use ContainerAwareTrait;
 

--- a/tests/Functional/App/Resolver/NullResolverMap.php
+++ b/tests/Functional/App/Resolver/NullResolverMap.php
@@ -6,7 +6,7 @@ namespace Overblog\GraphQLBundle\Tests\Functional\App\Resolver;
 
 use Overblog\GraphQLBundle\Resolver\ResolverMap;
 
-class NullResolverMap extends ResolverMap
+final class NullResolverMap extends ResolverMap
 {
     protected function map(): array
     {

--- a/tests/Functional/App/Resolver/PluralResolver.php
+++ b/tests/Functional/App/Resolver/PluralResolver.php
@@ -7,7 +7,7 @@ namespace Overblog\GraphQLBundle\Tests\Functional\App\Resolver;
 use GraphQL\Type\Definition\ResolveInfo;
 use function sprintf;
 
-class PluralResolver
+final class PluralResolver
 {
     public function __invoke(string $username, ResolveInfo $info): array
     {

--- a/tests/Functional/App/Resolver/SchemaLanguageMutationResolverMap.php
+++ b/tests/Functional/App/Resolver/SchemaLanguageMutationResolverMap.php
@@ -6,7 +6,7 @@ namespace Overblog\GraphQLBundle\Tests\Functional\App\Resolver;
 
 use Overblog\GraphQLBundle\Resolver\ResolverMap;
 
-class SchemaLanguageMutationResolverMap extends ResolverMap
+final class SchemaLanguageMutationResolverMap extends ResolverMap
 {
     protected function map(): array
     {

--- a/tests/Functional/App/Resolver/SchemaLanguageQueryResolverMap.php
+++ b/tests/Functional/App/Resolver/SchemaLanguageQueryResolverMap.php
@@ -12,7 +12,7 @@ use Overblog\GraphQLBundle\Tests\Functional\App\Type\YearScalarType;
 use function array_filter;
 use function in_array;
 
-class SchemaLanguageQueryResolverMap extends ResolverMap
+final class SchemaLanguageQueryResolverMap extends ResolverMap
 {
     protected function map(): array
     {

--- a/tests/Functional/App/Service/PrivateService.php
+++ b/tests/Functional/App/Service/PrivateService.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Tests\Functional\App\Service;
 
-class PrivateService
+final class PrivateService
 {
     public function hasAccess(): bool
     {

--- a/tests/Functional/App/Type/YearScalarType.php
+++ b/tests/Functional/App/Type/YearScalarType.php
@@ -10,7 +10,7 @@ use GraphQL\Type\Definition\ScalarType;
 use function sprintf;
 use function str_replace;
 
-class YearScalarType extends ScalarType
+final class YearScalarType extends ScalarType
 {
     /**
      * {@inheritdoc}

--- a/tests/Functional/ArgumentWrapper/ArgumentWrapperTest.php
+++ b/tests/Functional/ArgumentWrapper/ArgumentWrapperTest.php
@@ -6,7 +6,7 @@ namespace Overblog\GraphQLBundle\Tests\Functional\ArgumentWrapper;
 
 use Overblog\GraphQLBundle\Tests\Functional\TestCase;
 
-class ArgumentWrapperTest extends TestCase
+final class ArgumentWrapperTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/Functional/AutoConfigure/HelloWordTest.php
+++ b/tests/Functional/AutoConfigure/HelloWordTest.php
@@ -9,7 +9,7 @@ use Overblog\GraphQLBundle\Tests\Functional\TestCase;
 /**
  * @group legacy
  */
-class HelloWordTest extends TestCase
+final class HelloWordTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/Functional/BootTest.php
+++ b/tests/Functional/BootTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Tests\Functional;
 
-class BootTest extends TestCase
+final class BootTest extends TestCase
 {
     public function testBootAppKernel(): void
     {

--- a/tests/Functional/Command/CompileCommandTest.php
+++ b/tests/Functional/Command/CompileCommandTest.php
@@ -14,7 +14,7 @@ use function preg_replace;
 use function str_replace;
 use const PHP_EOL;
 
-class CompileCommandTest extends TestCase
+final class CompileCommandTest extends TestCase
 {
     private CommandTester $commandTester;
     private array $typesMapping;

--- a/tests/Functional/Command/DebugCommandTest.php
+++ b/tests/Functional/Command/DebugCommandTest.php
@@ -14,7 +14,7 @@ use function str_replace;
 use function trim;
 use const PHP_EOL;
 
-class DebugCommandTest extends TestCase
+final class DebugCommandTest extends TestCase
 {
     private CommandTester $commandTester;
     private array $logs = [];

--- a/tests/Functional/Command/GraphDumpSchemaCommandTest.php
+++ b/tests/Functional/Command/GraphDumpSchemaCommandTest.php
@@ -14,7 +14,7 @@ use function strcmp;
 use function trim;
 use function usort;
 
-class GraphDumpSchemaCommandTest extends TestCase
+final class GraphDumpSchemaCommandTest extends TestCase
 {
     private CommandTester $commandTester;
     private string $cacheDir;

--- a/tests/Functional/Command/ValidateCommandTest.php
+++ b/tests/Functional/Command/ValidateCommandTest.php
@@ -12,7 +12,7 @@ use Overblog\GraphQLBundle\Tests\Functional\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use function trim;
 
-class ValidateCommandTest extends TestCase
+final class ValidateCommandTest extends TestCase
 {
     /** @var ValidateCommand */
     private $command;

--- a/tests/Functional/Controller/GraphControllerTest.php
+++ b/tests/Functional/Controller/GraphControllerTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use function json_decode;
 use function json_encode;
 
-class GraphControllerTest extends TestCase
+final class GraphControllerTest extends TestCase
 {
     private string $friendsQuery = <<<'EOF'
         query FriendsQuery {

--- a/tests/Functional/DefaultValue/DefaultValueTest.php
+++ b/tests/Functional/DefaultValue/DefaultValueTest.php
@@ -6,7 +6,7 @@ namespace Overblog\GraphQLBundle\Tests\Functional\DefaultValue;
 
 use Overblog\GraphQLBundle\Tests\Functional\TestCase;
 
-class DefaultValueTest extends TestCase
+final class DefaultValueTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/Functional/DisableBuiltInMapping/DisableBuiltInMappingTest.php
+++ b/tests/Functional/DisableBuiltInMapping/DisableBuiltInMappingTest.php
@@ -8,7 +8,7 @@ use GraphQL\Type\Definition\Type;
 use Overblog\GraphQLBundle\Resolver\UnresolvableException;
 use Overblog\GraphQLBundle\Tests\Functional\TestCase;
 
-class DisableBuiltInMappingTest extends TestCase
+final class DisableBuiltInMappingTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/Functional/EventListener/DebugListenerTest.php
+++ b/tests/Functional/EventListener/DebugListenerTest.php
@@ -7,7 +7,7 @@ namespace Overblog\GraphQLBundle\Tests\Functional\EventListener;
 use GraphQL\Type\Introspection;
 use Overblog\GraphQLBundle\Tests\Functional\TestCase;
 
-class DebugListenerTest extends TestCase
+final class DebugListenerTest extends TestCase
 {
     public function testDisabledDebugInfo(): void
     {

--- a/tests/Functional/Exception/ExceptionTest.php
+++ b/tests/Functional/Exception/ExceptionTest.php
@@ -6,7 +6,7 @@ namespace Overblog\GraphQLBundle\Tests\Functional\Exception;
 
 use Overblog\GraphQLBundle\Tests\Functional\TestCase;
 
-class ExceptionTest extends TestCase
+final class ExceptionTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/Functional/Generator/TypeGeneratorTest.php
+++ b/tests/Functional/Generator/TypeGeneratorTest.php
@@ -8,7 +8,7 @@ use Overblog\GraphQLBundle\Generator\Exception\GeneratorException;
 use Overblog\GraphQLBundle\Tests\Functional\TestCase;
 use function json_decode;
 
-class TypeGeneratorTest extends TestCase
+final class TypeGeneratorTest extends TestCase
 {
     public function testPublicCallback(): void
     {

--- a/tests/Functional/Inheritance/InheritanceTest.php
+++ b/tests/Functional/Inheritance/InheritanceTest.php
@@ -7,7 +7,7 @@ namespace Overblog\GraphQLBundle\Tests\Functional\Inheritance;
 use Overblog\GraphQLBundle\Config\Processor\InheritanceProcessor;
 use Overblog\GraphQLBundle\Tests\Functional\TestCase;
 
-class InheritanceTest extends TestCase
+final class InheritanceTest extends TestCase
 {
     /** @var array */
     private $config;

--- a/tests/Functional/MultipleQueries/MultipleQueriesTest.php
+++ b/tests/Functional/MultipleQueries/MultipleQueriesTest.php
@@ -6,7 +6,7 @@ namespace Overblog\GraphQLBundle\Tests\Functional\MultipleQueries;
 
 use Overblog\GraphQLBundle\Tests\Functional\TestCase;
 
-class MultipleQueriesTest extends TestCase
+final class MultipleQueriesTest extends TestCase
 {
     private const REQUIRED_FAILS_ERRORS = [
         [

--- a/tests/Functional/MultipleSchema/MultipleSchemaTest.php
+++ b/tests/Functional/MultipleSchema/MultipleSchemaTest.php
@@ -7,7 +7,7 @@ namespace Overblog\GraphQLBundle\Tests\Functional\MultipleSchema;
 use GraphQL\Error\InvariantViolation;
 use Overblog\GraphQLBundle\Tests\Functional\TestCase;
 
-class MultipleSchemaTest extends TestCase
+final class MultipleSchemaTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/Functional/Relay/Connection/ConnectionTest.php
+++ b/tests/Functional/Relay/Connection/ConnectionTest.php
@@ -11,7 +11,7 @@ use Overblog\GraphQLBundle\Tests\Functional\TestCase;
  *
  * @see https://github.com/graphql/graphql-relay-js/blob/master/src/connection/__tests__/connection.js
  */
-class ConnectionTest extends TestCase
+final class ConnectionTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/Functional/Relay/Mutation/MutationTest.php
+++ b/tests/Functional/Relay/Mutation/MutationTest.php
@@ -11,7 +11,7 @@ use Overblog\GraphQLBundle\Tests\Functional\TestCase;
  *
  * @see https://github.com/graphql/graphql-relay-js/blob/master/src/mutation/__tests__/mutation.js
  */
-class MutationTest extends TestCase
+final class MutationTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/Functional/Relay/Node/GlobalTest.php
+++ b/tests/Functional/Relay/Node/GlobalTest.php
@@ -11,7 +11,7 @@ use Overblog\GraphQLBundle\Tests\Functional\TestCase;
  *
  * @see https://github.com/graphql/graphql-relay-js/blob/master/src/node/__tests__/global.js
  */
-class GlobalTest extends TestCase
+final class GlobalTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/Functional/Relay/Node/NodeTest.php
+++ b/tests/Functional/Relay/Node/NodeTest.php
@@ -13,7 +13,7 @@ use Overblog\GraphQLBundle\Tests\Functional\TestCase;
  *
  * @see https://github.com/graphql/graphql-relay-js/blob/master/src/node/__tests__/node.js
  */
-class NodeTest extends TestCase
+final class NodeTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/Functional/Relay/Node/PluralTest.php
+++ b/tests/Functional/Relay/Node/PluralTest.php
@@ -11,7 +11,7 @@ use Overblog\GraphQLBundle\Tests\Functional\TestCase;
  *
  * @see https://github.com/graphql/graphql-relay-js/blob/master/src/node/__tests__/plural.js
  */
-class PluralTest extends TestCase
+final class PluralTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/Functional/SchemaLanguage/SchemaLanguageTest.php
+++ b/tests/Functional/SchemaLanguage/SchemaLanguageTest.php
@@ -6,7 +6,7 @@ namespace Overblog\GraphQLBundle\Tests\Functional\SchemaLanguage;
 
 use Overblog\GraphQLBundle\Tests\Functional\TestCase;
 
-class SchemaLanguageTest extends TestCase
+final class SchemaLanguageTest extends TestCase
 {
     public function testQueryHumans(): void
     {

--- a/tests/Functional/Security/AccessTest.php
+++ b/tests/Functional/Security/AccessTest.php
@@ -17,7 +17,7 @@ use function spl_autoload_unregister;
 use function sprintf;
 use function sys_get_temp_dir;
 
-class AccessTest extends TestCase
+final class AccessTest extends TestCase
 {
     private Closure $loader;
 

--- a/tests/Functional/Security/DisableIntrospectionTest.php
+++ b/tests/Functional/Security/DisableIntrospectionTest.php
@@ -6,7 +6,7 @@ namespace Overblog\GraphQLBundle\Tests\Functional\Security;
 
 use Overblog\GraphQLBundle\Tests\Functional\TestCase;
 
-class DisableIntrospectionTest extends TestCase
+final class DisableIntrospectionTest extends TestCase
 {
     private string $introspectionQuery = <<<'EOF'
         query {

--- a/tests/Functional/Security/QueryComplexityTest.php
+++ b/tests/Functional/Security/QueryComplexityTest.php
@@ -6,7 +6,7 @@ namespace Overblog\GraphQLBundle\Tests\Functional\Security;
 
 use Overblog\GraphQLBundle\Tests\Functional\TestCase;
 
-class QueryComplexityTest extends TestCase
+final class QueryComplexityTest extends TestCase
 {
     private string $userFriendsWithoutLimitQuery = <<<'EOF'
         query {

--- a/tests/Functional/Security/QueryMaxDepthTest.php
+++ b/tests/Functional/Security/QueryMaxDepthTest.php
@@ -6,7 +6,7 @@ namespace Overblog\GraphQLBundle\Tests\Functional\Security;
 
 use Overblog\GraphQLBundle\Tests\Functional\TestCase;
 
-class QueryMaxDepthTest extends TestCase
+final class QueryMaxDepthTest extends TestCase
 {
     private string $userFriendsWithoutViolationQuery = <<<'EOF'
         query {

--- a/tests/Functional/Type/CustomScalarTest.php
+++ b/tests/Functional/Type/CustomScalarTest.php
@@ -6,7 +6,7 @@ namespace Overblog\GraphQLBundle\Tests\Functional\Type;
 
 use Overblog\GraphQLBundle\Tests\Functional\TestCase;
 
-class CustomScalarTest extends TestCase
+final class CustomScalarTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/Functional/Type/DateTimeType.php
+++ b/tests/Functional/Type/DateTimeType.php
@@ -9,7 +9,7 @@ use Exception;
 use GraphQL\Language\AST\StringValueNode;
 use Overblog\GraphQLBundle\Definition\ArgumentInterface;
 
-class DateTimeType
+final class DateTimeType
 {
     /**
      * @return string

--- a/tests/Functional/Type/DefinitionTest.php
+++ b/tests/Functional/Type/DefinitionTest.php
@@ -9,7 +9,7 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use Overblog\GraphQLBundle\Tests\Functional\TestCase;
 
-class DefinitionTest extends TestCase
+final class DefinitionTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/Functional/Upload/UploadTest.php
+++ b/tests/Functional/Upload/UploadTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 use function json_decode;
 use function json_encode;
 
-class UploadTest extends TestCase
+final class UploadTest extends TestCase
 {
     public function testSingleUpload(): void
     {

--- a/tests/Functional/Validator/DummyEntity.php
+++ b/tests/Functional/Validator/DummyEntity.php
@@ -11,7 +11,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  *
  * @Assert\Callback({"Overblog\GraphQLBundle\Tests\Functional\Validator\StaticValidator", "validateClass"})
  */
-class DummyEntity
+final class DummyEntity
 {
     /**
      * @Assert\EqualTo("Lorem Ipsum")

--- a/tests/Functional/Validator/ExpectedErrors.php
+++ b/tests/Functional/Validator/ExpectedErrors.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Tests\Functional\Validator;
 
-class ExpectedErrors
+final class ExpectedErrors
 {
     public const LINKED_CONSTRAINTS = [
         'message' => 'validation',

--- a/tests/Functional/Validator/InputValidatorTest.php
+++ b/tests/Functional/Validator/InputValidatorTest.php
@@ -10,7 +10,7 @@ use Symfony\Component\Validator\Validation;
 use function class_exists;
 use function json_decode;
 
-class InputValidatorTest extends TestCase
+final class InputValidatorTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/Functional/Validator/ServiceValidator.php
+++ b/tests/Functional/Validator/ServiceValidator.php
@@ -7,7 +7,7 @@ namespace Overblog\GraphQLBundle\Tests\Functional\Validator;
 use GraphQL\Type\Definition\ResolveInfo;
 use Overblog\GraphQLBundle\Definition\ArgumentInterface;
 
-class ServiceValidator
+final class ServiceValidator
 {
     public function isZipCodeValid(int $code): bool
     {

--- a/tests/Functional/Validator/StaticValidator.php
+++ b/tests/Functional/Validator/StaticValidator.php
@@ -8,7 +8,7 @@ use DateTime;
 use Exception;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
-class StaticValidator
+final class StaticValidator
 {
     /**
      * @param mixed $value

--- a/tests/Generator/TypeGeneratorTest.php
+++ b/tests/Generator/TypeGeneratorTest.php
@@ -6,20 +6,25 @@ namespace Overblog\GraphQLBundle\Tests\Generator;
 
 use Generator;
 use Overblog\GraphQLBundle\Event\SchemaCompiledEvent;
+use Overblog\GraphQLBundle\ExpressionLanguage\ExpressionLanguage;
+use Overblog\GraphQLBundle\Generator\Converter\ExpressionConverter;
 use Overblog\GraphQLBundle\Generator\TypeBuilder;
 use Overblog\GraphQLBundle\Generator\TypeGenerator;
 use Overblog\GraphQLBundle\Generator\TypeGeneratorOptions;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
-class TypeGeneratorTest extends TestCase
+final class TypeGeneratorTest extends TestCase
 {
     /**
      * @dataProvider getPermissionsProvider
      */
     public function testCacheDirPermissions(int $expectedMask, ?string $cacheDir, ?int $cacheDirMask): void
     {
-        $typeBuilder = $this->createMock(TypeBuilder::class);
+        $typeBuilder = new TypeBuilder(
+            new ExpressionConverter(new ExpressionLanguage()),
+            'namespace'
+        );
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
 
         $options = new TypeGeneratorOptions('App', $cacheDir, true, null, $cacheDirMask);
@@ -31,7 +36,10 @@ class TypeGeneratorTest extends TestCase
 
     public function testCompiledEvent(): void
     {
-        $typeBuilder = $this->createMock(TypeBuilder::class);
+        $typeBuilder = new TypeBuilder(
+            new ExpressionConverter(new ExpressionLanguage()),
+            'namespace'
+        );
         $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMock();
 
         $eventDispatcher->expects($this->once())

--- a/tests/Relay/Builder/RelayConnectionFieldsBuilderTest.php
+++ b/tests/Relay/Builder/RelayConnectionFieldsBuilderTest.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
 use Overblog\GraphQLBundle\Relay\Builder\RelayConnectionFieldsBuilder;
 use PHPUnit\Framework\TestCase;
 
-class RelayConnectionFieldsBuilderTest extends TestCase
+final class RelayConnectionFieldsBuilderTest extends TestCase
 {
     protected function doMapping(array $config): array
     {

--- a/tests/Relay/Builder/RelayEdgeFieldsBuilderTest.php
+++ b/tests/Relay/Builder/RelayEdgeFieldsBuilderTest.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
 use Overblog\GraphQLBundle\Relay\Builder\RelayEdgeFieldsBuilder;
 use PHPUnit\Framework\TestCase;
 
-class RelayEdgeFieldsBuilderTest extends TestCase
+final class RelayEdgeFieldsBuilderTest extends TestCase
 {
     protected function doMapping(array $config): array
     {

--- a/tests/Relay/Connection/ConnectionBuilderFromPromisedTest.php
+++ b/tests/Relay/Connection/ConnectionBuilderFromPromisedTest.php
@@ -17,7 +17,7 @@ use function call_user_func;
 use function func_get_args;
 use function React\Promise\resolve;
 
-class ConnectionBuilderFromPromisedTest extends AbstractConnectionBuilderTest
+final class ConnectionBuilderFromPromisedTest extends AbstractConnectionBuilderTest
 {
     public function testReturnsAllElementsWithoutFilters(): void
     {

--- a/tests/Relay/Connection/ConnectionBuilderTest.php
+++ b/tests/Relay/Connection/ConnectionBuilderTest.php
@@ -18,7 +18,7 @@ use function func_get_args;
  *
  * @see https://github.com/graphql/graphql-relay-js/blob/master/src/connection/__tests__/arrayconnection.js
  */
-class ConnectionBuilderTest extends AbstractConnectionBuilderTest
+final class ConnectionBuilderTest extends AbstractConnectionBuilderTest
 {
     public function testBasicSlicing(): void
     {

--- a/tests/Relay/Connection/Output/DeprecatedPropertyPublicAccessTraitTest.php
+++ b/tests/Relay/Connection/Output/DeprecatedPropertyPublicAccessTraitTest.php
@@ -9,7 +9,7 @@ use Overblog\GraphQLBundle\Relay\Connection\Output\Edge;
 use Overblog\GraphQLBundle\Relay\Connection\Output\PageInfo;
 use PHPUnit\Framework\TestCase;
 
-class DeprecatedPropertyPublicAccessTraitTest extends TestCase
+final class DeprecatedPropertyPublicAccessTraitTest extends TestCase
 {
     /**
      * @group legacy

--- a/tests/Relay/Connection/PaginatorBackend.php
+++ b/tests/Relay/Connection/PaginatorBackend.php
@@ -9,7 +9,7 @@ use function count;
 /**
  * Class PaginatorBackend.
  */
-class PaginatorBackend
+final class PaginatorBackend
 {
     public function count(array $array): int
     {

--- a/tests/Relay/Connection/PaginatorTest.php
+++ b/tests/Relay/Connection/PaginatorTest.php
@@ -14,7 +14,7 @@ use function array_slice;
 use function base64_encode;
 use function count;
 
-class PaginatorTest extends TestCase
+final class PaginatorTest extends TestCase
 {
     protected array $data = ['A', 'B', 'C', 'D', 'E'];
 

--- a/tests/Relay/Connection/fixtures/CustomConnection.php
+++ b/tests/Relay/Connection/fixtures/CustomConnection.php
@@ -6,7 +6,7 @@ namespace Overblog\GraphQLBundle\Tests\Relay\Connection\fixtures;
 
 use Overblog\GraphQLBundle\Relay\Connection\Output\Connection;
 
-class CustomConnection extends Connection
+final class CustomConnection extends Connection
 {
     public int $averageAge;
 }

--- a/tests/Relay/Connection/fixtures/CustomEdge.php
+++ b/tests/Relay/Connection/fixtures/CustomEdge.php
@@ -6,7 +6,7 @@ namespace Overblog\GraphQLBundle\Tests\Relay\Connection\fixtures;
 
 use Overblog\GraphQLBundle\Relay\Connection\Output\Edge;
 
-class CustomEdge extends Edge
+final class CustomEdge extends Edge
 {
     public string $customProperty;
 }

--- a/tests/Relay/Mutation/MutationFieldDefinitionTest.php
+++ b/tests/Relay/Mutation/MutationFieldDefinitionTest.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
 use Overblog\GraphQLBundle\Relay\Mutation\MutationFieldDefinition;
 use PHPUnit\Framework\TestCase;
 
-class MutationFieldDefinitionTest extends TestCase
+final class MutationFieldDefinitionTest extends TestCase
 {
     /** @var MutationFieldDefinition */
     private $definition;

--- a/tests/Relay/Node/GlobalIdTest.php
+++ b/tests/Relay/Node/GlobalIdTest.php
@@ -10,7 +10,7 @@ use function base64_decode;
 use function base64_encode;
 use function sprintf;
 
-class GlobalIdTest extends TestCase
+final class GlobalIdTest extends TestCase
 {
     public function testToGlobalId(): void
     {

--- a/tests/Relay/Node/NodeFieldDefinitionTest.php
+++ b/tests/Relay/Node/NodeFieldDefinitionTest.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
 use Overblog\GraphQLBundle\Relay\Node\NodeFieldDefinition;
 use PHPUnit\Framework\TestCase;
 
-class NodeFieldDefinitionTest extends TestCase
+final class NodeFieldDefinitionTest extends TestCase
 {
     private NodeFieldDefinition $definition;
 

--- a/tests/Relay/Node/PluralIdentifyingRootFieldDefinitionTest.php
+++ b/tests/Relay/Node/PluralIdentifyingRootFieldDefinitionTest.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
 use Overblog\GraphQLBundle\Relay\Node\PluralIdentifyingRootFieldDefinition;
 use PHPUnit\Framework\TestCase;
 
-class PluralIdentifyingRootFieldDefinitionTest extends TestCase
+final class PluralIdentifyingRootFieldDefinitionTest extends TestCase
 {
     /** @var PluralIdentifyingRootFieldDefinition */
     private $definition;

--- a/tests/Request/ExecutorTest.php
+++ b/tests/Request/ExecutorTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
-class ExecutorTest extends TestCase
+final class ExecutorTest extends TestCase
 {
     protected function getMockedExecutor(): RequestExecutor
     {

--- a/tests/Request/UploadParserTraitTest.php
+++ b/tests/Request/UploadParserTraitTest.php
@@ -11,7 +11,7 @@ use stdClass;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use function json_encode;
 
-class UploadParserTraitTest extends TestCase
+final class UploadParserTraitTest extends TestCase
 {
     use UploadParserTrait;
 

--- a/tests/Resolver/MutationResolverTest.php
+++ b/tests/Resolver/MutationResolverTest.php
@@ -6,7 +6,7 @@ namespace Overblog\GraphQLBundle\Tests\Resolver;
 
 use Overblog\GraphQLBundle\Resolver\MutationResolver;
 
-class MutationResolverTest extends AbstractProxyResolverTest
+final class MutationResolverTest extends AbstractProxyResolverTest
 {
     protected function createResolver(): MutationResolver
     {

--- a/tests/Resolver/ResolverFieldTest.php
+++ b/tests/Resolver/ResolverFieldTest.php
@@ -8,7 +8,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use Overblog\GraphQLBundle\Resolver\FieldResolver;
 use PHPUnit\Framework\TestCase;
 
-class ResolverFieldTest extends TestCase
+final class ResolverFieldTest extends TestCase
 {
     /**
      * @dataProvider resolverProvider

--- a/tests/Resolver/ResolverMapTest.php
+++ b/tests/Resolver/ResolverMapTest.php
@@ -18,7 +18,7 @@ use function array_merge;
 use function get_class;
 use function sprintf;
 
-class ResolverMapTest extends TestCase
+final class ResolverMapTest extends TestCase
 {
     /**
      * @param array|ArrayAccess $map

--- a/tests/Resolver/ResolverMapsTest.php
+++ b/tests/Resolver/ResolverMapsTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 use stdClass;
 use function sprintf;
 
-class ResolverMapsTest extends TestCase
+final class ResolverMapsTest extends TestCase
 {
     public function testUnresolvable(): void
     {

--- a/tests/Resolver/ResolverResolverTest.php
+++ b/tests/Resolver/ResolverResolverTest.php
@@ -6,7 +6,7 @@ namespace Overblog\GraphQLBundle\Tests\Resolver;
 
 use Overblog\GraphQLBundle\Resolver\QueryResolver;
 
-class ResolverResolverTest extends AbstractProxyResolverTest
+final class ResolverResolverTest extends AbstractProxyResolverTest
 {
     protected function createResolver(): QueryResolver
     {

--- a/tests/Resolver/Toto.php
+++ b/tests/Resolver/Toto.php
@@ -7,7 +7,7 @@ namespace Overblog\GraphQLBundle\Tests\Resolver;
 use Closure;
 use function func_get_args;
 
-class Toto
+final class Toto
 {
     public const PRIVATE_PROPERTY_WITH_GETTER_VALUE = 'IfYouWantMeUseMyGetter';
     public const PRIVATE_PROPERTY_WITH_GETTER2_VALUE = 'IfYouWantMeUseMyGetter2';

--- a/tests/Resolver/TypeResolverTest.php
+++ b/tests/Resolver/TypeResolverTest.php
@@ -8,7 +8,7 @@ use GraphQL\Type\Definition\ObjectType;
 use Overblog\GraphQLBundle\Resolver\TypeResolver;
 use Overblog\GraphQLBundle\Resolver\UnresolvableException;
 
-class TypeResolverTest extends AbstractResolverTest
+final class TypeResolverTest extends AbstractResolverTest
 {
     protected function createResolver(): TypeResolver
     {

--- a/tests/Security/SecurityTest.php
+++ b/tests/Security/SecurityTest.php
@@ -8,7 +8,7 @@ use LogicException;
 use Overblog\GraphQLBundle\Security\Security;
 use PHPUnit\Framework\TestCase;
 
-class SecurityTest extends TestCase
+final class SecurityTest extends TestCase
 {
     public function testIsGrantedSecurityCoreComponentRequired(): void
     {

--- a/tests/Transformer/ArgumentsTransformerTest.php
+++ b/tests/Transformer/ArgumentsTransformerTest.php
@@ -25,7 +25,7 @@ use function class_exists;
 use function count;
 use function is_array;
 
-class ArgumentsTransformerTest extends TestCase
+final class ArgumentsTransformerTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/Transformer/Enum1.php
+++ b/tests/Transformer/Enum1.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Tests\Transformer;
 
-class Enum1
+final class Enum1
 {
     /**
      * @var mixed

--- a/tests/Transformer/InputType1.php
+++ b/tests/Transformer/InputType1.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Tests\Transformer;
 
-class InputType1
+final class InputType1
 {
     /**
      * @var mixed

--- a/tests/Transformer/InputType2.php
+++ b/tests/Transformer/InputType2.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Tests\Transformer;
 
-class InputType2
+final class InputType2
 {
     /**
      * @var mixed

--- a/tests/Transformer/InputType3.php
+++ b/tests/Transformer/InputType3.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Tests\Transformer;
 
-class InputType3
+final class InputType3
 {
     /**
      * @var mixed

--- a/tests/Upload/Type/GraphQLUploadTypeTest.php
+++ b/tests/Upload/Type/GraphQLUploadTypeTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 use stdClass;
 use function sprintf;
 
-class GraphQLUploadTypeTest extends TestCase
+final class GraphQLUploadTypeTest extends TestCase
 {
     /**
      * @param mixed $invalidValue

--- a/tests/Validator/InputValidatorTest.php
+++ b/tests/Validator/InputValidatorTest.php
@@ -14,7 +14,7 @@ use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\Validator\Validation;
 use function class_exists;
 
-class InputValidatorTest extends TestCase
+final class InputValidatorTest extends TestCase
 {
     public function setUp(): void
     {

--- a/tests/Validator/Mapping/MetadataFactoryTest.php
+++ b/tests/Validator/Mapping/MetadataFactoryTest.php
@@ -14,7 +14,7 @@ use Symfony\Component\Validator\Exception\NoSuchMetadataException;
 use Symfony\Component\Validator\Validation;
 use function class_exists;
 
-class MetadataFactoryTest extends TestCase
+final class MetadataFactoryTest extends TestCase
 {
     public function setUp(): void
     {

--- a/tests/Validator/ValidationNodeTest.php
+++ b/tests/Validator/ValidationNodeTest.php
@@ -12,7 +12,7 @@ use Overblog\GraphQLBundle\Definition\ResolverArgs;
 use Overblog\GraphQLBundle\Validator\ValidationNode;
 use PHPUnit\Framework\TestCase;
 
-class ValidationNodeTest extends TestCase
+final class ValidationNodeTest extends TestCase
 {
     public function testValidationNode(): void
     {


### PR DESCRIPTION
All classes are now final. If you need an extension point, try to use composition, implementing the interface or raise an issue / PR.

Exceptions:
```
class Field extends Annotation
class ObjectNode implements NodeInterface
class Type extends Annotation
class CustomScalarType extends BaseCustomScalarType
class ExtensibleSchema extends Schema
class QueryTaggedServiceMappingPass extends TaggedServiceMappingPass
class ErrorHandler
class UserError extends BaseUserError
class UserWarning extends RuntimeException implements ClientAware
class ExpressionFunction extends BaseExpressionFunction
class Connection implements ConnectionInterface
class Edge implements EdgeInterface
class Executor
class MutationResolver extends AbstractProxyResolver
class QueryResolver extends AbstractProxyResolver
class TypeResolver extends AbstractResolver
```