### PR TITLE
add kernel.reset tag to allow clearing memory between request

### DIFF
--- a/src/Request/Executor.php
+++ b/src/Request/Executor.php
@@ -196,4 +196,9 @@ class Executor
             Events::POST_EXECUTOR
         )->getResult();
     }
+
+    public function reset(): void
+    {
+        $this->schemas = [];
+    }
 }

--- a/src/Resolver/TypeResolver.php
+++ b/src/Resolver/TypeResolver.php
@@ -76,6 +76,11 @@ class TypeResolver extends AbstractResolver
         return $type;
     }
 
+    public function reset(): void
+    {
+        $this->cache = [];
+    }
+
     protected function supportedSolutionClass(): ?string
     {
         return Type::class;

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -21,6 +21,8 @@ services:
         calls:
             - ["setMaxQueryComplexity", ["%overblog_graphql.query_max_complexity%"]]
             - ["setMaxQueryDepth", ["%overblog_graphql.query_max_depth%"]]
+        tags:
+            - { name: kernel.reset, method: reset }
 
     Overblog\GraphQLBundle\Definition\Builder\SchemaBuilder:
         arguments:
@@ -37,6 +39,7 @@ services:
             - ["setDispatcher", ["@event_dispatcher"]]
         tags:
             - { name: overblog_graphql.service, alias: typeResolver }
+            - { name: kernel.reset, method: reset }
 
     Overblog\GraphQLBundle\Transformer\ArgumentsTransformer:
         arguments:


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | 
| License       | MIT

When you run your application in an environment like FrankenPHP, RoadRunner etc, then you need to clear memory from one request to another. Using tag `kernel.reset` is the best way to tell Symfony to run the `reset()` method between requests. 
