### PR TITLE
Cleanup Input default value and Fix #1171

### DIFF
--- a/docs/annotations/annotations-reference.md
+++ b/docs/annotations/annotations-reference.md
@@ -591,13 +591,15 @@ class Hero {
 
 This annotation is used on _class_ to define a GraphQL interface.
 
-Required attributes:
-
--   **resolveType** : An expression to resolve the types
-
 Optional attributes:
 
+-   **resolveType** : An expression to resolve the types
 -   **name**  : The GraphQL name of the interface (default to the class name without namespace)
+
+If the `resolveType` attribute is not set, the service `overblog_graphql.interface_type_resolver` will be used to try to resolve the type automatically based on types implementing the interface and their associated class.  
+The system will register a map of interfaces with the list of types and their associated class name implementing the interface (the parameter is named `overblog_graphql_types.interfaces_map` in the container) and use it to resolve the type from the value (the first type where the class `instanceof` operator returns true will be used).  
+
+```php
 
 ## @Scalar
 

--- a/docs/annotations/annotations-reference.md
+++ b/docs/annotations/annotations-reference.md
@@ -599,8 +599,6 @@ Optional attributes:
 If the `resolveType` attribute is not set, the service `overblog_graphql.interface_type_resolver` will be used to try to resolve the type automatically based on types implementing the interface and their associated class.  
 The system will register a map of interfaces with the list of types and their associated class name implementing the interface (the parameter is named `overblog_graphql_types.interfaces_map` in the container) and use it to resolve the type from the value (the first type where the class `instanceof` operator returns true will be used).  
 
-```php
-
 ## @Scalar
 
 This annotation is used on a _class_ to define a custom scalar.

--- a/docs/annotations/annotations-reference.md
+++ b/docs/annotations/annotations-reference.md
@@ -1,4 +1,4 @@
-# Annotations reference
+# Annotations / Attributes reference
 
 In the following reference examples the line `use Overblog\GraphQLBundle\Annotation as GQL;` will be omitted.
 
@@ -8,7 +8,7 @@ In the following reference examples the line `use Overblog\GraphQLBundle\Annotat
 
     -   For example, `@GQL\Access("isAuthenticated()")` will be converted to `['access' => '@=isAuthenticated()']` during the compilation.
 
--   You can use multiple type annotations on the same class. For example, if you need your class to be a GraphQL Type AND a Graphql Input, you just need to add the two annotations. Incompatible annotations or properties for a specified Type will simply be ignored.
+-   You can use multiple type annotations on the same class. For example, if you need your class to be a GraphQL Type AND a GraphQL Input, you just need to add the two annotations. Incompatible annotations or properties for a specified Type will simply be ignored.
 
 In the following example, both the type `Coordinates` and the input type `CoordinatesInput` will be generated during the compilation process.  
 As fields on input types don't support resolvers, the field `elevation` will simply be ignored to generate the input type (it will only have two fields: `latitude` and `longitude`).
@@ -61,6 +61,8 @@ class Coordinates {
 [@FieldsBuilder](#fieldsbuilder)
 
 [@Input](#input)
+
+[@InputField](#inputfield)
 
 [@IsPublic](#ispublic)
 
@@ -424,6 +426,17 @@ Optional attributes:
 -   **isRelay** : Set to true if you want your input to be relay compatible (ie. An extra field `clientMutationId` will be added to the input)
 
 The corresponding class will also be used by the `Arguments Transformer` service. An instance of the corresponding class will be use as the `input` value if it is an argument of a query or mutation. (see [The Arguments Transformer documentation](arguments-transformer.md)).
+
+## @InputField
+
+This annotation is used in conjunction with the `@Input` annotation to define an input field.  
+It is the same as a regular `@Field` annotation, but it can hold a `defaultValue` and can't have a `resolver`.  
+
+Optional attributes:
+
+-   **name**  : The GraphQL name of the field (default to the property name)
+-   **type** : The GraphqL type of the field. This attribute can sometimes be guessed automatically from Doctrine ORM annotations
+-   **defaultValue** : The default value of the field
 
 ## @IsPublic
 

--- a/docs/annotations/arguments-transformer.md
+++ b/docs/annotations/arguments-transformer.md
@@ -1,15 +1,15 @@
 # The Arguments Transformer service
 
-When using annotation, as we use classes to describe our GraphQL objects, it is also possible to create and populate classes instances using GraphQL data.  
+When using attributes or annotations, as we use classes to describe our GraphQL objects, it is also possible to create and populate classes instances using GraphQL data.  
 If a class is used to describe a GraphQL Input, this same class can be instantiated to hold the corresponding GraphQL Input data.  
-This is where the `Arguments Transformer` comes into play. Knowing the matching between GraphQL types and PHP classes, the service is able to instantiate a PHP classes and populate it with data based on the corresponding GraphQL type.
+This is where the `Arguments Transformer` comes into play. Knowing the matching between GraphQL types and PHP classes, the service is able to instantiate a PHP classes and populate it with data based on the corresponding GraphQL type.  
 To invoke the Arguments Transformer, we use the `input` expression function in our resolvers. 
 
 ## the `arguments` function in expression language
 
 The `arguments` function take two parameters, a mapping of arguments name and their type, like `name => type`. The type is in GraphQL notation, eventually with the "[]" and "!". The data are indexed by argument name.
 This function will use the `Arguments Transformer` service to transform the list of arguments into their corresponding PHP class if it has one and using a property accessor, it will populate the instance, and will use the `validator` service to validate it.  
-The transformation is done recursively. If an Input include another Input as field, it will also be populated the same way.
+The transformation is done recursively. If an Input include another Input as field, it will also be populated the same way.  
 
 For example:
 
@@ -19,51 +19,34 @@ namespace App\GraphQL\Input;
 use Overblog\GraphQLBundle\Annotation as GQL;
 use Symfony\Component\Validator\Constraints as Assert;
 
-/**
- * @GQL\Input
- */ 
+#[GQL\Input]
 class UserRegisterInput {
-    /**
-     * @GQL\Field(type="String!")
-     * @Assert\NotBlank
-     * @Assert\Length(min = 2, max = 50)
-     */
+    #[Assert\NotBlank]
+    #[Assert\Length(min: 2, max: 50)]
+    #[GQL\Field(type: "String!")]
     public $username;
 
-    /**
-     * @GQL\Field(type="String!")
-     * @Assert\NotBlank
-     * @Assert\Email
-     */
+    #[Assert\NotBlank]
+    #[Assert\Email]
+    #[GQL\Field(type: "String!")]
     public $email;
 
-    /**
-     * @GQL\Field(type="String!")
-     * @Assert\NotBlank
-     * @Assert\Length(
-     *      min = 5, 
-     *      minMessage="The password must be at least 5 characters long."
-     * )
-     */
+    #[Assert\NotBlank]
+    #[Assert\Length(min: 5, minMessage: "The password must be at least 5 characters long.")]
+    #[GQL\Field(type: "String!")]
     public $password;
 
-    /**
-     * @GQL\Field(type="Int!")
-     * @Assert\NotBlank
-     * @Assert\GreaterThan(18)
-     */
+    #[Assert\NotBlank]
+    #[Assert\GreaterThan(18)]
+    #[GQL\Field(type: "Int!")]
     public $age;
 }
 
 ....
 
-/**
- * @GQL\Provider
- */
+#[GQL\Provider]
 class UserRepository {
-    /**
-     * @GQL\Mutation
-     */
+    #[GQL\Mutation]
     public function createUser(UserRegisterInput $input) : User {
         // Use the validated $input here
         $user = new User();
@@ -81,19 +64,10 @@ The mutation received the valid instance.
 In the above example, everything is auto-guessed and a Provider is used. But this would be the same as : 
 
 ```php
-/**
- * @GQL\Type
- */
+#[GQL\Type]
 class RootMutation {
-    /**
-     * @GQL\Field(
-     *   type="User",
-     *   args={
-     *     @GQL\Arg(name="input", type="UserRegisterInput")
-     *   },
-     *   resolve="@=call(service('UserRepository').createUser, arguments({input: 'UserRegisterInput'}, arg))"
-     * )
-     */
+    #[GQL\Field(type: "User", resolve: "@=call(service('UserRepository').createUser, arguments({input: 'UserRegisterInput'}, arg))")]
+    #[GQL\Arg(name: "input", type: "UserRegisterInput")]
     public $createUser;
 }
 ```

--- a/docs/annotations/index.md
+++ b/docs/annotations/index.md
@@ -1,20 +1,7 @@
-# Annotations & PHP 8 attributes
+# Attributes (PHP >= 8) & Annotations
 
-In order to use annotations or attributes, you need to configure the mapping:
+In order to use attributes or annotations, you need to configure the mapping:
 
-To use annotations, You must install `symfony/cache` and `doctrine/annotation` and use the `annotation` mapping type.
-
-
-```yaml
-# config/packages/graphql.yaml
-overblog_graphql:
-  definitions:
-    mappings:
-      types:
-        - type: annotation
-          dir: "%kernel.project_dir%/src/GraphQL"
-          suffix: ~
-```
 To use attributes, use the `attribute` mapping type.
 
 ```yaml
@@ -28,21 +15,30 @@ overblog_graphql:
           suffix: ~
 ```
 
+To use annotations, You must install `symfony/cache` and `doctrine/annotation` and use the `annotation` mapping type.
+
+```yaml
+# config/packages/graphql.yaml
+overblog_graphql:
+  definitions:
+    mappings:
+      types:
+        - type: annotation
+          dir: "%kernel.project_dir%/src/GraphQL"
+          suffix: ~
+```
+
 This will load all annotated classes in `%kernel.project_dir%/src/GraphQL` into the schema.
 
-The annotations & attributes are equivalent and are used in the same way. They share the same annotation namespaces, classes and API.
+The annotations & attributes are equivalent and are used in the same way. They share the same annotation namespaces, classes and API.  
 
 Example with annotations:
 ```php
 use Overblog\GraphQLBundle\Annotation as GQL;
 
-/**
- * @GQL\Type
- */
+#[GQL\Type]
 class MyType {
-    /**
-     * @GQL\Field(type="Int")
-     */
+    #[GQL\Field(type: "Int")]
     protected $myField;
 }
 ```
@@ -61,8 +57,9 @@ class MyType {
 
 ## Using Annotations or Attributes as your only Mapping
 
-If you only use annotations as mappings you need to add an empty `RootQuery` type.
-Your config should look like this:
+If you only use annotations as mappings you need to add an empty `RootQuery` type.  
+Your config should look like this:  
+
 ```yaml
 # config/packages/graphql.yaml
 overblog_graphql:
@@ -75,13 +72,12 @@ overblog_graphql:
           dir: "%kernel.project_dir%/src/GraphQL"
           suffix: ~
 ```
-Your `RootQuery` class should look like this:
+Your `RootQuery` class should look like this:  
+
 ```php
 namespace App\GraphQL\Query;
 
-/**
- * @GQL\Type
- */
+#[GQL\Type]
 class RootQuery
 {
 }
@@ -89,8 +85,8 @@ class RootQuery
 If you use mutations, you need a `RootMutation` type as well.
 
 
-## Annotations reference
-- [Annotations reference](annotations-reference.md)
+## Attributes/Annotations reference
+- [Attributes/Annotations reference](annotations-reference.md)
 
 ## Arguments transformation, populating & validation
 - [Arguments Transformer](arguments-transformer.md)
@@ -100,7 +96,7 @@ If you use mutations, you need a `RootMutation` type as well.
 As PHP classes naturally support inheritance (and so is the annotation reader), it doesn't make sense to allow classes to use the "inherits" option (as on types declared using YAML).  
 The type will inherit annotations declared on parent class properties and methods. The annotation on the class itself will not be inherited.
 
-## Annotations, value & default resolver
+## Attributes/Annotations, value & default resolver
 
 In GraphQL, when a type's field is resolved, GraphQL expects by default a property (for object) or a key (for array) on the corresponding value returned for the type.  
 
@@ -118,23 +114,23 @@ So, the `value` could be an object instance with a `name` property or an array w
 Except for the root Query and root Mutation types, the `value` variable is always returned by another resolver.  
 For the root Query and the Root Mutation types, the `value` variable is the service with an id that equals to the fully qualified name of the query/mutation class.  
 
-The following rules apply for `@Field`, `@Query` and `@Mutation` annotations to guess a resolver when no `resolver` attribute is defined:  
+The following rules apply for `#[GQL\Field]`, `#[GQL\Query]` and `#[GQL\Mutation]` annotations to guess a resolver when no `resolver` attribute is defined:  
 
-- If `@Field` is defined on a property :
-    - If `@Field`'s attribute `name` is defined and is not equal to the property name 
+- If `#[GQL\Field]` is defined on a property :
+    - If `#[GQL\Field]`'s attribute `name` is defined and is not equal to the property name 
         - `@=value.<property name>` for a regular type
         - `@=service(<FQCN>).<property name>` for root query or root mutation
 
-    - If `@Field`'s attribute `name` is not defined or is not equal to the property name
+    - If `#[GQL\Field]`'s attribute `name` is not defined or is not equal to the property name
         - The default GraphQL resolver will be use for a regular type (no `resolve` configuration will be define).
         - `@=service(<FQCN>).<name>` for root query or root mutation
 
-- If `@Field` is defined on a method :  
+- If `#[GQL\Field]` is defined on a method :  
     - `@=call(value.<method name>, args)` for a regular type 
     - `@=call(service(<FQCN>).<method name>, args)` for root query or mutation
 
 
-## Annotations, Root Query & Root Mutation
+## Attributes/Annotations, Root Query & Root Mutation
 
 If you define your root Query or root Mutation type as a class with annotations, it will allow you to define methods directly on the class itself to be exposed as GraphQL fields.  
 For example: 
@@ -142,13 +138,9 @@ For example:
 ```php
 namespace App\GraphQL\Query;
 
-/**
- * @GQL\Type
- */
+#[GQL\Type]
 class RootQuery {
-    /**
-     * @GQL\Field(name="something", type="String!")
-     */
+    #[GQL\Field(name: "something", type: "String!")]
     public function getSomething() {
         return "Hello world!";
     }
@@ -171,49 +163,42 @@ If the `type` option is not defined explicitly on the `@Field`, `@Query` or `@Mu
 
 It will stop on the first successful guess.
 
-### @Field type auto-guessing from DockBlock
+### `#[GQL\Field]` type auto-guessing from DockBlock
 
-The `type` option of the `@Field` annotation can be guessed if its DocBlock describes a known type. It is a more precise guessing as it supports collections of objects, e.g. `User[]` or `array<User>`.
+The `type` option of the `#[GQL\Field]` attribute/annotation can be guessed if its DocBlock describes a known type. It is a more precise guessing as it supports collections of objects, e.g. `User[]` or `array<User>`.
 
 For example:
 
 ```php
-/**
- * @GQL\Type
- */
+#[GQL\Type]
 class MyType {
     /**
-     * @GQL\Field
-     * 
      * @var Friend[]
      */
+    #[GQL\Field]
     public array $friends = [];
 }
 ```
 
 
-### @Field type auto-guessing when defined on a property with a type hint
+### `#[GQL\Field]` type auto-guessing when defined on a property with a type hint
 
-The type of the `@Field` annotation can be auto-guessed if it's defined on a property with a type hint.
+The type of the `#[GQL\Field]` attribute/annotation can be auto-guessed if it's defined on a property with a type hint.
 If the property has a usable type hint this is used and no further guessing is done.
 
 For example:
 
 ```php
-/**
- * @GQL\Type
- */
+#[GQL\Type]
 class MyType {
-    /**
-     * @GQL\Field
-     */
+    #[GQL\Field]
     protected string $property;
 }
 ```
 
 In this example, the type `String!` will be auto-guessed from the type hint of the property.  
 
-### @Field type auto-guessing from Doctrine ORM Annotations
+### `#[GQL\Field]` type auto-guessing from Doctrine ORM Annotations
 
 Based on other Doctrine annotations on your fields, the corresponding GraphQL type can sometimes be guessed automatically.  
 In order to activate this guesser, you must install `doctrine/orm` package.  
@@ -228,7 +213,6 @@ The type can be auto-guessed from the following annotations:
 You can also provide your own doctrine / GraphQL types mappings in the bundle configuration.  
 For example:
 
-
 ```yaml (graphql.yaml)
 overblog_graphql:
     ...
@@ -240,20 +224,16 @@ overblog_graphql:
 ```
 
 
-### @Field type auto-guessing when defined on a method with a return type hint
+### #[GQL\Field] type auto-guessing when defined on a method with a return type hint
 
-The type of the `@Field` annotation can be auto-guessed if it's defined on a method with a return type hint.
+The type of the `#[GQL\Field]` annotation can be auto-guessed if it's defined on a method with a return type hint.
 
 For example:
 
 ```php
-/**
- * @GQL\Type
- */
+#[GQL\Type]
 class MyType {
-    /**
-     * @GQL\Field
-     */
+    #[GQL\Field]
     public function getSomething(): string {
         return "Hello world!";
     }
@@ -262,20 +242,16 @@ class MyType {
 
 In this example, the type `String!` will be auto-guessed from the return type hint of the method.  
 
-### @Field arguments auto-guessing when defined on a method with type hinted parameters
+### `#[GQL\Field]` arguments auto-guessing when defined on a method with type hinted parameters
 
-The arguments of the `@Field` annotation can be auto-guessed if it's defined on a method with type hinted arguments. Arguments without default value will be consided required.
+The arguments of the `#[GQL\Field]` attribute/annotation can be auto-guessed if it's defined on a method with type hinted arguments. Arguments without default value will be consided required.
 
 For example:
 
 ```php
-/**
- * @GQL\Type
- */
+#[GQL\Type]
 class MyType {
-    /**
-     * @GQL\Field(type="[String]!")
-     */
+    #[GQL\Field(type: "[String]!")]
     public function getSomething(int $amount, string $name, MyInputClass $input, int $limit = 10) {
         ...
     }
@@ -284,10 +260,26 @@ class MyType {
 
 The GraphQL arguments will be auto-guessed as:  
 
-- `@Arg(name="amount", type="Int!")`
-- `@Arg(name="name", type="String!")`
-- `@Arg(name="input", type="MyInput!")`  (The input type corresponding to the `MyInputClass` will be used).
-- `@Arg(name="limit", type="Int", default = 10)`
+- `#[GQL\Arg(name: "amount", type: "Int!")`
+- `#[GQL\Arg(name: "name", type: "String!")`
+- `#[GQL\Arg(name: "input", type: "MyInput!")`  (The input type corresponding to the `MyInputClass` will be used).
+- `#[GQL\Arg(name: "limit", type: "Int", default: 10)`
+
+It is possible to mix auto-guessing and manual declaration of arguments. Explicit declaration with `#[GQL\Arg]` will always take precedence over auto-guessing.  
+If both are used, __it is important to name the arguments and the parameters the same way__, otherwise, they'll be considered as two different arguments.  
+For example:  
+```php
+#[GQL\Type]
+class MyType {
+    #[GQL\Field]
+    #[GQL\Arg(name: "totalAmount", type: "Int!")]
+    public function doSomething(int $amount) {
+        ...
+    }
+}
+```
+In this example, the `doSomething` field will have two arguments: `totalAmount` and `amount` and the system won't be able to pass the `totalAmount` argument to the `doSomething` method.  
+
 
 ### Limitation of auto-guessing:
 

--- a/src/Annotation/Arg.php
+++ b/src/Annotation/Arg.php
@@ -62,7 +62,7 @@ final class Arg extends Annotation
         $this->default = $default;
 
         if ($this->defaultValue === null && $this->default !== null) {
-            trigger_deprecation('overblog/graphql-bundle', '1.3', 'The "default" attribute on @GQL\Arg or #GQL\Arg is deprecated, use "defaultValue" instead.');
+            @trigger_error(sprintf("%s %s %s", 'overblog/graphql-bundle', '1.3', 'The "default" attribute on @GQL\Arg or #GQL\Arg is deprecated, use "defaultValue" instead.'), E_USER_DEPRECATED);
             $this->defaultValue = $default;
         }
     }

--- a/src/Annotation/Arg.php
+++ b/src/Annotation/Arg.php
@@ -37,19 +37,33 @@ final class Arg extends Annotation
      *
      * @var mixed
      */
+    public $defaultValue;
+
+    /**
+     * Default argument value.
+     * @deprecated use $defaultValue instead
+     * @var mixed
+     */
     public $default;
 
     /**
-     * @param string      $name        The name of the argument
-     * @param string      $type        The type of the argument
-     * @param string|null $description The description of the argument
-     * @param mixed|null  $default     Default value of the argument
+     * @param string      $name          The name of the argument
+     * @param string      $type          The type of the argument
+     * @param string|null $description   The description of the argument
+     * @param mixed|null  $defaultValue  Default value of the argument
+     * @param mixed|null  $default       Default value of the argument (deprecated, use $defaultValue instead)
      */
-    public function __construct(string $name, string $type, ?string $description = null, $default = null)
+    public function __construct(string $name, string $type, ?string $description = null, $defaultValue = null, $default = null)
     {
         $this->name = $name;
         $this->description = $description;
         $this->type = $type;
+        $this->defaultValue = $defaultValue;
         $this->default = $default;
+
+        if ($this->defaultValue === null && $this->default !== null) {
+            trigger_deprecation('overblog/graphql-bundle', '1.3', 'The "default" attribute on @GQL\Arg or #GQL\Arg is deprecated, use "defaultValue" instead.');
+            $this->defaultValue = $default;
+        }
     }
 }

--- a/src/Annotation/InputField.php
+++ b/src/Annotation/InputField.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Annotation;
+
+use Attribute;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
+
+/**
+ * Annotation for GraphQL input field.
+ *
+ * @Annotation
+ * @NamedArgumentConstructor
+ * @Target({"PROPERTY", "METHOD"})
+ */
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD)]
+final class InputField extends Field
+{
+    /**
+     * Optionnal default value.
+     */
+    public mixed $defaultValue;
+
+    /**
+     * @param string|null $name         The GraphQL name of the field
+     * @param string|null $type         The GraphQL type of the field
+     * @param string|null $complexity   A complexity expression
+     * @param mixed|null  $defaultValue The default value of the field
+     */
+    public function __construct(
+        ?string $name = null,
+        ?string $type = null,
+        ?string $complexity = null,
+        mixed $defaultValue = null
+    ) {
+        parent::__construct($name, $type, null, $complexity);
+        $this->defaultValue = $defaultValue;
+    }
+}

--- a/src/Annotation/TypeInterface.php
+++ b/src/Annotation/TypeInterface.php
@@ -20,7 +20,7 @@ final class TypeInterface extends Annotation
     /**
      * Resolver type for interface.
      */
-    public string $resolveType;
+    public ?string $resolveType;
 
     /**
      * Interface name.
@@ -31,7 +31,7 @@ final class TypeInterface extends Annotation
      * @param string        $resolveType The express resolve type
      * @param string|null   $name        The GraphQL name of the interface
      */
-    public function __construct(string $resolveType, ?string $name = null)
+    public function __construct(?string $resolveType = null, ?string $name = null)
     {
         $this->resolveType = $resolveType;
         $this->name = $name;

--- a/src/Config/Parser/MetadataParser/ClassesTypesMap.php
+++ b/src/Config/Parser/MetadataParser/ClassesTypesMap.php
@@ -12,7 +12,7 @@ final class ClassesTypesMap
     private array $classesMap = [];
 
     /**
-     * @var array<string, array{class: string, type: string}>
+     * @var array<string, array<string,string>>
      */
     private array $interfacesMap = [];
 

--- a/src/Config/Parser/MetadataParser/ClassesTypesMap.php
+++ b/src/Config/Parser/MetadataParser/ClassesTypesMap.php
@@ -11,6 +11,11 @@ final class ClassesTypesMap
      */
     private array $classesMap = [];
 
+    /**
+     * @var array<string, array{class: string, type: string}>
+     */
+    private array $interfacesMap = [];
+
     public function hasType(string $gqlType): bool
     {
         return isset($this->classesMap[$gqlType]);
@@ -72,8 +77,25 @@ final class ClassesTypesMap
         return $classNames;
     }
 
-    public function toArray(): array
+    public function classesToArray(): array
     {
         return $this->classesMap;
+    }
+
+    /**
+     * Add a type and its associated class to the interfaces map
+     */
+    public function addInterfaceType(string $interfaceType, string $graphqlType, string $className): void
+    {
+        if (!isset($this->interfacesMap[$interfaceType])) {
+            $this->interfacesMap[$interfaceType] = [];
+        }
+
+        $this->interfacesMap[$interfaceType][$className] = $graphqlType;
+    }
+
+    public function interfacesToArray(): array
+    {
+        return $this->interfacesMap;
     }
 }

--- a/src/Config/Parser/MetadataParser/MetadataParser.php
+++ b/src/Config/Parser/MetadataParser/MetadataParser.php
@@ -93,7 +93,9 @@ abstract class MetadataParser implements PreParserInterface
         $parameter = 'overblog_graphql_types.interfaces_map';
         $value = $container->hasParameter($parameter) ? $container->getParameter($parameter) : [];
         foreach (self::$map->interfacesToArray() as $interface => $types) {
+            /** @phpstan-ignore-next-line */
             if (!isset($value[$interface])) {
+                /** @phpstan-ignore-next-line */
                 $value[$interface] = [];
             }
             foreach ($types as $className => $typeName) {

--- a/src/Config/Parser/MetadataParser/MetadataParser.php
+++ b/src/Config/Parser/MetadataParser/MetadataParser.php
@@ -685,7 +685,7 @@ abstract class MetadataParser implements PreParserInterface
                 $fieldConfiguration['type'] = $fieldType;
             }
 
-            if($fieldMetadata instanceof InputField && $fieldMetadata->defaultValue !== null) {
+            if ($fieldMetadata instanceof InputField && null !== $fieldMetadata->defaultValue) {
                 $fieldConfiguration['defaultValue'] = $fieldMetadata->defaultValue;
             } elseif ($reflector->hasDefaultValue()) {
                 $fieldConfiguration['defaultValue'] = $reflector->getDefaultValue();

--- a/src/Config/Parser/MetadataParser/MetadataParser.php
+++ b/src/Config/Parser/MetadataParser/MetadataParser.php
@@ -601,7 +601,7 @@ abstract class MetadataParser implements PreParserInterface
             if (isset($arg->defaultValue)) {
                 $args[$arg->name]['defaultValue'] = $arg->defaultValue;
             } elseif (isset($arg->default)) {
-                trigger_deprecation('overblog/graphql-bundle', '1.3', 'The "default" attribute on @GQL\Arg or #GQL\Arg is deprecated, use "defaultValue" instead.');
+                @trigger_error(sprintf('%s %s %s', 'overblog/graphql-bundle', '1.3', 'The "default" attribute on @GQL\Arg or #GQL\Arg is deprecated, use "defaultValue" instead.'), E_USER_DEPRECATED);
                 $args[$arg->name]['defaultValue'] = $arg->default;
             }
         }

--- a/src/Config/Parser/MetadataParser/MetadataParser.php
+++ b/src/Config/Parser/MetadataParser/MetadataParser.php
@@ -245,9 +245,7 @@ abstract class MetadataParser implements PreParserInterface
             case $classMetadata instanceof Metadata\TypeInterface:
                 $gqlType = self::GQL_INTERFACE;
                 if (!$preProcess) {
-                    if (!$gqlName) {
-                        $gqlName = !empty($classMetadata->name) ? $classMetadata->name : $reflectionClass->getShortName();
-                    }
+                    $gqlName = !empty($classMetadata->name) ? $classMetadata->name : $reflectionClass->getShortName();
                     $gqlConfiguration = self::typeInterfaceMetadataToGQLConfiguration($reflectionClass, $classMetadata, $gqlName);
                 }
                 break;

--- a/src/Controller/ProfilerController.php
+++ b/src/Controller/ProfilerController.php
@@ -63,7 +63,7 @@ final class ProfilerController
 
         $tokens = array_map(function ($tokenData) {
             $profile = $this->profiler->loadProfile($tokenData['token']);
-            if (!$profile->hasCollector('graphql')) {
+            if (!$profile || !$profile->hasCollector('graphql')) {
                 return false;
             }
             $tokenData['graphql'] = $profile->getCollector('graphql');

--- a/src/DependencyInjection/Compiler/ConfigParserPass.php
+++ b/src/DependencyInjection/Compiler/ConfigParserPass.php
@@ -91,6 +91,8 @@ final class ConfigParserPass implements CompilerPassInterface
         $config = $container->getParameterBag()->resolveValue($container->getParameter('overblog_graphql.config'));
         $container->getParameterBag()->remove('overblog_graphql.config');
         $container->setParameter($this->getAlias().'.classes_map', []);
+        $container->setParameter($this->getAlias().'.interfaces_map', []);
+
         $typesMappings = $this->mappingConfig($config, $container);
         // reset treated files
         $this->treatedFiles = [];
@@ -116,6 +118,9 @@ final class ConfigParserPass implements CompilerPassInterface
         $this->checkTypesDuplication($typeConfigs);
         // flatten config is a requirement to support inheritance
         $flattenTypeConfig = array_merge(...$typeConfigs);
+
+        AnnotationParser::finalize($container);
+        AttributeParser::finalize($container);
 
         return $flattenTypeConfig;
     }

--- a/src/Resolver/InterfaceTypeResolver.php
+++ b/src/Resolver/InterfaceTypeResolver.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Resolver;
 
+use GraphQL\Type\Definition\Type;
+
 class InterfaceTypeResolver
 {
     private TypeResolver $typeResolver;
@@ -15,7 +17,7 @@ class InterfaceTypeResolver
         $this->interfacesMap = $interfacesMap;
     }
 
-    public function resolveType(string $interfaceType, mixed $value)
+    public function resolveType(string $interfaceType, mixed $value): ?Type
     {
         if (!isset($this->interfacesMap[$interfaceType])) {
             throw new UnresolvableException(sprintf('Default interface type resolver was unable to find interface with name "%s"', $interfaceType));

--- a/src/Resolver/InterfaceTypeResolver.php
+++ b/src/Resolver/InterfaceTypeResolver.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Resolver;
+
+class InterfaceTypeResolver
+{
+    private TypeResolver $typeResolver;
+    private array $interfacesMap;
+
+    public function __construct(TypeResolver $typeResolver, array $interfacesMap = [])
+    {
+        $this->typeResolver = $typeResolver;
+        $this->interfacesMap = $interfacesMap;
+    }
+
+    public function resolveType(string $interfaceType, mixed $value)
+    {
+        if (!isset($this->interfacesMap[$interfaceType])) {
+            throw new UnresolvableException(sprintf('Default interface type resolver was unable to find interface with name "%s"', $interfaceType));
+        }
+
+        $gqlType = null;
+        $types = $this->interfacesMap[$interfaceType];
+        foreach ($types as $className => $type) {
+            if ($value instanceof $className) {
+                $gqlType = $type;
+                break;
+            }
+        }
+
+        if (null === $gqlType) {
+            throw new UnresolvableException(sprintf('Default interface type resolver with interface "%s" did not find a matching instance in: %s', $interfaceType, implode(', ', array_keys($types))));
+        }
+
+        return $this->typeResolver->resolve($gqlType);
+    }
+}

--- a/src/Resources/config/aliases.yaml
+++ b/src/Resources/config/aliases.yaml
@@ -12,6 +12,7 @@ services:
     overblog_graphql.request_parser: '@Overblog\GraphQLBundle\Request\Parser'
     overblog_graphql.request_batch_parser: '@Overblog\GraphQLBundle\Request\BatchParser'
     overblog_graphql.arguments_transformer: '@Overblog\GraphQLBundle\Transformer\ArgumentsTransformer'
+    overblog_graphql.interface_type_resolver: '@Overblog\GraphQLBundle\Resolver\InterfaceTypeResolver'
 
     overblog_graphql.schema_builder:
         alias: 'Overblog\GraphQLBundle\Definition\Builder\SchemaBuilder'

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -10,14 +10,14 @@ services:
     Overblog\GraphQLBundle\Resolver\FieldResolver: ~
 
     Overblog\GraphQLBundle\Definition\GraphQLServices:
-        tags: ['container.service_locator']
+        tags: ["container.service_locator"]
 
     Overblog\GraphQLBundle\Request\Executor:
         arguments:
             - "@overblog_graphql.executor"
             - "@overblog_graphql.promise_adapter"
             - "@event_dispatcher"
-            - '@overblog_graphql.default_field_resolver'
+            - "@overblog_graphql.default_field_resolver"
         calls:
             - ["setMaxQueryComplexity", ["%overblog_graphql.query_max_complexity%"]]
             - ["setMaxQueryDepth", ["%overblog_graphql.query_max_depth%"]]
@@ -34,14 +34,14 @@ services:
 
     Overblog\GraphQLBundle\Resolver\TypeResolver:
         calls:
-            - ['setDispatcher', ['@event_dispatcher']]
+            - ["setDispatcher", ["@event_dispatcher"]]
         tags:
             - { name: overblog_graphql.service, alias: typeResolver }
 
     Overblog\GraphQLBundle\Transformer\ArgumentsTransformer:
         arguments:
-            - '@?validator'
-            - '%overblog_graphql_types.classes_map%'
+            - "@?validator"
+            - "%overblog_graphql_types.classes_map%"
 
     Overblog\GraphQLBundle\Resolver\QueryResolver:
         tags:
@@ -51,31 +51,36 @@ services:
         tags:
             - { name: overblog_graphql.service, alias: mutationResolver }
 
+    Overblog\GraphQLBundle\Resolver\InterfaceTypeResolver:
+        arguments:
+            - '@Overblog\GraphQLBundle\Resolver\TypeResolver'
+            - "%overblog_graphql_types.interfaces_map%"
+
     Overblog\GraphQLBundle\Resolver\AccessResolver:
         arguments:
-            - '@overblog_graphql.promise_adapter'
+            - "@overblog_graphql.promise_adapter"
 
     Overblog\GraphQLBundle\ExpressionLanguage\ExpressionLanguage:
         arguments:
-            - '@?overblog_graphql.cache_expression_language_parser'
+            - "@?overblog_graphql.cache_expression_language_parser"
 
     Overblog\GraphQLBundle\Generator\TypeGenerator:
         arguments:
-            - '%overblog_graphql_types.config%'
+            - "%overblog_graphql_types.config%"
             - '@Overblog\GraphQLBundle\Generator\TypeBuilder'
             - '@Symfony\Contracts\EventDispatcher\EventDispatcherInterface'
             - !service
-                class: Overblog\GraphQLBundle\Generator\TypeGeneratorOptions
-                arguments:
-                    - '%overblog_graphql.class_namespace%'
-                    - '%overblog_graphql.cache_dir%'
-                    - '%overblog_graphql.use_classloader_listener%'
-                    - '%kernel.cache_dir%'
-                    - '%overblog_graphql.cache_dir_permissions%'
+              class: Overblog\GraphQLBundle\Generator\TypeGeneratorOptions
+              arguments:
+                  - "%overblog_graphql.class_namespace%"
+                  - "%overblog_graphql.cache_dir%"
+                  - "%overblog_graphql.use_classloader_listener%"
+                  - "%kernel.cache_dir%"
+                  - "%overblog_graphql.cache_dir_permissions%"
 
     Overblog\GraphQLBundle\Definition\ArgumentFactory:
         arguments:
-            - '%overblog_graphql.argument_class%'
+            - "%overblog_graphql.argument_class%"
         tags:
             - { name: overblog_graphql.service, alias: argumentFactory }
 
@@ -90,7 +95,7 @@ services:
 
     Overblog\GraphQLBundle\Definition\ConfigProcessor:
         arguments:
-            - !tagged_iterator 'overblog_graphql.definition_config_processor'
+            - !tagged_iterator "overblog_graphql.definition_config_processor"
 
     GraphQL\Executor\Promise\PromiseAdapter: "@overblog_graphql.promise_adapter"
 
@@ -100,7 +105,7 @@ services:
 
     Overblog\GraphQLBundle\Security\Security:
         arguments:
-            - '@?security.helper'
+            - "@?security.helper"
         tags:
             - { name: overblog_graphql.service, alias: security, public: false }
 
@@ -111,12 +116,12 @@ services:
     Overblog\GraphQLBundle\Generator\TypeBuilder:
         arguments:
             - '@Overblog\GraphQLBundle\Generator\Converter\ExpressionConverter'
-            - '%overblog_graphql.class_namespace%'
+            - "%overblog_graphql.class_namespace%"
 
     Overblog\GraphQLBundle\Validator\InputValidatorFactory:
         arguments:
-            - '@?validator.validator_factory'
-            - '@?validator'
-            - '@?translator.default'
+            - "@?validator.validator_factory"
+            - "@?validator"
+            - "@?translator.default"
         tags:
             - { name: overblog_graphql.service, alias: input_validator_factory, public: false }

--- a/tests/Config/Parser/MetadataParserTest.php
+++ b/tests/Config/Parser/MetadataParserTest.php
@@ -252,6 +252,10 @@ abstract class MetadataParserTest extends TestCase
             'description' => 'The armored interface',
             'resolveType' => '@=query(\'character_type\', [value])',
         ]);
+
+        $this->expect('Biped', 'interface', [
+            'resolveType' => "@=service('overblog_graphql.interface_type_resolver').resolveType('Biped', value)",
+        ]);
     }
 
     public function testEnum(): void
@@ -304,7 +308,7 @@ abstract class MetadataParserTest extends TestCase
     public function testInterfaceAutoguessed(): void
     {
         $this->expect('Mandalorian', 'object', [
-            'interfaces' => ['Character', 'WithArmor'],
+            'interfaces' => ['Biped', 'Character', 'WithArmor'],
             'fields' => [
                 'name' => ['type' => 'String!', 'description' => 'The name of the character'],
                 'friends' => ['type' => '[Character]', 'description' => 'The friends of the character', 'resolve' => "@=query('App\\MyResolver::getFriends')"],

--- a/tests/Config/Parser/MetadataParserTest.php
+++ b/tests/Config/Parser/MetadataParserTest.php
@@ -233,6 +233,17 @@ abstract class MetadataParserTest extends TestCase
                 'alienInvasion' => ['type' => 'Boolean!', 'deprecationReason' => 'No more alien invasions on planets'],
             ],
         ]);
+
+        $this->expect('MateriaInput', 'input-object', [
+            'fields' => [
+                'name' => ['type' => 'String!', 'defaultValue' => 'default name'],
+                'ap' => ['type' => 'Int!', 'defaultValue' => 100],
+                'description' => ['type' => 'String!', 'defaultValue' => 'A description by default'],
+                'diameter' => ['type' => 'Int'],
+                'colors' => ['type' => '[String]!', 'defaultValue' => ['red', 'green', 'blue']],
+                'effects' => ['type' => '[String]', 'defaultValue' => ['slow', 'enrage', 'boost']],
+            ],
+        ]);
     }
 
     public function testInterfaces(): void

--- a/tests/Config/Parser/fixtures/annotations/Input/MateriaInput.php
+++ b/tests/Config/Parser/fixtures/annotations/Input/MateriaInput.php
@@ -16,7 +16,7 @@ final class MateriaInput
      * @GQL\InputField(type="String!")
      */
     #[GQL\InputField(type: 'String!')]
-    public string $name = "default name";
+    public string $name = 'default name';
 
     /**
      * @GQL\InputField(type="Int!", defaultValue=100)
@@ -28,7 +28,7 @@ final class MateriaInput
      * @GQL\Field
      */
     #[GQL\Field]
-    public string $description = "A description by default";
+    public string $description = 'A description by default';
 
     /**
      * @GQL\Field

--- a/tests/Config/Parser/fixtures/annotations/Input/MateriaInput.php
+++ b/tests/Config/Parser/fixtures/annotations/Input/MateriaInput.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Input;
+
+use Overblog\GraphQLBundle\Annotation as GQL;
+
+/**
+ * @GQL\Input
+ */
+#[GQL\Input]
+final class MateriaInput
+{
+    /**
+     * @GQL\InputField(type="String!")
+     */
+    #[GQL\InputField(type: 'String!')]
+    public string $name = "default name";
+
+    /**
+     * @GQL\InputField(type="Int!", defaultValue=100)
+     */
+    #[GQL\InputField(type: 'Int!', defaultValue: 100)]
+    public int $ap;
+
+    /**
+     * @GQL\Field
+     */
+    #[GQL\Field]
+    public string $description = "A description by default";
+
+    /**
+     * @GQL\Field
+     */
+    #[GQL\Field]
+    // @phpstan-ignore-next-line
+    public ?int $diameter;
+
+    // @phpstan-ignore-next-line
+    public $dummy;
+
+    /**
+     * @GQL\Field(type="[String]!")
+     */
+    #[GQL\Field(type: '[String]!')]
+    public array $colors = ['red', 'green', 'blue'];
+
+    /**
+     * @GQL\InputField(type="[String]", defaultValue={"slow", "enrage", "boost"})
+     */
+    #[GQL\InputField(type: '[String]', defaultValue: ['slow', 'enrage', 'boost'])]
+    public ?array $effects = null;
+}

--- a/tests/Config/Parser/fixtures/annotations/Type/Biped.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/Biped.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Type;
+
+use Overblog\GraphQLBundle\Annotation as GQL;
+
+/**
+ * @GQL\TypeInterface
+ */
+#[GQL\TypeInterface]
+interface Biped
+{
+}

--- a/tests/Config/Parser/fixtures/annotations/Type/Hero.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/Hero.php
@@ -15,7 +15,7 @@ use Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Union\Killab
  */
 #[GQL\Type(interfaces: ['Character'])]
 #[GQL\Description('The Hero type')]
-final class Hero extends Character implements Killable
+final class Hero extends Character implements Killable, Biped
 {
     /**
      * @GQL\Field(type="Race")

--- a/tests/Config/Parser/fixtures/annotations/Type/Mandalorian.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/Mandalorian.php
@@ -11,6 +11,6 @@ use Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Union\Killab
  * @GQL\Type
  */
 #[GQL\Type]
-final class Mandalorian extends Character implements Killable, Armored
+final class Mandalorian extends Character implements Killable, Armored, Biped
 {
 }

--- a/tests/Config/Parser/fixtures/annotations/Type/Sith.php
+++ b/tests/Config/Parser/fixtures/annotations/Type/Sith.php
@@ -20,7 +20,7 @@ use Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Union\Killab
 #[GQL\Description('The Sith type')]
 #[GQL\Access('isAuthenticated()')]
 #[GQL\IsPublic('isAuthenticated()')]
-final class Sith extends Character implements Killable
+final class Sith extends Character implements Killable, Biped
 {
     /**
      * @GQL\Field(type="String!")

--- a/tests/Functional/App/GraphQL/Attributes/DemoInterface.php
+++ b/tests/Functional/App/GraphQL/Attributes/DemoInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Functional\App\GraphQL\Attributes;
+
+use Overblog\GraphQLBundle\Annotation as GQL;
+
+#[GQL\TypeInterface]
+abstract class DemoInterface
+{
+    #[GQL\Field]
+    public string $fieldInterface = 'field_interface';
+}

--- a/tests/Functional/App/GraphQL/Attributes/QueryProvider.php
+++ b/tests/Functional/App/GraphQL/Attributes/QueryProvider.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Functional\App\GraphQL\Attributes;
+
+use Overblog\GraphQLBundle\Annotation as GQL;
+
+#[GQL\Provider]
+final class QueryProvider
+{
+    #[GQL\Query(type: '[DemoInterface]')]
+    public function getDemoItems(): array
+    {
+        return [
+            new Type1(),
+            new Type2(),
+        ];
+    }
+}

--- a/tests/Functional/App/GraphQL/Attributes/RootMutation.php
+++ b/tests/Functional/App/GraphQL/Attributes/RootMutation.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Functional\App\GraphQL\Attributes;
+
+use Overblog\GraphQLBundle\Annotation as GQL;
+
+#[GQL\Type]
+final class RootMutation
+{
+    #[GQL\Field]
+    public string $field1 = '';
+}

--- a/tests/Functional/App/GraphQL/Attributes/RootQuery.php
+++ b/tests/Functional/App/GraphQL/Attributes/RootQuery.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Functional\App\GraphQL\Attributes;
+
+use Overblog\GraphQLBundle\Annotation as GQL;
+
+#[GQL\Type]
+final class RootQuery
+{
+}

--- a/tests/Functional/App/GraphQL/Attributes/Type1.php
+++ b/tests/Functional/App/GraphQL/Attributes/Type1.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Functional\App\GraphQL\Attributes;
+
+use Overblog\GraphQLBundle\Annotation as GQL;
+
+#[GQL\Type]
+class Type1 extends DemoInterface
+{
+    #[GQL\Field]
+    public string $field1 = 'type1_field1';
+}

--- a/tests/Functional/App/GraphQL/Attributes/Type2.php
+++ b/tests/Functional/App/GraphQL/Attributes/Type2.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Functional\App\GraphQL\Attributes;
+
+use Overblog\GraphQLBundle\Annotation as GQL;
+
+#[GQL\Type]
+class Type2 extends DemoInterface
+{
+    #[GQL\Field]
+    public string $field1 = 'type2_field1';
+}

--- a/tests/Functional/App/config/attributes/config.yml
+++ b/tests/Functional/App/config/attributes/config.yml
@@ -1,0 +1,19 @@
+imports:
+  - { resource: ../config.yml }
+
+overblog_graphql:
+  definitions:
+    use_classloader_listener: false
+    class_namespace: "Overblog\\GraphQLBundle\\Attributes\\__DEFINITIONS__"
+    schema:
+      query: RootQuery
+      mutation: RootMutation
+    mappings:
+      types:
+        - type: attribute
+          dir: "%kernel.project_dir%/GraphQL/Attributes/"
+          suffix: ~
+
+services:
+  Overblog\GraphQLBundle\Tests\Functional\App\GraphQL\Attributes\QueryProvider:
+    public: true

--- a/tests/Functional/InterfaceTypeResolver/InterfaceTypeResolverTest.php
+++ b/tests/Functional/InterfaceTypeResolver/InterfaceTypeResolverTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Functional\InterfaceTypeResolver;
+
+use Closure;
+use Overblog\GraphQLBundle\Tests\Functional\TestCase;
+use Symfony\Component\HttpKernel\Kernel;
+
+final class InterfaceTypeResolverTest extends TestCase
+{
+    private Closure $loader;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // load types
+        $this->loader = function ($class): void {
+            if (preg_match('@^'.preg_quote('Overblog\GraphQLBundle\Attributes\__DEFINITIONS__\\').'(.*)$@', $class, $matches)) {
+                $file = sys_get_temp_dir().'/OverblogGraphQLBundle/'.Kernel::VERSION.'/attributes/cache/testattributes/overblog/graphql-bundle/__definitions__/'.$matches[1].'.php';
+                if (file_exists($file)) {
+                    require $file;
+                }
+            }
+        };
+        spl_autoload_register($this->loader);
+        static::bootKernel(['test_case' => 'attributes']);
+    }
+
+    public function testAutoTypeResolution(): void
+    {
+        $query = <<<'EOF'
+            query res {
+                getDemoItems {
+                    fieldInterface
+                    ... on Type1 {
+                        field1
+                    }
+                    ... on Type2 {
+                        field1
+                    }
+                }
+            }
+            EOF;
+        $result = $this->executeGraphQLRequest($query);
+
+        $this->assertEquals($result['data']['getDemoItems'][0]['fieldInterface'], 'field_interface');
+        $this->assertEquals($result['data']['getDemoItems'][0]['field1'], 'type1_field1');
+        $this->assertEquals($result['data']['getDemoItems'][1]['fieldInterface'], 'field_interface');
+        $this->assertEquals($result['data']['getDemoItems'][1]['field1'], 'type2_field1');
+    }
+}

--- a/tests/Transformer/ArgumentsTransformerTest.php
+++ b/tests/Transformer/ArgumentsTransformerTest.php
@@ -91,7 +91,17 @@ final class ArgumentsTransformerTest extends TestCase
             ],
         ]);
 
-        $types = [$t1, $t2, $t3, $t4];
+        $t5 = new InputObjectType([
+            'name' => 'InputType4',
+            'fields' => [
+                'field1' => ['type' => Type::string(), 'defaultValue' => 'value_from_config_field1'],
+                'field2' => Type::listOf(Type::string()),
+                'field3' => ['type' => Type::int(), 'defaultValue' => 10],
+                'field4' => Type::string(),
+            ],
+        ]);
+
+        $types = [$t1, $t2, $t3, $t4, $t5];
 
         if (PHP_VERSION_ID >= 80100) {
             $t5 = new PhpEnumType([
@@ -115,6 +125,7 @@ final class ArgumentsTransformerTest extends TestCase
             'InputType1' => ['type' => 'input', 'class' => InputType1::class],
             'InputType2' => ['type' => 'input', 'class' => InputType2::class],
             'InputType3' => ['type' => 'input', 'class' => InputType3::class],
+            'InputType4' => ['type' => 'input', 'class' => InputType4::class],
         ]);
 
         $info = $this->getResolveInfo(self::getTypes());
@@ -177,6 +188,16 @@ final class ArgumentsTransformerTest extends TestCase
         $this->assertEquals($data['field1'][1]['field1'], $res->field1[1]->field1);
         $this->assertEquals($data['field1'][1]['field2'], $res->field1[1]->field2);
         $this->assertEquals($data['field1'][1]['field3'], $res->field1[1]->field3);
+
+        // InputType4
+        $data = ['field4' => 'value_field4'];
+        $res = $transformer->getInstanceAndValidate('InputType4', $data, $info, 'input');
+
+        $this->assertInstanceOf(InputType4::class, $res);
+        $this->assertEquals($res->field1, 'default_value_field1');
+        $this->assertEquals($res->field2, null);
+        $this->assertEquals($res->field3, 5);
+        $this->assertEquals($res->field4, 'value_field4');
 
         $res = $transformer->getInstanceAndValidate('Enum1', 2, $info, 'enum1');
 
@@ -241,7 +262,7 @@ final class ArgumentsTransformerTest extends TestCase
         try {
             $res = $builder->getArguments($mapping, $data, $this->getResolveInfo(self::getTypes()));
             $this->fail("When input data validation fail, it should raise an Overblog\GraphQLBundle\Error\InvalidArgumentsError exception");
-        } catch (Exception $e) {
+        } catch (InvalidArgumentsError $e) {
             $this->assertInstanceOf(InvalidArgumentsError::class, $e);
             $first = $e->getErrors()[0];
             $this->assertInstanceOf(InvalidArgumentError::class, $first);

--- a/tests/Transformer/InputType4.php
+++ b/tests/Transformer/InputType4.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Transformer;
+
+final class InputType4
+{
+    /**
+     * @var mixed
+     */
+    public $field1 = "default_value_field1";
+
+    /**
+     * @var mixed
+     */
+    public $field2 = ["v1", "v2"];
+
+    /**
+     * @var mixed
+     */
+    public $field3 = 5;
+
+    /**
+     * @var mixed
+     */
+    public $field4;
+}

--- a/tests/Transformer/InputType4.php
+++ b/tests/Transformer/InputType4.php
@@ -9,12 +9,12 @@ final class InputType4
     /**
      * @var mixed
      */
-    public $field1 = "default_value_field1";
+    public $field1 = 'default_value_field1';
 
     /**
      * @var mixed
      */
-    public $field2 = ["v1", "v2"];
+    public $field2 = ['v1', 'v2'];
 
     /**
      * @var mixed


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | kind of
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Documented?   | yes
| Fixed tickets | #1171
| License       | MIT

- Handle default value on Input field and introduce a new attribute #[InputField]
- Update docs with example with attributes instead of annotation
- Rename `default` to `defaultValue` to be consistent in #[GQL\Arg] attribute (and deprecate the old one)