### PR TITLE
Merge guessed argument properties and args described with GQL\Arg

### DIFF
--- a/src/Config/Parser/MetadataParser/MetadataParser.php
+++ b/src/Config/Parser/MetadataParser/MetadataParser.php
@@ -568,7 +568,7 @@ abstract class MetadataParser implements PreParserInterface
             }
 
             if (isset($arg->default)) {
-                $args[$arg->name]['defaultValue'] ??= $arg->default;
+                $args[$arg->name]['defaultValue'] = $arg->default;
             }
         }
 

--- a/src/Config/Parser/MetadataParser/MetadataParser.php
+++ b/src/Config/Parser/MetadataParser/MetadataParser.php
@@ -561,7 +561,7 @@ abstract class MetadataParser implements PreParserInterface
         }
 
         foreach ($argAnnotations as $arg) {
-            $args[$arg->name] ??= ['type' => $arg->type];
+            $args[$arg->name] = ['type' => $arg->type];
 
             if (isset($arg->description)) {
                 $args[$arg->name]['description'] = $arg->description;

--- a/src/Config/Parser/MetadataParser/MetadataParser.php
+++ b/src/Config/Parser/MetadataParser/MetadataParser.php
@@ -556,20 +556,20 @@ abstract class MetadataParser implements PreParserInterface
         /** @var Metadata\Arg[] $argAnnotations */
         $argAnnotations = self::getMetadataMatching($metadatas, Metadata\Arg::class);
 
+        if ($reflector instanceof ReflectionMethod) {
+            $args = self::guessArgs($reflectionClass, $reflector);
+        }
+
         foreach ($argAnnotations as $arg) {
-            $args[$arg->name] = ['type' => $arg->type];
+            $args[$arg->name] ??= ['type' => $arg->type];
 
             if (isset($arg->description)) {
                 $args[$arg->name]['description'] = $arg->description;
             }
 
             if (isset($arg->default)) {
-                $args[$arg->name]['defaultValue'] = $arg->default;
+                $args[$arg->name]['defaultValue'] ??= $arg->default;
             }
-        }
-
-        if (empty($argAnnotations) && $reflector instanceof ReflectionMethod) {
-            $args = self::guessArgs($reflectionClass, $reflector);
         }
 
         if (!empty($args)) {

--- a/tests/Config/Parser/MetadataParserTest.php
+++ b/tests/Config/Parser/MetadataParserTest.php
@@ -451,8 +451,8 @@ abstract class MetadataParserTest extends TestCase
                 'casualties' => [
                     'type' => 'Int',
                     'args' => [
-                        'raceId' => ['type' => 'String!', 'description' => 'A race ID'],
                         'areaId' => ['type' => 'Int!'],
+                        'raceId' => ['type' => 'String!', 'description' => 'A race ID'],
                         'dayStart' => ['type' => 'Int', 'defaultValue' => null],
                         'dayEnd' => ['type' => 'Int', 'defaultValue' => null],
                         'nameStartingWith' => ['type' => 'String', 'defaultValue' => ''],
@@ -460,7 +460,7 @@ abstract class MetadataParserTest extends TestCase
                         'away' => ['type' => 'Boolean', 'defaultValue' => false],
                         'maxDistance' => ['type' => 'Float', 'defaultValue' => null],
                     ],
-                    'resolve' => '@=call(value.getCasualties, arguments({areaId: "Int!", raceId: "String!", dayStart: "Int", dayEnd: "Int", nameStartingWith: "String", planet: "PlanetInput", away: "Boolean", maxDistance: "Float"}, args))',
+                    'resolve' => '@=call(value.getCasualties, arguments({raceId: "String!", areaId: "Int!", dayStart: "Int", dayEnd: "Int", nameStartingWith: "String", planet: "PlanetInput", away: "Boolean", maxDistance: "Float"}, args))',
                     'complexity' => '@=childrenComplexity * 5',
                 ],
             ],

--- a/tests/Config/Parser/MetadataParserTest.php
+++ b/tests/Config/Parser/MetadataParserTest.php
@@ -452,7 +452,7 @@ abstract class MetadataParserTest extends TestCase
                     'type' => 'Int',
                     'args' => [
                         'areaId' => ['type' => 'Int!'],
-                        'raceId' => ['type' => 'String!'],
+                        'raceId' => ['type' => 'String!', 'description' => 'A race ID'],
                         'dayStart' => ['type' => 'Int', 'defaultValue' => null],
                         'dayEnd' => ['type' => 'Int', 'defaultValue' => null],
                         'nameStartingWith' => ['type' => 'String', 'defaultValue' => ''],

--- a/tests/Config/Parser/MetadataParserTest.php
+++ b/tests/Config/Parser/MetadataParserTest.php
@@ -451,8 +451,8 @@ abstract class MetadataParserTest extends TestCase
                 'casualties' => [
                     'type' => 'Int',
                     'args' => [
-                        'areaId' => ['type' => 'Int!'],
                         'raceId' => ['type' => 'String!', 'description' => 'A race ID'],
+                        'areaId' => ['type' => 'Int!'],
                         'dayStart' => ['type' => 'Int', 'defaultValue' => null],
                         'dayEnd' => ['type' => 'Int', 'defaultValue' => null],
                         'nameStartingWith' => ['type' => 'String', 'defaultValue' => ''],

--- a/tests/Config/Parser/fixtures/annotations/Type/Battle.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/Battle.php
@@ -21,11 +21,13 @@ final class Battle
 
     /**
      * @GQL\Field(name="casualties", complexity="childrenComplexity * 5")
+     * @GQL\Arg(name="raceId", type="String!", description="A race ID")
      */
     #[GQL\Field(name: 'casualties', complexity: 'childrenComplexity * 5')]
+    #[GQL\Arg(name: 'raceId', type: 'String!', description: 'A race ID')]
     public function getCasualties(
         int $areaId,
-        string $raceId,
+        ?string $raceId,
         int $dayStart = null,
         int $dayEnd = null,
         string $nameStartingWith = '',

--- a/tests/Config/Parser/fixtures/annotations/Type/Battle.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/Battle.php
@@ -21,6 +21,7 @@ final class Battle
 
     /**
      * @GQL\Field(name="casualties", complexity="childrenComplexity * 5")
+     *
      * @GQL\Arg(name="raceId", type="String!", description="A race ID")
      */
     #[GQL\Field(name: 'casualties', complexity: 'childrenComplexity * 5')]


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Deprecations? | no
| Tests pass?   | yes/no
| Documented?   | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

When a single argument is described with `#[GQL\Arg]` all other are not guessed anymore

This commit starts by guessing all arguments and override the ones that have `#[GQL\Arg]` attributes describing them

I'm not sure of a few things:

* should the type specified in the attribute override the one that was guessed?
* same for the default
* Is there cases where guessing could fail and adding the #[GQL\Arg] attribute was a way to prevent guessing failing / crashing?

in the future it would be nice if we could add the attribute on the argument directly instead of the method so we could make the name & type optional there (or forbidden?) 