### PR TITLE
Account for type change in Symfony Profiler ^6.2

### DIFF
--- a/src/Controller/ProfilerController.php
+++ b/src/Controller/ProfilerController.php
@@ -9,6 +9,7 @@ use Overblog\GraphQLBundle\Request\Executor as RequestExecutor;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
 use Symfony\Component\Routing\RouterInterface;
 use Twig\Environment;
@@ -54,6 +55,11 @@ final class ProfilerController
 
         $profile = $this->profiler->loadProfile($token);
 
+        $limit = 100;
+        if (!version_compare(Kernel::VERSION, '6.2', '>')) {
+            $limit = (string) $limit;
+        }
+
         $tokens = array_map(function ($tokenData) {
             $profile = $this->profiler->loadProfile($tokenData['token']);
             if (!$profile->hasCollector('graphql')) {
@@ -62,7 +68,7 @@ final class ProfilerController
             $tokenData['graphql'] = $profile->getCollector('graphql');
 
             return $tokenData;
-        }, $this->profiler->find(null, $this->queryMatch ?: $this->endpointUrl, '100', 'POST', null, null, null)); // @phpstan-ignore-line
+        }, $this->profiler->find(null, $this->queryMatch ?: $this->endpointUrl, $limit, 'POST', null, null, null)); // @phpstan-ignore-line
 
         $schemas = [];
         foreach ($this->requestExecutor->getSchemasNames() as $schemaName) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | n/a
| Fixed tickets | none atm
| License       | MIT

In Symfony 6.2, the `$limit` argument to `Profiler::find()` was changed from a string to an integer in this commit: https://github.com/symfony/http-kernel/commit/13b9831be953c052c6c515a7fd58c7d31979542d and related issue: https://github.com/symfony/symfony/issues/49656 This takes into account older Symfony versions that only accept a string.