### PR TITLE
Fixed php enum invalid serialization test

### DIFF
--- a/tests/Definition/Type/PhpEnumTypeTest.php
+++ b/tests/Definition/Type/PhpEnumTypeTest.php
@@ -75,7 +75,9 @@ final class PhpEnumTypeTest extends TestCase
     {
         $this->expectException(SerializationError::class);
         $this->expectExceptionMessage(sprintf(
-            'Cannot serialize value Overblog\GraphQLBundle\Tests\Definition\Type\PhpEnumTypeTest as it must be an instance of enum',
+            'Cannot serialize value "%s" as it must be an instance of enum %s.',
+            PhpEnumTypeTest::class,
+            Color::class,
         ));
 
         $this->getEnum()->serialize(self::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

I've noticed, that master branch failed tests with PHP 8.1. [PhpEnumType](https://github.com/overblog/GraphQLBundle/blob/1c46382260787f43f616d66ae5fbb28e006e8390/src/Definition/Type/PhpEnumType.php#L117) interpolates `enumClass`, but [test case](https://github.com/overblog/GraphQLBundle/blob/1c46382260787f43f616d66ae5fbb28e006e8390/tests/Definition/Type/PhpEnumTypeTest.php#L78) expects message without enum FQCN.