### PR TITLE
fix: Fix the memory leak

### DIFF
--- a/src/ExpressionLanguage/ExpressionFunction.php
+++ b/src/ExpressionLanguage/ExpressionFunction.php
@@ -12,7 +12,9 @@ class ExpressionFunction extends BaseExpressionFunction
     public function __construct(string $name, callable $compiler, ?callable $evaluator = null)
     {
         if (null === $evaluator) {
-            $evaluator = new EvaluatorIsNotAllowedException($name);
+            $evaluator = static function (string $name) {
+                throw new EvaluatorIsNotAllowedException($name);
+            };
         }
 
         parent::__construct($name, $compiler, $evaluator);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | could not check
| Documented?   | no
| Fixed tickets | #721
| License       | MIT

Follow up of [my
comment](https://github.com/overblog/GraphQLBundle/issues/721#issuecomment-1414158275).

I cannot investigate further, but my guess is that exceptions are not cheap objects. When creating an exception you also capture the context and stack trace which means that even if the extension is unsued:

- It slows down the program because instantiating it is not cheap.
- May prevent some objects to be garbage collected because referenced in the exception.


<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
