### PR TITLE
Fixed `rootValue` typing in `ExecutorArgumentsEvent` class.

### DIFF
--- a/src/Event/ExecutorArgumentsEvent.php
+++ b/src/Event/ExecutorArgumentsEvent.php
@@ -18,13 +18,9 @@ final class ExecutorArgumentsEvent extends Event
     private ?array $variableValue = null;
     private ?string $operationName = null;
     private ?float $startTime = null;
-
-    /** @var mixed */
-    private $rootValue;
+    private mixed $rootValue;
 
     /**
-     * @param mixed|null $rootValue
-     *
      * @return static
      */
     public static function create(
@@ -32,11 +28,11 @@ final class ExecutorArgumentsEvent extends Event
         ExtensibleSchema $schema,
         string $requestString,
         ArrayObject $contextValue,
-        $rootValue = null,
+        mixed $rootValue = null,
         array $variableValue = null,
         string $operationName = null
     ): self {
-        $instance = new static();
+        $instance = new self();
         $instance->setSchemaName($schemaName);
         $instance->setSchema($schema);
         $instance->setRequestString($requestString);
@@ -64,10 +60,7 @@ final class ExecutorArgumentsEvent extends Event
         $this->contextValue = $contextValue;
     }
 
-    /**
-     * @param mixed $rootValue
-     */
-    public function setRootValue($rootValue = null): void
+    public function setRootValue(mixed $rootValue = null): void
     {
         $this->rootValue = $rootValue;
     }
@@ -107,7 +100,7 @@ final class ExecutorArgumentsEvent extends Event
         return $this->requestString;
     }
 
-    public function getRootValue(): ?array
+    public function getRootValue(): mixed
     {
         return $this->rootValue;
     }


### PR DESCRIPTION
In relation to #1028.
- Changed the typing and PhpDocs related to `ExecutorArgumentsEvent::$rootValue` property to `mixed`<br> (as PHP is set to v8.0 which supports this type).
- Changed `new static();` to `new self();` as the `ExecutorArgumentsEvent` class is `final`

The target branch is `0.15` as it is the latest stable branch. Can be merged to `dev-master` if more properly (I don't know the process 😅).