### PR TITLE
ResolveInfo injection in Query

### DIFF
--- a/src/Transformer/ArgumentsTransformer.php
+++ b/src/Transformer/ArgumentsTransformer.php
@@ -28,6 +28,8 @@ use function substr;
 
 final class ArgumentsTransformer
 {
+    public const RESOLVE_INFO_TOKEN = '#ResolveInfo';
+
     private PropertyAccessor $accessor;
     private ?ValidatorInterface $validator;
     private array $classesMap;
@@ -190,6 +192,10 @@ final class ArgumentsTransformer
 
         foreach ($mapping as $name => $type) {
             try {
+                if (self::RESOLVE_INFO_TOKEN === $type) {
+                    $args[] = $info;
+                    continue;
+                }
                 $value = $this->getInstanceAndValidate($type, $data[$name], $info, $name);
                 $args[] = $value;
             } catch (InvalidArgumentError $exception) {

--- a/tests/Config/Parser/MetadataParserTest.php
+++ b/tests/Config/Parser/MetadataParserTest.php
@@ -372,6 +372,15 @@ abstract class MetadataParserTest extends TestCase
                     'access' => '@=default_access',
                     'public' => '@=default_public',
                 ],
+                'planet_isHabitablePlanet' => [
+                    'type' => 'Boolean!',
+                    'args' => [
+                        'planetId' => ['type' => 'Int!'],
+                    ],
+                    'resolve' => "@=call(service('Overblog\\\\GraphQLBundle\\\\Tests\\\\Config\\\\Parser\\\\fixtures\\\\annotations\\\\Repository\\\\PlanetRepository').isHabitablePlanet, arguments({planetId: \"Int!\", info: \"#ResolveInfo\"}, args))",
+                    'access' => '@=default_access',
+                    'public' => '@=default_public',
+                ],
             ],
         ]);
 

--- a/tests/Config/Parser/fixtures/annotations/Repository/PlanetRepository.php
+++ b/tests/Config/Parser/fixtures/annotations/Repository/PlanetRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Repository;
 
+use GraphQL\Type\Definition\ResolveInfo;
 use Overblog\GraphQLBundle\Annotation as GQL;
 use Overblog\GraphQLBundle\Tests\Config\Parser\fixtures\annotations\Type\Planet;
 
@@ -137,5 +138,14 @@ final class PlanetRepository
             'minDistance' => $minDistance,
             'maxDistance' => $maxDistance,
         ];
+    }
+
+    /**
+     * @GQL\Query
+     */
+    #[GQL\Query]
+    public function isHabitablePlanet(int $planetId, ResolveInfo $info): bool
+    {
+        return true;
     }
 }

--- a/tests/Transformer/ArgumentsTransformerTest.php
+++ b/tests/Transformer/ArgumentsTransformerTest.php
@@ -37,7 +37,7 @@ final class ArgumentsTransformerTest extends TestCase
         }
     }
 
-    private function getTransformer(array $classesMap = null, ConstraintViolationList $validateReturn = null): ArgumentsTransformer
+    private function getTransformer(array $classesMap = [], ConstraintViolationList $validateReturn = null): ArgumentsTransformer
     {
         $validator = $this->createMock(RecursiveValidator::class);
         $validator->method('validate')->willReturn($validateReturn ?? new ConstraintViolationList());
@@ -454,5 +454,15 @@ final class ArgumentsTransformerTest extends TestCase
         $typeValue = $transformer->getInstanceAndValidate('Type1', $data, $info, 'type1');
 
         $this->assertEquals($data, $typeValue);
+    }
+
+    public function testResolveInfoInjection(): void
+    {
+        $transformer = $this->getTransformer();
+        $resolveInfo = $this->getResolveInfo([]);
+
+        $result = $transformer->getArguments(['resolveInfo' => ArgumentsTransformer::RESOLVE_INFO_TOKEN], [], $resolveInfo);
+
+        $this->assertTrue($result[0] === $resolveInfo);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | yes
| Fixed tickets | #1186 
| License       | MIT

This PR allows to inject the `ResolveInfo` into a query or mutation just by adding it to the list of auto-guessed arguments.  

Exemple:

````php
#[Query]
public function test(int $id, ResolveInfo $info) {

}
````

It only works with annotations/attributes and auto-guess parameters when the query resolver is auto-generated. 
