### PR TITLE
Fixed not providing file permissions while saving files.

### DIFF
--- a/src/Generator/TypeGenerator.php
+++ b/src/Generator/TypeGenerator.php
@@ -92,7 +92,7 @@ class TypeGenerator
 
             if ($mode & self::MODE_WRITE) {
                 if (($mode & self::MODE_OVERRIDE) || !file_exists($path)) {
-                    $phpFile->save($path);
+                    $phpFile->save($path, $this->getCacheDirMask());
                 }
             }
         }


### PR DESCRIPTION
Closes #1060 

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #1060
| License       | MIT

File permission passed to the file saving method.