### PR TITLE
Support Symfony 7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           - '6.2.*'
           - '6.4.*'
           - '7.0.*'
+          - '7.1.*'
         dependencies:
           - 'lowest'
           - 'highest'
@@ -38,8 +39,12 @@ jobs:
             symfony-version: '6.4.*'
           - php-version: '8.0'
             symfony-version: '7.0.*'
+          - php-version: '8.0'
+            symfony-version: '7.1.*'
           - php-version: '8.1'
             symfony-version: '7.0.*'
+          - php-version: '8.1'
+            symfony-version: '7.1.*'
         include:
           - php-version: '8.0'
             symfony-version: '5.4.*'

--- a/src/DependencyInjection/OverblogGraphQLExtension.php
+++ b/src/DependencyInjection/OverblogGraphQLExtension.php
@@ -26,10 +26,10 @@ use Overblog\GraphQLBundle\Request\Executor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 use function realpath;
 use function sprintf;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #1187 
| License       | MIT

With Symfony 7.1, `Symfony\Component\HttpKernel\DependencyInjection\Extension` is made for internal (Symfony) use only. This needs to be replaced with `Symfony\Component\DependencyInjection\Extension\Extension`.

No breaking changes with this deprecation update.
