### PR TITLE
Fix validation constraints namespace conflicts in generated definition files

### DIFF
--- a/src/Generator/TypeBuilder.php
+++ b/src/Generator/TypeBuilder.php
@@ -44,7 +44,6 @@ use function ltrim;
 use function reset;
 use function rtrim;
 use function strpos;
-use function strrchr;
 use function strtolower;
 use function substr;
 
@@ -617,19 +616,17 @@ class TypeBuilder
             if (false !== strpos($name, '\\')) {
                 // Custom constraint
                 $fqcn = ltrim($name, '\\');
-                $name = ltrim(strrchr($name, '\\'), '\\');
-                $this->file->addUse($fqcn);
+                $instance = Instance::new("@\\$fqcn");
             } else {
                 // Symfony constraint
-                $this->file->addUseGroup(static::CONSTRAINTS_NAMESPACE, $name);
                 $fqcn = static::CONSTRAINTS_NAMESPACE."\\$name";
+                $this->file->addUse(static::CONSTRAINTS_NAMESPACE.' as SymfonyConstraints');
+                $instance = Instance::new("@SymfonyConstraints\\$name");
             }
 
             if (!class_exists($fqcn)) {
                 throw new GeneratorException("Constraint class '$fqcn' doesn't exist.");
             }
-
-            $instance = Instance::new($name);
 
             if (is_array($args)) {
                 if (isset($args[0]) && is_array($args[0])) {

--- a/tests/Functional/App/Validator/CustomValidator1/Constraint.php
+++ b/tests/Functional/App/Validator/CustomValidator1/Constraint.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Functional\App\Validator\CustomValidator1;
+
+use Overblog\GraphQLBundle\Tests\Functional\App\Validator\MockValidator;
+use Symfony\Component\Validator\Constraint as BaseConstraint;
+
+/**
+ * This and CustomValidator2/Constraint should be named same,
+ * to test that generated type class doesn't include them both into use statement,
+ * which produced a namespace conflict
+ *
+ * @Annotation
+ */
+class Constraint extends BaseConstraint
+{
+    public string $message = 'Mock constraint';
+
+    /**
+     * @return class-string
+     */
+    public function validatedBy(): string
+    {
+        return MockValidator::class;
+    }
+}

--- a/tests/Functional/App/Validator/CustomValidator2/Constraint.php
+++ b/tests/Functional/App/Validator/CustomValidator2/Constraint.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Functional\App\Validator\CustomValidator2;
+
+use Overblog\GraphQLBundle\Tests\Functional\App\Validator\MockValidator;
+use Symfony\Component\Validator\Constraint as BaseConstraint;
+
+/**
+ * @Annotation
+ */
+class Constraint extends BaseConstraint
+{
+    public string $message = 'Mock constraint';
+
+    /**
+     * @return class-string
+     */
+    public function validatedBy(): string
+    {
+        return MockValidator::class;
+    }
+}

--- a/tests/Functional/App/Validator/MockValidator.php
+++ b/tests/Functional/App/Validator/MockValidator.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Functional\App\Validator;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Just a dummy validator
+ */
+class MockValidator extends ConstraintValidator
+{
+    public function validate($value, Constraint $constraint): void
+    {
+    }
+}

--- a/tests/Functional/App/config/conflictingValidatorNamespaces/config.yml
+++ b/tests/Functional/App/config/conflictingValidatorNamespaces/config.yml
@@ -1,0 +1,25 @@
+imports:
+    - { resource: ../config.yml }
+
+framework:
+    annotations: true
+    validation:
+        enabled: true
+        enable_annotations: true
+
+overblog_graphql:
+    definitions:
+        config_validation: false
+        class_namespace: "Overblog\\GraphQLBundle\\Validator\\__DEFINITIONS__"
+        schema:
+            query: Mutation
+            mutation: Mutation
+        mappings:
+            types:
+                - type: yaml
+                  dir: "%kernel.project_dir%/config/conflictingValidatorNamespaces/mapping"
+
+services:
+    Overblog\GraphQLBundle\Tests\Functional\App\Mutation\InputValidatorMutation:
+        tags:
+            - { name: "overblog_graphql.mutation", alias: "mutation_mock", method: "mutationMock" }

--- a/tests/Functional/App/config/conflictingValidatorNamespaces/mapping/Mutation.types.yml
+++ b/tests/Functional/App/config/conflictingValidatorNamespaces/mapping/Mutation.types.yml
@@ -1,0 +1,27 @@
+Mutation:
+    type: object
+    config:
+        fields:
+            conflictingValidatorNamespaces:
+                type: Boolean
+                resolve: '@=m("mutation_mock", args, validator)'
+                args:
+                    # Covers case where Symfony's Symfony\Component\Validator\Constraints\Type constraint
+                    # conflicts with GraphQL\Type\Definition\Type
+                    # in generated definition file
+                    test:
+                        type: "String"
+                        validation:
+                            -   Type:
+                                    type: numeric
+                    # Following two args cover the case, where custom constraints with same class name
+                    # but different FQCN conflict with each other
+                    # in generated definition file
+                    test2:
+                        type: "String"
+                        validation:
+                            -   Overblog\GraphQLBundle\Tests\Functional\App\Validator\CustomValidator1\Constraint: ~
+                    test3:
+                        type: "String"
+                        validation:
+                            -   Overblog\GraphQLBundle\Tests\Functional\App\Validator\CustomValidator2\Constraint: ~

--- a/tests/Functional/Generator/TypeGeneratorTest.php
+++ b/tests/Functional/Generator/TypeGeneratorTest.php
@@ -7,6 +7,7 @@ namespace Overblog\GraphQLBundle\Tests\Functional\Generator;
 use Overblog\GraphQLBundle\Generator\Exception\GeneratorException;
 use Overblog\GraphQLBundle\Tests\Functional\App\Validator;
 use Overblog\GraphQLBundle\Tests\Functional\TestCase;
+use Symfony\Component\Validator\Validation;
 use function json_decode;
 
 class TypeGeneratorTest extends TestCase
@@ -106,6 +107,10 @@ class TypeGeneratorTest extends TestCase
      */
     public function testConflictingValidatorNamespaces(): void
     {
+        if (!class_exists(Validation::class)) {
+            $this->markTestSkipped('Symfony validator component is not installed');
+        }
+
         parent::setUp();
         $kernel = static::bootKernel(['test_case' => 'conflictingValidatorNamespaces']);
 


### PR DESCRIPTION
Closes #863

Use alias for Symfony constraints.
Use FQCN for custom validators.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #863
| License       | MIT

