### PR TITLE
Exclude docs and technical files from artifact

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
+/docs export-ignore
 /tests export-ignore
 /benchmarks export-ignore
-.gitattributes export-ignore
-.gitignore export-ignore
-.editorconfig export-ignore
+.* export-ignore
+*.neon export-ignore
 phpunit.xml.dist export-ignore
+Dockerfile export-ignore


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | n/a
| License       | MIT

The `./docs/` directory is 780K. Not necessary for deployments.

