### PR TITLE
Fix Arguments order of the method matter

### DIFF
--- a/src/Config/Parser/MetadataParser/MetadataParser.php
+++ b/src/Config/Parser/MetadataParser/MetadataParser.php
@@ -976,10 +976,12 @@ abstract class MetadataParser implements PreParserInterface
     private static function guessArgs(
         ReflectionClass $reflectionClass,
         ReflectionMethod $method,
-        array $arguments,
+        array $currentArguments,
     ): array {
+        $arguments = [];
         foreach ($method->getParameters() as $index => $parameter) {
-            if (array_key_exists($parameter->getName(), $arguments)) {
+            if (array_key_exists($parameter->getName(), $currentArguments)) {
+                $arguments[$parameter->getName()] = $currentArguments[$parameter->getName()];
                 continue;
             }
 

--- a/tests/Config/Parser/MetadataParserTest.php
+++ b/tests/Config/Parser/MetadataParserTest.php
@@ -361,6 +361,17 @@ abstract class MetadataParserTest extends TestCase
                     'access' => '@=default_access',
                     'public' => '@=default_public',
                 ],
+                'planet_getNextPlanet' => [
+                    'type' => 'Json',
+                    'args' => [
+                        'planetId' => ['type' => 'Int!'],
+                        'minDistance' => ['type' => 'Int!'],
+                        'maxDistance' => ['type' => 'Int!'],
+                    ],
+                    'resolve' => "@=call(service('Overblog\\\\GraphQLBundle\\\\Tests\\\\Config\\\\Parser\\\\fixtures\\\\annotations\\\\Repository\\\\PlanetRepository').getNextPlanet, arguments({planetId: \"Int!\", minDistance: \"Int!\", maxDistance: \"Int!\"}, args))",
+                    'access' => '@=default_access',
+                    'public' => '@=default_public',
+                ],
             ],
         ]);
 
@@ -475,7 +486,7 @@ abstract class MetadataParserTest extends TestCase
                         'away' => ['type' => 'Boolean', 'defaultValue' => false],
                         'maxDistance' => ['type' => 'Float', 'defaultValue' => null],
                     ],
-                    'resolve' => '@=call(value.getCasualties, arguments({raceId: "String!", areaId: "Int!", dayStart: "Int", dayEnd: "Int", nameStartingWith: "String", planet: "PlanetInput", away: "Boolean", maxDistance: "Float"}, args))',
+                    'resolve' => '@=call(value.getCasualties, arguments({areaId: "Int!", raceId: "String!", dayStart: "Int", dayEnd: "Int", nameStartingWith: "String", planet: "PlanetInput", away: "Boolean", maxDistance: "Float"}, args))',
                     'complexity' => '@=childrenComplexity * 5',
                 ],
             ],

--- a/tests/Config/Parser/fixtures/annotations/Repository/PlanetRepository.php
+++ b/tests/Config/Parser/fixtures/annotations/Repository/PlanetRepository.php
@@ -120,4 +120,22 @@ final class PlanetRepository
     {
         return 10;
     }
+
+    /**
+     * @GQL\Query(type="Json")
+     *
+     * @GQL\Arg(name="maxDistance", type="Int!")
+     * @GQL\Arg(name="planetId", type="Int!")
+     */
+    #[GQL\Query(type: 'Json')]
+    #[GQL\Arg(name: 'maxDistance', type: 'Int!')]
+    #[GQL\Arg(name: 'planetId', type: 'Int!')]
+    public function getNextPlanet(int $planetId, int $minDistance, int $maxDistance): array
+    {
+        return [
+            'planetId' => $planetId,
+            'minDistance' => $minDistance,
+            'maxDistance' => $maxDistance,
+        ];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #1177
| License       | MIT

Ensure, the argument are declared in the same order as the related method. 