### PR TITLE
Added GraphQL type config resolve directive

### DIFF
--- a/src/Config/Parser/GraphQL/ASTConverter/DirectiveNode.php
+++ b/src/Config/Parser/GraphQL/ASTConverter/DirectiveNode.php
@@ -21,6 +21,10 @@ final class DirectiveNode implements NodeInterface
                 $config['deprecationReason'] = $reason;
                 break;
             }
+
+            if ('resolve' === $directiveDef->name->value) {
+                $config['resolve'] = $directiveDef->arguments[0]->value->value;
+            }
         }
 
         return $config;

--- a/src/Config/Parser/GraphQL/ASTConverter/FieldsNode.php
+++ b/src/Config/Parser/GraphQL/ASTConverter/FieldsNode.php
@@ -29,6 +29,10 @@ final class FieldsNode implements NodeInterface
                     $fieldConfig['deprecationReason'] = $directiveConfig['deprecationReason'];
                 }
 
+                if (isset($directiveConfig['resolve'])) {
+                    $fieldConfig['resolve'] = $directiveConfig['resolve'];
+                }
+
                 $config[$definition->name->value] = $fieldConfig;
             }
         }

--- a/src/Config/Parser/GraphQLParser.php
+++ b/src/Config/Parser/GraphQLParser.php
@@ -69,6 +69,8 @@ final class GraphQLParser implements ParserInterface
                 } else {
                     self::throwUnsupportedDefinitionNode($typeDef);
                 }
+            } else if (isset($typeDef->kind) && $typeDef->kind == NodeKind::DIRECTIVE_DEFINITION && isset($typeDef->name) && $typeDef->name->value == 'resolve') {
+                // Allow a directive named resolve
             } else {
                 self::throwUnsupportedDefinitionNode($typeDef);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Documented?   | no
| Fixed tickets | 
| License       | MIT

We're looking at federating our schemas, and an important piece in making that process smooth is to be able to define our type configuration using the GraphQL Schema syntax. However, we're not very keen on using resolver maps, and would much rather just define our resolvers using directives in the schema. This PR adds support for defining resolvers using a directive. 

I'm creating this as a draft PR, because before any merging I would like to discuss this further, specifically the following points: 

* Is defining schema metadata in directives a road you want to go down?
* What other metadata should we support?
* How can we ensure that schema metadata doesn't end up in schema introspection queries?

We're willing to put some work into this, so I'm looking forward to a discussion!