### PR TITLE
Validate only InputObject types fix #1170

### DIFF
--- a/src/Transformer/ArgumentsTransformer.php
+++ b/src/Transformer/ArgumentsTransformer.php
@@ -147,9 +147,13 @@ final class ArgumentsTransformer
         $endIndex = ($isRequired ? 1 : 0) + ($isMultiple ? 1 : 0) + ($isStrictMultiple ? 1 : 0);
         $type = substr($argType, $isMultiple ? 1 : 0, $endIndex > 0 ? -$endIndex : strlen($argType));
 
-        $result = $this->populateObject($this->getType($type, $info), $data, $isMultiple, $info);
+        $gqlType = $this->getType($type, $info);
+        $result = $this->populateObject($gqlType, $data, $isMultiple, $info);
 
-        if (null !== $this->validator) {
+        // We only want to validate input object types and not the scalar or object types that are already validated by the GraphQL library.
+        $shouldValidate = $gqlType instanceof InputObjectType;
+
+        if (null !== $this->validator && $shouldValidate) {
             $errors = new ConstraintViolationList();
             if (is_object($result)) {
                 $errors = $this->validator->validate($result);

--- a/tests/Transformer/Type1.php
+++ b/tests/Transformer/Type1.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Transformer;
+
+final class Type1
+{
+    /**
+     * @var mixed
+     */
+    public $field1;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes/no
| Fixed tickets | #1170
| License       | MIT


The `ArgumentsTransformer` should not validated arguments that are not `Input` or list of `Input`.  
For example, if we have a scalar returning an invalid object, we should not validate it on our side.  

In our case for example, we have scalars that turn `id` into doctrine entities so we can get entities in our methods. The scalar is in charge of validating that the object exists, but we shouldn't call the validation on the object returned by the scalar. Anyway, in a query or mutation, we should only validate inputted data through `InputObject`.  
