### PR TITLE
Make the `ConnectionBuilder` class a generic type

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -481,47 +481,37 @@ parameters:
 			path: tests/Functional/Validator/DummyEntity.php
 
 		-
-			message: "#^Cannot access offset mixed on iterable\\<Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\EdgeInterface\\>\\.$#"
+			message: "#^Cannot access offset mixed on iterable\\<Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\EdgeInterface\\<mixed\\>\\>\\.$#"
 			count: 2
 			path: tests/Relay/Connection/AbstractConnectionBuilderTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, iterable\\<Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\EdgeInterface\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, iterable\\<Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\EdgeInterface\\<mixed\\>\\> given\\.$#"
 			count: 1
 			path: tests/Relay/Connection/AbstractConnectionBuilderTest.php
 
 		-
-			message: "#^Cannot access offset 0 on iterable\\<Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\EdgeInterface\\>\\.$#"
+			message: "#^Cannot access offset 0 on iterable\\<Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\EdgeInterface\\<mixed\\>\\>\\.$#"
 			count: 4
 			path: tests/Relay/Connection/ConnectionBuilderTest.php
 
 		-
-			message: "#^Cannot access offset 1 on iterable\\<Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\EdgeInterface\\>\\.$#"
+			message: "#^Cannot access offset 1 on iterable\\<Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\EdgeInterface\\<mixed\\>\\>\\.$#"
 			count: 4
 			path: tests/Relay/Connection/ConnectionBuilderTest.php
 
 		-
-			message: "#^Cannot access offset 2 on iterable\\<Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\EdgeInterface\\>\\.$#"
+			message: "#^Cannot access offset 2 on iterable\\<Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\EdgeInterface\\<mixed\\>\\>\\.$#"
 			count: 1
 			path: tests/Relay/Connection/ConnectionBuilderTest.php
 
 		-
-			message: "#^Cannot access offset 3 on iterable\\<Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\EdgeInterface\\>\\.$#"
+			message: "#^Cannot access offset 3 on iterable\\<Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\EdgeInterface\\<mixed\\>\\>\\.$#"
 			count: 1
 			path: tests/Relay/Connection/ConnectionBuilderTest.php
 
 		-
-			message: "#^Access to an undefined property Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\EdgeInterface\\:\\:\\$cursor\\.$#"
-			count: 1
-			path: tests/Relay/Connection/Output/DeprecatedPropertyPublicAccessTraitTest.php
-
-		-
-			message: "#^Access to an undefined property Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\EdgeInterface\\:\\:\\$node\\.$#"
-			count: 1
-			path: tests/Relay/Connection/Output/DeprecatedPropertyPublicAccessTraitTest.php
-
-		-
-			message: "#^Access to an undefined property Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\Output\\\\Connection\\:\\:\\$extra\\.$#"
+			message: "#^Access to an undefined property Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\Output\\\\Connection\\<mixed\\>\\:\\:\\$extra\\.$#"
 			count: 1
 			path: tests/Relay/Connection/Output/DeprecatedPropertyPublicAccessTraitTest.php
 
@@ -546,22 +536,32 @@ parameters:
 			path: tests/Relay/Connection/Output/DeprecatedPropertyPublicAccessTraitTest.php
 
 		-
-			message: "#^Access to protected property Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\Output\\\\Connection\\:\\:\\$edges\\.$#"
-			count: 2
-			path: tests/Relay/Connection/Output/DeprecatedPropertyPublicAccessTraitTest.php
-
-		-
-			message: "#^Access to protected property Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\Output\\\\Connection\\:\\:\\$pageInfo\\.$#"
-			count: 2
-			path: tests/Relay/Connection/Output/DeprecatedPropertyPublicAccessTraitTest.php
-
-		-
-			message: "#^Access to protected property Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\Output\\\\Edge\\:\\:\\$cursor\\.$#"
+			message: "#^Access to protected property Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\Output\\\\Connection\\<mixed\\>\\:\\:\\$edges\\.$#"
 			count: 1
 			path: tests/Relay/Connection/Output/DeprecatedPropertyPublicAccessTraitTest.php
 
 		-
-			message: "#^Access to protected property Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\Output\\\\Edge\\:\\:\\$node\\.$#"
+			message: "#^Access to protected property Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\Output\\\\Connection\\<mixed\\>\\:\\:\\$pageInfo\\.$#"
+			count: 1
+			path: tests/Relay/Connection/Output/DeprecatedPropertyPublicAccessTraitTest.php
+
+		-
+			message: "#^Access to protected property Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\Output\\\\Connection\\<string\\>\\:\\:\\$edges\\.$#"
+			count: 1
+			path: tests/Relay/Connection/Output/DeprecatedPropertyPublicAccessTraitTest.php
+
+		-
+			message: "#^Access to protected property Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\Output\\\\Connection\\<string\\>\\:\\:\\$pageInfo\\.$#"
+			count: 1
+			path: tests/Relay/Connection/Output/DeprecatedPropertyPublicAccessTraitTest.php
+
+		-
+			message: "#^Access to protected property Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\Output\\\\Edge\\<null\\>\\:\\:\\$cursor\\.$#"
+			count: 1
+			path: tests/Relay/Connection/Output/DeprecatedPropertyPublicAccessTraitTest.php
+
+		-
+			message: "#^Access to protected property Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\Output\\\\Edge\\<null\\>\\:\\:\\$node\\.$#"
 			count: 1
 			path: tests/Relay/Connection/Output/DeprecatedPropertyPublicAccessTraitTest.php
 
@@ -582,6 +582,21 @@ parameters:
 
 		-
 			message: "#^Access to protected property Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\Output\\\\PageInfo\\:\\:\\$startCursor\\.$#"
+			count: 1
+			path: tests/Relay/Connection/Output/DeprecatedPropertyPublicAccessTraitTest.php
+
+		-
+			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\) with 'node' and null will always evaluate to false\\.$#"
+			count: 1
+			path: tests/Relay/Connection/Output/DeprecatedPropertyPublicAccessTraitTest.php
+
+		-
+			message: "#^Cannot access offset 0 on iterable\\<Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\EdgeInterface\\<string\\>\\>\\.$#"
+			count: 4
+			path: tests/Relay/Connection/Output/DeprecatedPropertyPublicAccessTraitTest.php
+
+		-
+			message: "#^Property Overblog\\\\GraphQLBundle\\\\Relay\\\\Connection\\\\Output\\\\Edge\\<null\\>\\:\\:\\$node \\(null\\) does not accept string\\.$#"
 			count: 1
 			path: tests/Relay/Connection/Output/DeprecatedPropertyPublicAccessTraitTest.php
 

--- a/src/Relay/Connection/ConnectionBuilder.php
+++ b/src/Relay/Connection/ConnectionBuilder.php
@@ -19,13 +19,17 @@ use function is_callable;
 use function is_numeric;
 use function max;
 use function min;
-use function sprintf;
 use function str_replace;
 
 /**
  * Class ConnectionBuilder.
  *
  * https://github.com/graphql/graphql-relay-js/blob/master/src/connection/arrayconnection.js
+ *
+ * @phpstan-type ConnectionFactoryFunc callable(EdgeInterface<T>[], PageInfoInterface): ConnectionInterface
+ * @phpstan-type EdgeFactoryFunc callable(string, T, int): EdgeInterface<T>
+ *
+ * @phpstan-template T
  */
 final class ConnectionBuilder
 {
@@ -34,24 +38,32 @@ final class ConnectionBuilder
     private CursorEncoderInterface $cursorEncoder;
 
     /**
-     * If set, used to generate the connection object.
+     * Factorty callback used to generate the connection object.
      *
-     * @var callable|null
+     * @var callable
+     *
+     * @phpstan-var ConnectionFactoryFunc
      */
     private $connectionCallback;
 
     /**
-     * If set, used to generate the edge object.
+     * Factorty callback used to generate the edge object.
      *
-     * @var ?callable
+     * @var callable
+     *
+     * @phpstan-var EdgeFactoryFunc
      */
     private $edgeCallback;
 
-    public function __construct(?CursorEncoderInterface $cursorEncoder = null, callable $connectionCallback = null, callable $edgeCallback = null)
+    /**
+     * @phpstan-param ConnectionFactoryFunc|null $connectionCallback
+     * @phpstan-param EdgeFactoryFunc|null $edgeCallback
+     */
+    public function __construct(?CursorEncoderInterface $cursorEncoder = null, ?callable $connectionCallback = null, ?callable $edgeCallback = null)
     {
         $this->cursorEncoder = $cursorEncoder ?? new Base64CursorEncoder();
-        $this->connectionCallback = $connectionCallback;
-        $this->edgeCallback = $edgeCallback;
+        $this->connectionCallback = $connectionCallback ?? static fn (array $edges, PageInfoInterface $pageInfo): Connection => new Connection($edges, $pageInfo);
+        $this->edgeCallback = $edgeCallback ?? static fn (string $cursor, mixed $value): Edge => new Edge($cursor, $value);
     }
 
     /**
@@ -60,6 +72,10 @@ final class ConnectionBuilder
      * so pagination will only work if the array is static.
      *
      * @param array|ArgumentInterface $args
+     *
+     * @phpstan-param T[] $data
+     *
+     * @return ConnectionInterface<T>
      */
     public function connectionFromArray(array $data, $args = []): ConnectionInterface
     {
@@ -99,6 +115,10 @@ final class ConnectionBuilder
      * total result large enough to cover the range specified in `args`.
      *
      * @param array|ArgumentInterface $args
+     *
+     * @phpstan-param T[] $arraySlice
+     *
+     * @phpstan-return ConnectionInterface<T>
      */
     public function connectionFromArraySlice(array $arraySlice, $args, array $meta): ConnectionInterface
     {
@@ -257,20 +277,23 @@ final class ConnectionBuilder
         return str_replace(static::PREFIX, '', $this->cursorEncoder->decode($cursor));
     }
 
+    /**
+     * @phpstan-param iterable<T> $slice
+     *
+     * @phpstan-return EdgeInterface<T>[]
+     */
     private function createEdges(iterable $slice, int $startOffset): array
     {
         $edges = [];
 
         foreach ($slice as $index => $value) {
             $cursor = $this->offsetToCursor($startOffset + $index);
-            if ($this->edgeCallback) {
-                $edge = ($this->edgeCallback)($cursor, $value, $index);
-                if (!($edge instanceof EdgeInterface)) {
-                    throw new InvalidArgumentException(sprintf('The $edgeCallback of the ConnectionBuilder must return an instance of EdgeInterface'));
-                }
-            } else {
-                $edge = new Edge($cursor, $value);
+            $edge = ($this->edgeCallback)($cursor, $value, $index);
+
+            if (!($edge instanceof EdgeInterface)) {
+                throw new InvalidArgumentException('The $edgeCallback of the ConnectionBuilder must return an instance of EdgeInterface');
             }
+
             $edges[] = $edge;
         }
 
@@ -278,20 +301,19 @@ final class ConnectionBuilder
     }
 
     /**
-     * @param mixed $edges
+     * @phpstan-param EdgeInterface<T>[] $edges
+     *
+     * @phpstan-return ConnectionInterface<T>
      */
-    private function createConnection($edges, PageInfoInterface $pageInfo): ConnectionInterface
+    private function createConnection(array $edges, PageInfoInterface $pageInfo): ConnectionInterface
     {
-        if ($this->connectionCallback) {
-            $connection = ($this->connectionCallback)($edges, $pageInfo);
-            if (!($connection instanceof ConnectionInterface)) {
-                throw new InvalidArgumentException(sprintf('The $connectionCallback of the ConnectionBuilder must return an instance of ConnectionInterface'));
-            }
+        $connection = ($this->connectionCallback)($edges, $pageInfo);
 
-            return $connection;
+        if (!($connection instanceof ConnectionInterface)) {
+            throw new InvalidArgumentException('The $connectionCallback of the ConnectionBuilder must return an instance of ConnectionInterface');
         }
 
-        return new Connection($edges, $pageInfo);
+        return $connection;
     }
 
     private function getOptionsWithDefaults(array $options, array $defaults): array

--- a/src/Relay/Connection/ConnectionInterface.php
+++ b/src/Relay/Connection/ConnectionInterface.php
@@ -6,19 +6,22 @@ namespace Overblog\GraphQLBundle\Relay\Connection;
 
 use GraphQL\Executor\Promise\Promise;
 
+/**
+ * @phpstan-template T
+ */
 interface ConnectionInterface
 {
     /**
      * Get the connection edges.
      *
-     * @return iterable|EdgeInterface[]
+     * @return iterable<EdgeInterface<T>>
      */
     public function getEdges();
 
     /**
      * Set the connection edges.
      *
-     * @param iterable|EdgeInterface[] $edges
+     * @param iterable<EdgeInterface<T>> $edges
      */
     public function setEdges(iterable $edges): void;
 

--- a/src/Relay/Connection/EdgeInterface.php
+++ b/src/Relay/Connection/EdgeInterface.php
@@ -4,12 +4,17 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Relay\Connection;
 
+/**
+ * @phpstan-template T
+ */
 interface EdgeInterface
 {
     /**
      * Get the edge node.
      *
      * @return mixed
+     *
+     * @phpstan-return T|null
      */
     public function getNode();
 
@@ -17,13 +22,13 @@ interface EdgeInterface
      * Set the edge node.
      *
      * @param mixed $node
+     *
+     * @phpstan-param T|null $node
      */
     public function setNode($node): void;
 
     /**
      * Get the edge cursor.
-     *
-     * @return string
      */
     public function getCursor(): ?string;
 

--- a/src/Relay/Connection/Output/Connection.php
+++ b/src/Relay/Connection/Output/Connection.php
@@ -9,18 +9,26 @@ use Overblog\GraphQLBundle\Relay\Connection\ConnectionInterface;
 use Overblog\GraphQLBundle\Relay\Connection\EdgeInterface;
 use Overblog\GraphQLBundle\Relay\Connection\PageInfoInterface;
 
+/**
+ * @phpstan-template T
+ *
+ * @phpstan-implements ConnectionInterface<T>
+ */
 class Connection implements ConnectionInterface
 {
     use DeprecatedPropertyPublicAccessTrait;
 
-    /** @var EdgeInterface[] */
-    protected array $edges;
+    /** @phpstan-var iterable<EdgeInterface<T>> */
+    protected iterable $edges;
 
     protected ?PageInfoInterface $pageInfo;
 
     /** @var int|Promise|null Total count or promise that returns the total count */
     protected $totalCount = null;
 
+    /**
+     * @param EdgeInterface<T>[] $edges
+     */
     public function __construct(array $edges = [], PageInfoInterface $pageInfo = null)
     {
         $this->edges = $edges;
@@ -30,7 +38,7 @@ class Connection implements ConnectionInterface
     /**
      * {@inheritdoc}
      */
-    public function getEdges(): array
+    public function getEdges(): iterable
     {
         return $this->edges;
     }

--- a/src/Relay/Connection/Output/Edge.php
+++ b/src/Relay/Connection/Output/Edge.php
@@ -6,17 +6,24 @@ namespace Overblog\GraphQLBundle\Relay\Connection\Output;
 
 use Overblog\GraphQLBundle\Relay\Connection\EdgeInterface;
 
+/**
+ * @phpstan-template T
+ *
+ * @phpstan-implements EdgeInterface<T>
+ */
 class Edge implements EdgeInterface
 {
     use DeprecatedPropertyPublicAccessTrait;
 
     protected ?string $cursor;
 
-    /** @var mixed */
-    protected $node;
+    /** @phpstan-var T|null */
+    protected mixed $node;
 
     /**
      * @param mixed $node
+     *
+     * @phpstan-param T|null $node
      */
     public function __construct(string $cursor = null, $node = null)
     {

--- a/src/Resolver/AccessResolver.php
+++ b/src/Resolver/AccessResolver.php
@@ -12,9 +12,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use Overblog\GraphQLBundle\Error\UserError;
 use Overblog\GraphQLBundle\Error\UserWarning;
 use Overblog\GraphQLBundle\Relay\Connection\Output\Connection;
-use Overblog\GraphQLBundle\Relay\Connection\Output\Edge;
 
-use function array_map;
 use function call_user_func_array;
 use function is_iterable;
 
@@ -90,14 +88,9 @@ final class AccessResolver
                 $result[$i] = $this->hasAccess($accessChecker, $resolveArgs, $object) ? $object : null; // @phpstan-ignore-line
             }
         } elseif ($result instanceof Connection) {
-            $result->setEdges(array_map(
-                function (Edge $edge) use ($accessChecker, $resolveArgs) {
-                    $edge->setNode($this->hasAccess($accessChecker, $resolveArgs, $edge->getNode()) ? $edge->getNode() : null);
-
-                    return $edge;
-                },
-                $result->getEdges()
-            ));
+            foreach ($result->getEdges() as $edge) {
+                $edge->setNode($this->hasAccess($accessChecker, $resolveArgs, $edge->getNode()) ? $edge->getNode() : null);
+            }
         } elseif (!$this->hasAccess($accessChecker, $resolveArgs, $result)) {
             throw new UserWarning('Access denied to this field.');
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| License       | MIT

By making the `ConnectionBuilder` class a generic type, the static analysis tools will understand that the outputted `ConnectionInterface` contains a list of nodes of the expected type, augmenting the IDE completion and ensuring correctness of the code upstream. I wasn't sure about the target branch to submit the change to, so if I have to change it just ask and I will do it.