### PR TITLE
fix/profiler-limit-type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
     "require": {
         "php": "^8.0",
         "ext-json": "*",
+        "composer/semver": "^3.3",
         "murtukov/php-code-generator": "^0.1.5",
         "phpdocumentor/reflection-docblock": "^5.2",
         "phpdocumentor/type-resolver": "^1.6.1",

--- a/src/Controller/ProfilerController.php
+++ b/src/Controller/ProfilerController.php
@@ -62,7 +62,7 @@ final class ProfilerController
             $tokenData['graphql'] = $profile->getCollector('graphql');
 
             return $tokenData;
-        }, $this->profiler->find(null, $this->queryMatch ?: $this->endpointUrl, '100', 'POST', null, null, null)); // @phpstan-ignore-line
+        }, $this->profiler->find(null, $this->queryMatch ?: $this->endpointUrl, 100, 'POST', null, null, null)); // @phpstan-ignore-line
 
         $schemas = [];
         foreach ($this->requestExecutor->getSchemasNames() as $schemaName) {

--- a/src/Controller/ProfilerController.php
+++ b/src/Controller/ProfilerController.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Controller;
 
+use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
 use GraphQL\Utils\SchemaPrinter;
 use Overblog\GraphQLBundle\Request\Executor as RequestExecutor;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
@@ -54,6 +56,10 @@ final class ProfilerController
 
         $profile = $this->profiler->loadProfile($token);
 
+        $limit = InstalledVersions::satisfies(new VersionParser, 'symfony/symfony', '<5.4')
+            ? '100'
+            : 100;
+
         $tokens = array_map(function ($tokenData) {
             $profile = $this->profiler->loadProfile($tokenData['token']);
             if (!$profile->hasCollector('graphql')) {
@@ -62,7 +68,7 @@ final class ProfilerController
             $tokenData['graphql'] = $profile->getCollector('graphql');
 
             return $tokenData;
-        }, $this->profiler->find(null, $this->queryMatch ?: $this->endpointUrl, 100, 'POST', null, null, null)); // @phpstan-ignore-line
+        }, $this->profiler->find(null, $this->queryMatch ?: $this->endpointUrl, $limit, 'POST', null, null, null)); // @phpstan-ignore-line
 
         $schemas = [];
         foreach ($this->requestExecutor->getSchemasNames() as $schemaName) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Documented?   | no
| License       | MIT

I'm getting a Symfony error when opening the GraphQL tab of the Profiler. I found out the limit is now hard typed in `int` and a string is actually sent from the ProfilerController.

## Screenshot

<img width="1369" alt="Capture d’écran 2023-04-11 à 14 50 25" src="https://user-images.githubusercontent.com/84911237/231167481-7cb2a082-696d-42ea-8959-54cbb1e5dd90.png">


