### PR TITLE
Make bad request exception generic unless in debug mode (0.15)

### DIFF
--- a/src/Controller/GraphController.php
+++ b/src/Controller/GraphController.php
@@ -10,6 +10,7 @@ use Overblog\GraphQLBundle\Request\Parser;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use function in_array;
 
 class GraphController
@@ -19,19 +20,22 @@ class GraphController
     private Parser $requestParser;
     private bool $shouldHandleCORS;
     private bool $useApolloBatchingMethod;
+    private bool $debugMode;
 
     public function __construct(
         BatchParser $batchParser,
         Executor $requestExecutor,
         Parser $requestParser,
         bool $shouldHandleCORS,
-        string $graphQLBatchingMethod
+        string $graphQLBatchingMethod,
+        bool $debugMode
     ) {
         $this->batchParser = $batchParser;
         $this->requestExecutor = $requestExecutor;
         $this->requestParser = $requestParser;
         $this->shouldHandleCORS = $shouldHandleCORS;
         $this->useApolloBatchingMethod = 'apollo' === $graphQLBatchingMethod;
+        $this->debugMode = $debugMode;
     }
 
     /**
@@ -61,7 +65,17 @@ class GraphController
             if (!in_array($request->getMethod(), ['POST', 'GET'])) {
                 return new JsonResponse('', 405);
             }
-            $payload = $this->processQuery($request, $schemaName, $batched);
+
+            try {
+                $payload = $this->processQuery($request, $schemaName, $batched);
+            } catch(BadRequestHttpException $e) {
+                if ($this->debugMode) {
+                    throw $e;
+                } else {
+                    return new JsonResponse('', 400);
+                }
+            }
+
             $response = new JsonResponse($payload, 200);
         }
         $this->addCORSHeadersIfNeeded($response, $request);

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -88,6 +88,7 @@ services:
             - '@Overblog\GraphQLBundle\Request\Parser'
             - "%overblog_graphql.handle_cors%"
             - "%overblog_graphql.batching_method%"
+            - "%kernel.debug%"
 
     Overblog\GraphQLBundle\Definition\ConfigProcessor:
         arguments:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | debatable
| New feature?  | no
| BC breaks?    | tbd
| Deprecations? | no
| Tests pass?   | tbd
| Documented?   | not yet
| Fixed tickets | #1121
| License       | MIT

(This is a 0.15 port of https://github.com/overblog/GraphQLBundle/pull/1128 The README is outdated and it's not entirely clear which branches are stable now, but it seems to be 0.15 and 1.0. I'm unsure if this will be accepted, I will add doc and possibly tests if there is some approval.)

Exceptions and specifically stack traces should not be shown in production. This bundle has a customisable error handler, but as the documentation states: ["Only query parsed error won't be replaced."](https://github.com/overblog/GraphQLBundle/blob/f35dda77dd57179f3696b9217f1a383eb86621b5/docs/error-handling/index.md). I could make my own `Parser` override class which catches the exceptions in prod mode, but then how can I produce a usable JSON response? I needed to modify the `GraphController` to do that.

The fix is to check `kernel.debug` and catch bad request exceptions. If debug mode is enabled, it rethrows the exception (i.e. works as before). If disabled (prod mode), it instead returns a blank JsonResponse with HTTP 400 Bad Request status code (like the 405 response above it). The simplest manual test is to access `example.com/graphql` in a browser, in debug and prod modes.

**Option:** As is, the PR returns an empty HTTP 400 response. It might be good to keep the exception message, and just remove the stack trace. I don't know if it's as simple as new JsonResponse($e->getMessage(), 400) because it's a HttpResponse. Would need to see how other errors are modeled here and do something similar. Or maybe if there's a handler displaying that exception it should just display $e->getMessage() instead of (string)$e? Just guessing here. Please let me know if you know the answer.

If rejected, please let me know if you can see ways of doing this in my project without modifying your bundle. Thanks!

**Related:** It would also be nice to disable introspection in prod mode by default, [like shown in the doc](https://github.com/overblog/GraphQLBundle/blob/f35dda77dd57179f3696b9217f1a383eb86621b5/docs/security/disable_introspection.md). But since it hasn't been done yet, I assume the maintainers aren't keen on it.