### PR TITLE
Fix unbound webonyx/graphql-php constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "symfony/http-kernel": "^5.4 || ^6.0",
         "symfony/options-resolver": "^5.4 || ^6.0",
         "symfony/property-access": "^5.4 || ^6.0",
-        "webonyx/graphql-php": ">=14.5"
+        "webonyx/graphql-php": ">=14.5 <15"
     },
     "suggest": {
         "nelmio/cors-bundle": "For more flexibility when using CORS prefight",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #1083 
| License       | MIT

v0.15 ist not compatible with webonyx/graphql-php >=15