### PR TITLE
Append @deprecated directive for Input's fields

### DIFF
--- a/src/Config/InputObjectTypeDefinition.php
+++ b/src/Config/InputObjectTypeDefinition.php
@@ -32,6 +32,7 @@ final class InputObjectTypeDefinition extends TypeDefinition
                         ->append($this->descriptionSection())
                         ->append($this->defaultValueSection())
                         ->append($this->validationSection(self::VALIDATION_LEVEL_PROPERTY))
+                        ->append($this->deprecationReasonSection())
                     ->end()
                     ->isRequired()
                     ->requiresAtLeastOneElement()

--- a/src/Config/Parser/MetadataParser/MetadataParser.php
+++ b/src/Config/Parser/MetadataParser/MetadataParser.php
@@ -398,7 +398,7 @@ abstract class MetadataParser implements PreParserInterface
     {
         $inputConfiguration = array_merge([
             'fields' => self::getGraphQLInputFieldsFromMetadatas($reflectionClass, self::getClassProperties($reflectionClass)),
-        ], self::getDescriptionConfiguration(static::getMetadatas($reflectionClass)));
+        ], self::getDescriptionConfiguration(static::getMetadatas($reflectionClass), true));
 
         return ['type' => $inputAnnotation->isRelay ? 'relay-mutation-input' : 'input-object', 'config' => $inputConfiguration];
     }

--- a/tests/Config/Parser/MetadataParserTest.php
+++ b/tests/Config/Parser/MetadataParserTest.php
@@ -230,6 +230,7 @@ abstract class MetadataParserTest extends TestCase
                 'diameter' => ['type' => 'Int'],
                 'variable' => ['type' => 'Int!'],
                 'tags' => ['type' => '[String]!'],
+                'alienInvasion' => ['type' => 'Boolean!', 'deprecationReason' => 'No more alien invasions on planets'],
             ],
         ]);
     }

--- a/tests/Config/Parser/fixtures/annotations/Input/Planet.php
+++ b/tests/Config/Parser/fixtures/annotations/Input/Planet.php
@@ -60,4 +60,13 @@ final class Planet
      */
     #[GQL\Field(type: '[String]!')]
     public array $tags;
+
+    /**
+     * @GQL\Field(type="Boolean!")
+     *
+     * @GQL\Deprecated("No more alien invasions on planets")
+     */
+    #[GQL\Field(type: 'Boolean!')]
+    #[GQL\Deprecated('No more alien invasions on planets')]
+    public string $alienInvasion;
 }

--- a/tests/Config/Parser/fixtures/graphql/schema.graphql
+++ b/tests/Config/Parser/fixtures/graphql/schema.graphql
@@ -27,6 +27,7 @@ interface Character {
   friends: [Character]
   appearsIn: [Episode]!
   deprecatedField: String! @deprecated(reason: "This field was deprecated!")
+  fieldWithDeprecatedArg(deprecatedArg: Boolean! = false @deprecated(reason: "This arg was deprecated!")): String!
 }
 
 type Human implements Character {
@@ -52,6 +53,7 @@ input ReviewInput {
   stars: Int! = 5
   rate: Float! = 1.58
   commentary: String = null
+  deprecatedInputField: String! @deprecated(reason: "This input field was deprecated!")
 }
 
 scalar Year

--- a/tests/Config/Parser/fixtures/graphql/schema.php
+++ b/tests/Config/Parser/fixtures/graphql/schema.php
@@ -88,6 +88,18 @@ return [
                     'description' => null,
                     'deprecationReason' => 'This field was deprecated!',
                 ],
+                'fieldWithDeprecatedArg' => [
+                    'type' => 'String!',
+                    'description' => null,
+                    'args' => [
+                        'deprecatedArg' => [
+                            'type' => 'Boolean!',
+                            'description' => null,
+                            'defaultValue' => false,
+                            'deprecationReason' => 'This arg was deprecated!',
+                        ],
+                    ],
+                ],
             ],
         ],
     ],
@@ -135,6 +147,11 @@ return [
                 'stars' => ['type' => 'Int!', 'description' => null, 'defaultValue' => 5],
                 'rate' => ['type' => 'Float!', 'description' => null, 'defaultValue' => 1.58],
                 'commentary' => ['type' => 'String', 'description' => null, 'defaultValue' => null],
+                'deprecatedInputField' => [
+                    'type' => 'String!',
+                    'description' => null,
+                    'deprecationReason' => 'This input field was deprecated!',
+                ],
             ],
         ],
     ],

--- a/tests/Functional/App/config/definition/mapping/deprecated.types.yml
+++ b/tests/Functional/App/config/definition/mapping/deprecated.types.yml
@@ -19,3 +19,11 @@ ObjectWithDeprecatedField:
             bar:
                 type: String
                 deprecationReason: "A terrible reason"
+
+InputObjectWithDeprecatedField:
+    type: input-object
+    config:
+        fields:
+            baz:
+                type: String
+                deprecationReason: "A terrible reason for input"

--- a/tests/Functional/Type/DefinitionTest.php
+++ b/tests/Functional/Type/DefinitionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Overblog\GraphQLBundle\Tests\Functional\Type;
 
 use GraphQL\Type\Definition\EnumType;
+use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use Overblog\GraphQLBundle\Tests\Functional\TestCase;
@@ -41,6 +42,17 @@ final class DefinitionTest extends TestCase
         $this->assertSame('A terrible reason', $field->deprecationReason);
         $this->assertSame('bar', $field->name);
         $this->assertSame([], $field->args);
+    }
+
+    public function testDefinesAnInputObjectTypeWithDeprecatedField(): void
+    {
+        /** @var InputObjectType $InputObjectWithDeprecatedField */
+        $InputObjectWithDeprecatedField = $this->getType('InputObjectWithDeprecatedField');
+        $field = $InputObjectWithDeprecatedField->getField('baz');
+        $this->assertSame(Type::string(), $field->getType());
+        $this->assertTrue($field->isDeprecated());
+        $this->assertSame('A terrible reason for input', $field->deprecationReason);
+        $this->assertSame('baz', $field->name);
     }
 
     private function getType(string $type): ?Type


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #...
| License       | MIT

The @deprecated directive is supported by this bundle for different GraphQL entities: Types, Objects, Interfaces, Enums.
But not for Inputs for some reason. 
