### PR TITLE
Fix mutation.md example

### DIFF
--- a/docs/definitions/mutation.md
+++ b/docs/definitions/mutation.md
@@ -9,7 +9,7 @@ Mutation:
         fields:
             IntroduceShip:
                 type: IntroduceShipPayload!
-                resolve: "@=mutation('create_ship', [args['input']['shipName'], args['input']['factionId']])"
+                resolve: "@=mutation('create_ship', args['input']['shipName'], args['input']['factionId'])"
                 args:
                     #using input object type is optional, we use it here to be iso with relay mutation example.
                     input:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| License       | MIT

In the example, the resolve arguments are sent as an array instead of 2 seperate variables - this will create an error.
