### PR TITLE
Fix tests & arguments transformer when data is not set

### DIFF
--- a/src/Transformer/ArgumentsTransformer.php
+++ b/src/Transformer/ArgumentsTransformer.php
@@ -102,7 +102,7 @@ final class ArgumentsTransformer
             $fields = $type->getFields();
 
             foreach ($fields as $name => $field) {
-                $fieldData = $this->accessor->getValue($data, sprintf('[%s]', $name));
+                $fieldData = \array_key_exists($name, $data) ? $this->accessor->getValue($data, sprintf('[%s]', $name)) : $this->accessor->getValue($instance, $name);
                 $fieldType = $field->getType();
 
                 if ($fieldType instanceof NonNull) {

--- a/src/Transformer/ArgumentsTransformer.php
+++ b/src/Transformer/ArgumentsTransformer.php
@@ -102,7 +102,10 @@ final class ArgumentsTransformer
             $fields = $type->getFields();
 
             foreach ($fields as $name => $field) {
-                $fieldData = \array_key_exists($name, $data) ? $this->accessor->getValue($data, sprintf('[%s]', $name)) : $this->accessor->getValue($instance, $name);
+                if (!array_key_exists($name, $data)) {
+                    continue;
+                }
+                $fieldData = $this->accessor->getValue($data, sprintf('[%s]', $name));
                 $fieldType = $field->getType();
 
                 if ($fieldType instanceof NonNull) {

--- a/tests/Definition/Type/PhpEnumTypeTest.php
+++ b/tests/Definition/Type/PhpEnumTypeTest.php
@@ -74,9 +74,7 @@ final class PhpEnumTypeTest extends TestCase
     public function testInvalidSerialize(): void
     {
         $this->expectException(SerializationError::class);
-        $this->expectExceptionMessage(sprintf(
-            'Cannot serialize value Overblog\GraphQLBundle\Tests\Definition\Type\PhpEnumTypeTest as it must be an instance of enum',
-        ));
+        $this->expectExceptionMessageMatches('/Cannot serialize value (.*) as it must be an instance of enum/');
 
         $this->getEnum()->serialize(self::class);
     }

--- a/tests/Relay/Connection/ConnectionBuilderTest.php
+++ b/tests/Relay/Connection/ConnectionBuilderTest.php
@@ -271,15 +271,13 @@ final class ConnectionBuilderTest extends AbstractConnectionBuilderTest
 
     public function testReturnsNoElementsIfCursorsCross(): void
     {
-        $actual = call_user_func(
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Arguments "before" and "after" cannot be intersected');
+        call_user_func(
             [static::getBuilder(), 'connectionFromArray'],
             $this->letters,
             ['before' => 'YXJyYXljb25uZWN0aW9uOjI=', 'after' => 'YXJyYXljb25uZWN0aW9uOjQ=']
         );
-
-        $expected = $this->getExpectedConnection([], false, false);
-
-        $this->assertSameConnection($expected, $actual);
     }
 
     /**

--- a/tests/Transformer/ArgumentsTransformerTest.php
+++ b/tests/Transformer/ArgumentsTransformerTest.php
@@ -125,6 +125,9 @@ final class ArgumentsTransformerTest extends TestCase
         $this->assertEquals($res->field1, $data['field1']);
         $this->assertEquals($res->field2, $data['field2']);
         $this->assertEquals($res->field3, $data['field3']);
+        $this->assertEquals($res->field4, "default_value_when_not_set_in_data");
+        $this->assertEquals($res->field5, []);
+        $this->assertEquals($res->field6, null);
 
         $data = [
             'field1' => [

--- a/tests/Transformer/ArgumentsTransformerTest.php
+++ b/tests/Transformer/ArgumentsTransformerTest.php
@@ -125,7 +125,7 @@ final class ArgumentsTransformerTest extends TestCase
         $this->assertEquals($res->field1, $data['field1']);
         $this->assertEquals($res->field2, $data['field2']);
         $this->assertEquals($res->field3, $data['field3']);
-        $this->assertEquals($res->field4, "default_value_when_not_set_in_data");
+        $this->assertEquals($res->field4, 'default_value_when_not_set_in_data');
         $this->assertEquals($res->field5, []);
         $this->assertEquals($res->field6, null);
 

--- a/tests/Transformer/InputType1.php
+++ b/tests/Transformer/InputType1.php
@@ -31,5 +31,8 @@ final class InputType1
      */
     public $field5 = [];
 
+    /**
+     * @var mixed
+     */
     public $field6;
 }

--- a/tests/Transformer/InputType1.php
+++ b/tests/Transformer/InputType1.php
@@ -20,4 +20,16 @@ final class InputType1
      * @var mixed
      */
     public $field3;
+
+    /**
+     * @var mixed
+     */
+    public $field4 = "default_value_when_not_set_in_data";
+
+    /**
+     * @var array
+     */
+    public $field5 = [];
+
+    public $field6;
 }

--- a/tests/Transformer/InputType1.php
+++ b/tests/Transformer/InputType1.php
@@ -24,7 +24,7 @@ final class InputType1
     /**
      * @var mixed
      */
-    public $field4 = "default_value_when_not_set_in_data";
+    public $field4 = 'default_value_when_not_set_in_data';
 
     /**
      * @var array


### PR DESCRIPTION
When data for an input doesn't exist (ie. The property is not set in the data), use the default value of the input property or null if is doesn't have one.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| License       | MIT


When a input object is used in conjunction with the `ArgumentsTransformer`, if the data doesn't contain the property, use the default one from the input object instead of null.

For example:

```php
<?php
final class MyInput
{
    public $field1;

    public $field2 = "default_me";
}
?>
```
If the submitted `data` doesn't include the `field2` property, the input instance will be left untouched and `$field2` will equals `default_me` instead of `null`.


