### PR TITLE
Add type shorthand failling test

### DIFF
--- a/src/Generator/TypeBuilder.php
+++ b/src/Generator/TypeBuilder.php
@@ -689,10 +689,12 @@ class TypeBuilder
         // Convert to object for better readability
         $c = (object) $fieldConfig;
 
+        // TODO(any): modify `InputValidator` and `TypeDecoratorListener` to support it before re-enabling this
+        // see https://github.com/overblog/GraphQLBundle/issues/973
         // If there is only 'type', use shorthand
-        if (1 === count($fieldConfig) && isset($c->type)) {
+        /*if (1 === count($fieldConfig) && isset($c->type)) {
             return $this->buildType($c->type);
-        }
+        }*/
 
         $field = Collection::assoc()
             ->addItem('type', $this->buildType($c->type));

--- a/tests/Functional/App/config/typeShorthand/config.yml
+++ b/tests/Functional/App/config/typeShorthand/config.yml
@@ -1,0 +1,20 @@
+imports:
+    - { resource: ../config.yml }
+framework:
+    annotations: true
+    validation:
+        enabled: true
+        enable_annotations: true
+
+overblog_graphql:
+    errors_handler:
+        debug: true
+    definitions:
+        class_namespace: "Overblog\\GraphQLBundle\\TypeShorthand\\__DEFINITIONS__"
+        schema:
+            query: RootQuery
+        mappings:
+            types:
+                -
+                    type: yaml
+                    dir: "%kernel.project_dir%/config/typeShorthand/mapping"

--- a/tests/Functional/App/config/typeShorthand/mapping/schema.types.yml
+++ b/tests/Functional/App/config/typeShorthand/mapping/schema.types.yml
@@ -1,0 +1,41 @@
+RootQuery:
+    type: object
+    config:
+        fields:
+            user:
+               type: User!
+               args:
+                    auth:
+                        type: AuthInput!
+                        validation: cascade
+               resolve: >
+                     @={
+                       "username": args["auth"]["username"],
+                       "address": {
+                         "street": args["auth"]["username"] ~ " foo street",
+                         "zipcode": "12345"
+                       }
+                     }
+
+AuthInput:
+    type: input-object
+    config:
+        fields:
+            username:
+                type: String!
+                validation:
+                  - NotBlank: ~
+            password: String!
+User:
+    type: object
+    config:
+        fields:
+            username: String!
+            address: Address!
+
+Address:
+    type: object
+    config:
+        fields:
+            street: String!
+            zipcode: String!

--- a/tests/Functional/TypeShorthand/TypeShorthandTest.php
+++ b/tests/Functional/TypeShorthand/TypeShorthandTest.php
@@ -4,12 +4,20 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Tests\Functional\AutoConfigure;
 
+use Doctrine\Common\Annotations\Reader;
 use Overblog\GraphQLBundle\Tests\Functional\TestCase;
+use Symfony\Component\Validator\Validation;
 
 class TypeShorthandTest extends TestCase
 {
     protected function setUp(): void
     {
+        if (!class_exists(Validation::class)) {
+            $this->markTestSkipped('Symfony validator component is not installed');
+        }
+        if (!interface_exists(Reader::class)) {
+            $this->markTestSkipped('Symfony validator component requires doctrine/annotations but it is not installed');
+        }
         static::bootKernel(['test_case' => 'typeShorthand']);
     }
 

--- a/tests/Functional/TypeShorthand/TypeShorthandTest.php
+++ b/tests/Functional/TypeShorthand/TypeShorthandTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Functional\AutoConfigure;
+
+use Overblog\GraphQLBundle\Tests\Functional\TestCase;
+
+class TypeShorthandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        static::bootKernel(['test_case' => 'typeShorthand']);
+    }
+
+    public function testQuery(): void
+    {
+        $query = 'query { user(auth: {username: "bar", password: "baz"}) {username, address {street, zipcode}} }';
+        $expectedData = ['user' => ['username' => 'bar', 'address' => ['street' => 'bar foo street', 'zipcode' => '12345']]];
+
+        $this->assertGraphQL($query, $expectedData);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #973
| License       | MIT

Building type with fields using shorthand type is not completely supported right now. I revert this change right now to quick fix this bug.
