### PR TITLE
[Doc] Fix incorrect syntax for passing mutation arguments

### DIFF
--- a/docs/definitions/mutation.md
+++ b/docs/definitions/mutation.md
@@ -9,7 +9,7 @@ Mutation:
         fields:
             IntroduceShip:
                 type: IntroduceShipPayload!
-                resolve: "@=mutation('create_ship', [args['input']['shipName'], args['input']['factionId']])"
+                resolve: "@=mutation('create_ship', args['input']['shipName'], args['input']['factionId'])"
                 args:
                     #using input object type is optional, we use it here to be iso with relay mutation example.
                     input:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Documented?   | yes/no
| Fixed tickets | #1044 
| License       | MIT

Fix incorrect syntax for passing mutation arguments
