### PR TITLE
Define default value for `$processors`

### DIFF
--- a/src/Definition/ConfigProcessor.php
+++ b/src/Definition/ConfigProcessor.php
@@ -11,7 +11,7 @@ final class ConfigProcessor
     /**
      * @var ConfigProcessorInterface[]
      */
-    private array $processors;
+    private array $processors = [];
 
     public function __construct(iterable $processors)
     {


### PR DESCRIPTION
This makes it possible to initialize a `ConfigProcessor` that has no processors.

Solves this error:

Typed property Overblog\GraphQLBundle\Definition\ConfigProcessor::$processors must not be accessed before initialization.
