### PR TITLE
Restrict to send JSON request as string (object expected)

### DIFF
--- a/src/Request/Parser.php
+++ b/src/Request/Parser.php
@@ -54,7 +54,7 @@ final class Parser implements ParserInterface
 
                 $parsedBody = json_decode($body, true);
 
-                if (JSON_ERROR_NONE !== json_last_error()) {
+                if (JSON_ERROR_NONE !== json_last_error() || is_string($parsedBody)) {
                     throw new BadRequestHttpException('POST body sent invalid JSON');
                 }
                 break;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | 
| License       | MIT

Return value of getParsedBody must be array. But passed string will cause TypeError

Example

```
fetch("ENDPOINT", {
  "headers": {
    "content-type": "application/json",
  },
  "body": "111",
  "method": "POST"
});
```
