### PR TITLE
Do not inject the authorization checker service in GraphQL types

### DIFF
--- a/docs/security/fields-public-control.md
+++ b/docs/security/fields-public-control.md
@@ -17,7 +17,7 @@ AnObject:
                 type: "String!"
             privateData:
                 type: "String"
-                public: "@=service('security.authorization_checker').isGranted('ROLE_ADMIN')"
+                public: "@=isGranted('ROLE_ADMIN')"
 ```
 
 ## With Annotations


### PR DESCRIPTION
In Symfony 6+ `security.authorization-checker` is not a public service anymore, hence the previous example won't work.

However the expression language supports using `isGranted` directly hence I propose to update the documentation.