### PR TITLE
Fix profiler & update phpcs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          php-version: "8.2"
+          php-version: "8.1"
           coverage: "none"
 
       - name: "Install dependencies"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           tools: flex
-          php-version: "8.1"
+          php-version: "8.2"
           coverage: "none"
 
       - name: "Install dependencies"
@@ -116,7 +116,7 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          php-version: "8.1"
+          php-version: "8.2"
           coverage: "none"
 
       - name: "Install dependencies"

--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
         "static-analysis": [
             "phpstan analyse --ansi --memory-limit=1G"
         ],
-        "install-cs": "test -f php-cs-fixer.phar || wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v3.17.0/php-cs-fixer.phar -O php-cs-fixer.phar",
+        "install-cs": "test -f php-cs-fixer.phar || wget https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/download/v3.48.0/php-cs-fixer.phar -O php-cs-fixer.phar",
         "fix-cs": [
             "@install-cs",
             "@php php-cs-fixer.phar fix --diff -v --allow-risky=yes --ansi"

--- a/src/Config/TypeDefinition.php
+++ b/src/Config/TypeDefinition.php
@@ -81,6 +81,7 @@ abstract class TypeDefinition
                                 return $value;
                             }
                         }
+
                         // validation: [list of constraints]
                         return ['constraints' => $value];
                     }

--- a/src/Relay/Connection/ConnectionInterface.php
+++ b/src/Relay/Connection/ConnectionInterface.php
@@ -27,8 +27,6 @@ interface ConnectionInterface
 
     /**
      * Get the page info.
-     *
-     * @return PageInfoInterface
      */
     public function getPageInfo(): ?PageInfoInterface;
 

--- a/src/Relay/Connection/Output/PageInfo.php
+++ b/src/Relay/Connection/Output/PageInfo.php
@@ -23,9 +23,6 @@ final class PageInfo implements PageInfoInterface
         $this->hasNextPage = $hasNextPage;
     }
 
-    /**
-     * @return string
-     */
     public function getStartCursor(): ?string
     {
         return $this->startCursor;
@@ -36,9 +33,6 @@ final class PageInfo implements PageInfoInterface
         $this->startCursor = $startCursor;
     }
 
-    /**
-     * @return string
-     */
     public function getEndCursor(): ?string
     {
         return $this->endCursor;
@@ -49,9 +43,6 @@ final class PageInfo implements PageInfoInterface
         $this->endCursor = $endCursor;
     }
 
-    /**
-     * @return bool
-     */
     public function getHasPreviousPage(): ?bool
     {
         return $this->hasPreviousPage;
@@ -62,9 +53,6 @@ final class PageInfo implements PageInfoInterface
         $this->hasPreviousPage = $hasPreviousPage;
     }
 
-    /**
-     * @return bool
-     */
     public function getHasNextPage(): ?bool
     {
         return $this->hasNextPage;

--- a/src/Relay/Connection/PageInfoInterface.php
+++ b/src/Relay/Connection/PageInfoInterface.php
@@ -12,30 +12,18 @@ namespace Overblog\GraphQLBundle\Relay\Connection;
 
 interface PageInfoInterface
 {
-    /**
-     * @return string
-     */
     public function getStartCursor(): ?string;
 
     public function setStartCursor(string $startCursor): void;
 
-    /**
-     * @return string
-     */
     public function getEndCursor(): ?string;
 
     public function setEndCursor(string $endCursor): void;
 
-    /**
-     * @return bool
-     */
     public function getHasPreviousPage(): ?bool;
 
     public function setHasPreviousPage(bool $hasPreviousPage): void;
 
-    /**
-     * @return bool
-     */
     public function getHasNextPage(): ?bool;
 
     public function setHasNextPage(bool $hasNextPage): void;

--- a/src/Resolver/TypeResolver.php
+++ b/src/Resolver/TypeResolver.php
@@ -46,8 +46,6 @@ class TypeResolver extends AbstractResolver
 
     /**
      * @param string $alias
-     *
-     * @return Type
      */
     public function resolve($alias): ?Type
     {

--- a/src/Resources/config/profiler.yaml
+++ b/src/Resources/config/profiler.yaml
@@ -5,6 +5,7 @@ services:
             - "@?profiler"
             - "@?twig"
             - "@router"
+            - '@Overblog\GraphQLBundle\Resolver\TypeResolver'
             - '@Overblog\GraphQLBundle\Request\Executor'
             - "%overblog_graphql.profiler.query_match%"
 

--- a/src/Upload/Type/GraphQLUploadType.php
+++ b/src/Upload/Type/GraphQLUploadType.php
@@ -14,9 +14,6 @@ use function sprintf;
 
 final class GraphQLUploadType extends ScalarType
 {
-    /**
-     * @param string $name
-     */
     public function __construct(string $name = null)
     {
         parent::__construct([

--- a/src/Validator/InputValidator.php
+++ b/src/Validator/InputValidator.php
@@ -63,7 +63,7 @@ final class InputValidator
     /**
      * @throws ArgumentsValidationException
      */
-    public function validate(string|array|null $groups = null, bool $throw = true): ?ConstraintViolationListInterface
+    public function validate(string|array $groups = null, bool $throw = true): ?ConstraintViolationListInterface
     {
         $rootNode = new ValidationNode(
             $this->info->parentType,

--- a/tests/Config/Parser/fixtures/graphql/schema.php
+++ b/tests/Config/Parser/fixtures/graphql/schema.php
@@ -159,9 +159,9 @@ return [
         'type' => 'custom-scalar',
         'config' => [
             'description' => null,
-            'serialize' => [\Overblog\GraphQLBundle\Config\Parser\GraphQL\ASTConverter\CustomScalarNode::class, 'mustOverrideConfig'],
-            'parseValue' => [\Overblog\GraphQLBundle\Config\Parser\GraphQL\ASTConverter\CustomScalarNode::class, 'mustOverrideConfig'],
-            'parseLiteral' => [\Overblog\GraphQLBundle\Config\Parser\GraphQL\ASTConverter\CustomScalarNode::class, 'mustOverrideConfig'],
+            'serialize' => [Overblog\GraphQLBundle\Config\Parser\GraphQL\ASTConverter\CustomScalarNode::class, 'mustOverrideConfig'],
+            'parseValue' => [Overblog\GraphQLBundle\Config\Parser\GraphQL\ASTConverter\CustomScalarNode::class, 'mustOverrideConfig'],
+            'parseLiteral' => [Overblog\GraphQLBundle\Config\Parser\GraphQL\ASTConverter\CustomScalarNode::class, 'mustOverrideConfig'],
         ],
     ],
 ];

--- a/tests/Controller/ProfilerControllerTest.php
+++ b/tests/Controller/ProfilerControllerTest.php
@@ -7,7 +7,6 @@ namespace Overblog\GraphQLBundle\Tests\Controller;
 use GraphQL\Type\Schema;
 use Overblog\GraphQLBundle\Controller\ProfilerController;
 use Overblog\GraphQLBundle\DataCollector\GraphQLCollector;
-use Overblog\GraphQLBundle\Generator\TypeGenerator;
 use Overblog\GraphQLBundle\Request\Executor;
 use Overblog\GraphQLBundle\Resolver\TypeResolver;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -48,7 +47,7 @@ final class ProfilerControllerTest extends TestCase
     }
 
     /**
-     * @return TypeGenerator&MockObject
+     * @return TypeResolver&MockObject
      */
     protected function getMockTypeResolver(int $expected = 2): TypeResolver
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

This fix the problem with the profiler if the schema doesn't have a subscription. 
It's related to https://github.com/overblog/GraphQLBundle/issues/1112 and the fact that Webonyx expects `null` from not found type with the `TypeResolver` while we raise an exception. 
