### PR TITLE
Add PHPStan configuration for `ConfigProcessor::process`

### DIFF
--- a/src/Definition/ConfigProcessor.php
+++ b/src/Definition/ConfigProcessor.php
@@ -30,6 +30,11 @@ final class ConfigProcessor
         $this->processors[] = $configProcessor;
     }
 
+    /**
+     * @phpstan-template T of array
+     * @phpstan-param T $config
+     * @phpstan-return T
+     */
     public function process(array $config): array
     {
         foreach ($this->processors as $processor) {

--- a/src/Definition/GraphQLServices.php
+++ b/src/Definition/GraphQLServices.php
@@ -34,6 +34,11 @@ final class GraphQLServices extends ServiceLocator
         return $this->get('mutationResolver')->resolve([$alias, $args]);
     }
 
+    /**
+     * @phpstan-template T of Type
+     * @phpstan-param class-string<T> $typeName
+     * @phpstan-return ?T
+     */
     public function getType(string $typeName): ?Type
     {
         return $this->get('typeResolver')->resolve($typeName);


### PR DESCRIPTION
This way, PHPStan knows that input becomes output.

Example, not PHPStan understands this:
```php
/**
 * @phpstan-import-type ObjectConfig from ObjectType
 */
final class MYType extends ObjectType implements AliasedInterface
{
    public function __construct(ConfigProcessor $processor, GraphQLServiceLocator $locator)
    {
        /**
         * @var ObjectConfig $config
         */
        $config = [
            'name' => self::NAME,
            'fields' => fn () => [
                'id' => [
                    'type' => Type::nonNull(Type::id()),
                ],
            ],
            'interfaces' => fn () => [
                $locator->getType(NodeType::class),
            ],
        ];
    
        parent::__construct($processor->process($config));
    }
}
```