### PR TITLE
Don't validate fields that were not passed

### DIFF
--- a/src/Validator/InputValidator.php
+++ b/src/Validator/InputValidator.php
@@ -144,6 +144,7 @@ final class InputValidator
                 continue;
             }
             
+            
             $config = static::normalizeConfig($arg['validation'] ?? []);
 
             if (isset($config['cascade']) && isset($inputData[$property])) {
@@ -181,7 +182,6 @@ final class InputValidator
                             /** @phpstan-ignore-next-line */
                             $this->cachedMetadata[$fqcn] = $this->defaultValidator->getMetadataFor($fqcn);
                         }
-
 
                         // Get metadata from the property and it's getters
                         $propertyMetadata = $this->cachedMetadata[$fqcn]->getPropertyMetadata($classProperty);

--- a/src/Validator/InputValidator.php
+++ b/src/Validator/InputValidator.php
@@ -182,6 +182,7 @@ final class InputValidator
                             $this->cachedMetadata[$fqcn] = $this->defaultValidator->getMetadataFor($fqcn);
                         }
 
+
                         // Get metadata from the property and it's getters
                         $propertyMetadata = $this->cachedMetadata[$fqcn]->getPropertyMetadata($classProperty);
 

--- a/src/Validator/InputValidator.php
+++ b/src/Validator/InputValidator.php
@@ -138,14 +138,12 @@ final class InputValidator
 
         foreach ($fields as $name => $arg) {
             $property = $arg['name'] ?? $name;
+            $config = static::normalizeConfig($arg['validation'] ?? []);
 
             if (!array_key_exists($property, $inputData)) {
                 // This field was not provided in the inputData. Do not attempt to validate it.
                 continue;
             }
-            
-            
-            $config = static::normalizeConfig($arg['validation'] ?? []);
 
             if (isset($config['cascade']) && isset($inputData[$property])) {
                 $groups = $config['cascade'];

--- a/src/Validator/InputValidator.php
+++ b/src/Validator/InputValidator.php
@@ -138,6 +138,12 @@ final class InputValidator
 
         foreach ($fields as $name => $arg) {
             $property = $arg['name'] ?? $name;
+
+            if (!array_key_exists($property, $inputData)) {
+                // This field was not provided in the inputData. Do not attempt to validate it.
+                continue;
+            }
+            
             $config = static::normalizeConfig($arg['validation'] ?? []);
 
             if (isset($config['cascade']) && isset($inputData[$property])) {

--- a/tests/Functional/App/config/validator/mapping/Mutation.types.yml
+++ b/tests/Functional/App/config/validator/mapping/Mutation.types.yml
@@ -138,3 +138,11 @@ Mutation:
                         validation:
                             cascade:
                                 groups: ['group2']
+
+            onlyPassedFieldsValidation:
+                type: Boolean
+                resolve: '@=m("mutation_mock", args)'
+                args:
+                    person:
+                        validation: cascade
+                        type: Person!

--- a/tests/Functional/App/config/validator/mapping/Person.types.yml
+++ b/tests/Functional/App/config/validator/mapping/Person.types.yml
@@ -1,0 +1,14 @@
+Person:
+    type: input-object
+    config:
+        fields:
+            firstName:
+                type: String
+                validation:
+                    - NotBlank: ~
+                    - NotNull: ~
+            surname:
+                type: String
+                validation:
+                    - NotBlank: ~
+                    - NotNull: ~

--- a/tests/Functional/Validator/InputValidatorTest.php
+++ b/tests/Functional/Validator/InputValidatorTest.php
@@ -87,6 +87,22 @@ final class InputValidatorTest extends TestCase
         $this->assertTrue($result['data']['linkedConstraintsValidation']);
     }
 
+    public function testOnlyPassedFieldsValidated(): void
+    {
+        $query = '
+            mutation {
+                onlyPassedFieldsValidation(
+                    person: { firstName: "Joe" }
+                )
+            }
+        ';
+
+        $result = $this->executeGraphQLRequest($query);
+
+        $this->assertTrue(empty($result['errors']));
+        $this->assertTrue($result['data']['onlyPassedFieldsValidation']);
+    }
+
     public function testLinkedConstraintsValidationFails(): void
     {
         $query = '


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Documented?   | no
| Fixed tickets | https://github.com/overblog/GraphQLBundle/issues/1182
| License       | MIT

This fixes the validation rules so that when passing a partial input object, only the fields passed are validated.
