### PR TITLE
Ensure registerLoader method exists on AnnotationReader

### DIFF
--- a/src/Config/Parser/AnnotationParser.php
+++ b/src/Config/Parser/AnnotationParser.php
@@ -46,7 +46,7 @@ final class AnnotationParser extends MetadataParser
                 throw new ServiceNotFoundException("In order to use annotations, you need to install 'symfony/cache' first. See: 'https://symfony.com/doc/current/components/cache.html'");
             }
 
-            if (class_exists(AnnotationRegistry::class)) {
+            if (class_exists(AnnotationRegistry::class) && method_exists(AnnotationRegistry::class, 'registerLoader')) {
                 AnnotationRegistry::registerLoader('class_exists');
             }
             $cacheKey = md5(__DIR__);


### PR DESCRIPTION
`registerLoader` method doesn't exist anymore. We must still check for older versions.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| Deprecations? | yes
| Tests pass?   | yes/no
