### PR TITLE
Ensure that a #[GQL\Arg] on method has a matching parameter

### DIFF
--- a/tests/Config/Parser/MetadataParserTest.php
+++ b/tests/Config/Parser/MetadataParserTest.php
@@ -524,6 +524,18 @@ abstract class MetadataParserTest extends TestCase
         }
     }
 
+    public function testInvalidArgumentMatching(): void
+    {
+        try {
+            $file = __DIR__.'/fixtures/annotations/Invalid/InvalidArgumentNaming.php';
+            $this->parser('parse', new SplFileInfo($file), $this->containerBuilder, $this->parserConfig);
+            $this->fail('Missing matching argument should have raise an exception');
+        } catch (Exception $e) {
+            $this->assertInstanceOf(InvalidArgumentException::class, $e);
+            $this->assertMatchesRegularExpression('/The argument "missingParameter" defined/', $e->getPrevious()->getMessage());
+        }
+    }
+
     public function testInvalidReturnGuessing(): void
     {
         try {

--- a/tests/Config/Parser/fixtures/annotations/Invalid/InvalidArgumentNaming.php
+++ b/tests/Config/Parser/fixtures/annotations/Invalid/InvalidArgumentNaming.php
@@ -16,8 +16,6 @@ final class InvalidArgumentNaming
      * @GQL\Field(name="guessFailed")
      *
      * @GQL\Arg(name="missingParameter", type="String")
-     *
-     * @param mixed $test
      */
     #[GQL\Field(name: 'guessFailed')]
     #[GQL\Arg(name: 'missingParameter', type: 'String')]

--- a/tests/Config/Parser/fixtures/annotations/Invalid/InvalidArgumentNaming.php
+++ b/tests/Config/Parser/fixtures/annotations/Invalid/InvalidArgumentNaming.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Invalid;
+
+use Overblog\GraphQLBundle\Annotation as GQL;
+
+/**
+ * @GQL\Type
+ */
+#[GQL\Type]
+final class InvalidArgumentNaming
+{
+    /**
+     * @GQL\Field(name="guessFailed")
+     *
+     * @GQL\Arg(name="missingParameter", type="String")
+     *
+     * @param mixed $test
+     */
+    #[GQL\Field(name: 'guessFailed')]
+    #[GQL\Arg(name: 'missingParameter', type: 'String')]
+    public function guessFail(int $test): int
+    {
+        return 12;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

This PR force an argument defined with `#[GQL\Arg]` or `@GQL\Arg` on a method to use a name matching one of the parameter of the method. 
It will avoid potential error following the last update and the arguments merging.