### PR TITLE
Fix argument transformer for typed properties without default value

### DIFF
--- a/src/Transformer/ArgumentsTransformer.php
+++ b/src/Transformer/ArgumentsTransformer.php
@@ -102,7 +102,7 @@ final class ArgumentsTransformer
             $fields = $type->getFields();
 
             foreach ($fields as $name => $field) {
-                if (!array_key_exists($name, $data)) {
+                if ($field->defaultValueExists() && !array_key_exists($name, $data)) {
                     continue;
                 }
                 $fieldData = $this->accessor->getValue($data, sprintf('[%s]', $name));

--- a/tests/Transformer/ArgumentsTransformerTest.php
+++ b/tests/Transformer/ArgumentsTransformerTest.php
@@ -61,6 +61,12 @@ final class ArgumentsTransformerTest extends TestCase
                 'field1' => Type::string(),
                 'field2' => Type::int(),
                 'field3' => Type::boolean(),
+                'field7' => Type::string(),
+                'field8' => ['type' => Type::string(), 'defaultValue' => 'default_value_when_not_set_in_data'],
+                'field9' => [
+                    'type' => Type::nonNull(Type::string()),
+                    'defaultValue' => 'default_value_when_not_set_in_data'
+                ],
             ],
         ]);
 
@@ -128,6 +134,9 @@ final class ArgumentsTransformerTest extends TestCase
         $this->assertEquals($res->field4, 'default_value_when_not_set_in_data');
         $this->assertEquals($res->field5, []);
         $this->assertEquals($res->field6, null);
+        $this->assertEquals($res->field7, null);
+        $this->assertEquals($res->field8, 'default_value_when_not_set_in_data');
+        $this->assertEquals($res->field9, 'default_value_when_not_set_in_data');
 
         $data = [
             'field1' => [

--- a/tests/Transformer/ArgumentsTransformerTest.php
+++ b/tests/Transformer/ArgumentsTransformerTest.php
@@ -65,7 +65,7 @@ final class ArgumentsTransformerTest extends TestCase
                 'field8' => ['type' => Type::string(), 'defaultValue' => 'default_value_when_not_set_in_data'],
                 'field9' => [
                     'type' => Type::nonNull(Type::string()),
-                    'defaultValue' => 'default_value_when_not_set_in_data'
+                    'defaultValue' => 'default_value_when_not_set_in_data',
                 ],
             ],
         ]);

--- a/tests/Transformer/InputType1.php
+++ b/tests/Transformer/InputType1.php
@@ -35,4 +35,10 @@ final class InputType1
      * @var mixed
      */
     public $field6;
+
+    public ?string $field7;
+
+    public ?string $field8 = 'default_value_when_not_set_in_data';
+
+    public string $field9 = 'default_value_when_not_set_in_data';
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #1073
| License       | MIT

Fixes https://github.com/overblog/GraphQLBundle/pull/1073#issuecomment-1759508677

The change did not consider typed properties without default value. This actually breaks existing application when upgrading to v1.0.
