### PR TITLE
Added async support to the interface.

### DIFF
--- a/src/Controller/GraphController.php
+++ b/src/Controller/GraphController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Controller;
 
+use GraphQL\Executor\Promise\Promise;
 use Overblog\GraphQLBundle\Request\BatchParser;
 use Overblog\GraphQLBundle\Request\Executor;
 use Overblog\GraphQLBundle\Request\Parser;
@@ -53,7 +54,7 @@ final class GraphController
     /**
      * @return JsonResponse|Response
      */
-    private function createResponse(Request $request, ?string $schemaName, bool $batched)
+    private function createResponse(Request $request, ?string $schemaName, bool $batched, bool $async = false)
     {
         if ('OPTIONS' === $request->getMethod()) {
             $response = new JsonResponse([], 200);
@@ -61,7 +62,7 @@ final class GraphController
             if (!in_array($request->getMethod(), ['POST', 'GET'])) {
                 return new JsonResponse('', 405);
             }
-            $payload = $this->processQuery($request, $schemaName, $batched);
+            $payload = $this->processQuery($request, $schemaName, $batched, $async);
             $response = new JsonResponse($payload, 200);
         }
         $this->addCORSHeadersIfNeeded($response, $request);
@@ -80,12 +81,12 @@ final class GraphController
         }
     }
 
-    private function processQuery(Request $request, ?string $schemaName, bool $batched): array
+    private function processQuery(Request $request, ?string $schemaName, bool $batched, bool $async = false): array|Promise
     {
         if ($batched) {
             $payload = $this->processBatchQuery($request, $schemaName);
         } else {
-            $payload = $this->processNormalQuery($request, $schemaName);
+            $payload = $this->processNormalQuery($request, $schemaName, $async);
         }
 
         return $payload;
@@ -109,9 +110,13 @@ final class GraphController
         return $payloads;
     }
 
-    private function processNormalQuery(Request $request, string $schemaName = null): array
+    private function processNormalQuery(Request $request, string $schemaName = null, bool $async = false): array|Promise
     {
         $params = $this->requestParser->parse($request);
+
+        if ($async) {
+            return $this->requestExecutor->execute($schemaName, $params);
+        }
 
         return $this->requestExecutor->execute($schemaName, $params)->toArray();
     }

--- a/src/Executor/Executor.php
+++ b/src/Executor/Executor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Executor;
 
 use GraphQL\Executor\ExecutionResult;
+use GraphQL\Executor\Promise\Promise;
 use GraphQL\Executor\Promise\PromiseAdapter;
 use GraphQL\GraphQL;
 use GraphQL\Type\Schema;
@@ -41,5 +42,19 @@ final class Executor implements ExecutorInterface
         }
 
         return $promiseAdapter->wait(GraphQL::promiseToExecute(...func_get_args()));
+    }
+
+    public function executeAsync(
+        PromiseAdapter $promiseAdapter,
+        Schema $schema,
+        string $requestString,
+        $rootValue = null,
+        $contextValue = null,
+        $variableValues = null,
+        $operationName = null,
+        ?callable $fieldResolver = null,
+        ?array $validationRules = null
+    ): Promise {
+        return GraphQL::promiseToExecute(...func_get_args());
     }
 }

--- a/src/Executor/ExecutorInterface.php
+++ b/src/Executor/ExecutorInterface.php
@@ -6,6 +6,7 @@ namespace Overblog\GraphQLBundle\Executor;
 
 use ArrayObject;
 use GraphQL\Executor\ExecutionResult;
+use GraphQL\Executor\Promise\Promise;
 use GraphQL\Executor\Promise\PromiseAdapter;
 use GraphQL\Type\Schema;
 
@@ -28,4 +29,24 @@ interface ExecutorInterface
         ?callable $fieldResolver = null,
         ?array $validationRules = null
     ): ExecutionResult;
+
+    /**
+     * @param mixed $rootValue
+     * @param null $contextValue
+     * @param null $variableValues
+     * @param string|null $operationName
+     * @param array|null $validationRules
+     * @return Promise<ExecutionResult>
+     */
+    public function executeAsync(
+        PromiseAdapter $promiseAdapter,
+        Schema $schema,
+        string $requestString,
+        $rootValue = null,
+        $contextValue = null,
+        $variableValues = null,
+        $operationName = null,
+        ?callable $fieldResolver = null,
+        ?array $validationRules = null
+    ): Promise;
 }

--- a/src/Request/Executor.php
+++ b/src/Request/Executor.php
@@ -7,6 +7,7 @@ namespace Overblog\GraphQLBundle\Request;
 use ArrayObject;
 use Closure;
 use GraphQL\Executor\ExecutionResult;
+use GraphQL\Executor\Promise\Promise;
 use GraphQL\Executor\Promise\PromiseAdapter;
 use GraphQL\Type\Schema;
 use GraphQL\Validator\DocumentValidator;
@@ -127,7 +128,7 @@ class Executor
     /**
      * @param array|ArrayObject|object|null $rootValue
      */
-    public function execute(?string $schemaName, array $request, $rootValue = null): ExecutionResult
+    public function execute(?string $schemaName, array $request, $rootValue = null, bool $async = false): ExecutionResult|Promise
     {
         $schema = $this->getSchema($schemaName);
         /** @var string $schemaName */
@@ -144,6 +145,21 @@ class Executor
         );
 
         $executorArgumentsEvent->getSchema()->processExtensions();
+
+        if ($async) {
+            return $this->executor->executeAsync(
+                $this->promiseAdapter,
+                $executorArgumentsEvent->getSchema(),
+                $executorArgumentsEvent->getRequestString(),
+                $executorArgumentsEvent->getRootValue(),
+                $executorArgumentsEvent->getContextValue(),
+                $executorArgumentsEvent->getVariableValue(),
+                $executorArgumentsEvent->getOperationName(),
+                $this->defaultFieldResolver
+            )->then(
+                fn ($result) => $this->postExecute($result, $executorArgumentsEvent)
+            );
+        }
 
         $result = $this->executor->execute(
             $this->promiseAdapter,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

This PR adds support for ReactPHP promises, because the wait() method of the current executor is synchronous and it will block the event loop.

This is more like a hack btw, because it's the first time I dove into the project and I need something to work for my current work, which has ReactPHP.

I have issues with adding yet another flag to be honest and I'm not sure how to solve the issue with the controller, which will need to something like this in the createResponse method

`
if ($payload instanceof Promise) {
                return new ReactPromise(
                    function ($resolve) use ($payload) {
                        $payload
                            ->then(
                                function (ExecutionResult $test) use ($resolve) {
                                    $resolve(new JsonResponse($test->toArray(), 200));
                                },
                                function ($error) {
                                    var_dump($error);
                                }
                            );
                    }
                );
            }
`
I would be glad to implement this properly, so I would like to ask for some opinions, on how this actually should look like