### PR TITLE
Support defining enum values by callable and/or generator

### DIFF
--- a/src/EventListener/TypeDecoratorListener.php
+++ b/src/EventListener/TypeDecoratorListener.php
@@ -16,6 +16,7 @@ use Overblog\GraphQLBundle\Definition\Type\CustomScalarType;
 use Overblog\GraphQLBundle\Event\TypeLoadedEvent;
 use Overblog\GraphQLBundle\Resolver\ResolverMapInterface;
 use Overblog\GraphQLBundle\Resolver\ResolverMaps;
+use Traversable;
 use function array_diff;
 use function count;
 use function current;
@@ -163,6 +164,10 @@ final class TypeDecoratorListener
             if (is_callable($fields)) {
                 $fields = $fields();
             }
+
+            // Convert a Generator to an array so that can modify it (by reference)
+            // and return the new array.
+            $fields = $fields instanceof Traversable ? iterator_to_array($fields) : (array) $fields;
 
             $fieldNames = [];
             foreach ($fields as $key => &$field) {

--- a/tests/EventListener/TypeDecoratorListenerTest.php
+++ b/tests/EventListener/TypeDecoratorListenerTest.php
@@ -60,12 +60,10 @@ final class TypeDecoratorListenerTest extends TestCase
     {
         $objectType = new ObjectType([
             'name' => 'Foo',
-            'fields' => function () {
-                return [
-                    'bar' => ['type' => Type::string()],
-                    'baz' => ['type' => Type::string()],
-                    'toto' => ['type' => Type::boolean(), 'resolve' => null],
-                ];
+            'fields' => function (): iterable {
+                yield 'bar' => ['type' => Type::string()];
+                yield 'baz' => ['type' => Type::string()];
+                yield 'toto' => ['type' => Type::boolean(), 'resolve' => null];
             },
         ]);
         $barResolver = static fn () => 'bar';

--- a/tests/EventListener/TypeDecoratorListenerTest.php
+++ b/tests/EventListener/TypeDecoratorListenerTest.php
@@ -141,6 +141,35 @@ final class TypeDecoratorListenerTest extends TestCase
         );
     }
 
+    public function testEnumTypeLazyValuesDecoration(): void
+    {
+        $enumType = new EnumType([
+            'name' => 'Foo',
+            'values' => function (): iterable {
+                yield 'BAR' => ['name' => 'BAR', 'value' => 'BAR'];
+                yield 'BAZ' => ['name' => 'BAZ', 'value' => 'BAZ'];
+                yield 'TOTO' => ['name' => 'TOTO', 'value' => 'TOTO'];
+            },
+        ]);
+
+        $this->decorate(
+            [$enumType->name => $enumType],
+            [$enumType->name => ['BAR' => 1, 'BAZ' => 2]]
+        );
+
+        $values = is_callable($enumType->config['values']) ? $enumType->config['values']() : $enumType->config['values'];
+        $values = $values instanceof Traversable ? iterator_to_array($values) : (array) $values;
+
+        $this->assertSame(
+            [
+                'BAR' => ['name' => 'BAR', 'value' => 1],
+                'BAZ' => ['name' => 'BAZ', 'value' => 2],
+                'TOTO' => ['name' => 'TOTO', 'value' => 'TOTO'],
+            ],
+            $values
+        );
+    }
+
     public function testEnumTypeUnknownField(): void
     {
         $enumType = new EnumType([


### PR DESCRIPTION
This PR adds support for the new feature merged in webonyx/graphql-php#1040.

It allows returning enum values by closure and/or generator.

While working on this I also noticed that the object decorator doesn't work properly when the objects fields are returned by a generator. That's now fixed as well.

I had to add a PHPStan ignore line because of this issue: https://github.com/webonyx/graphql-php/issues/1041