### PR TITLE
perf: less memory allocation in `TypeGenerator::compile`

### DIFF
--- a/src/Generator/TypeGenerator.php
+++ b/src/Generator/TypeGenerator.php
@@ -59,7 +59,7 @@ final class TypeGenerator
             $config['config']['name'] ??= $name;
             $config['config']['class_name'] = $config['class_name'];
             $classMap = $this->generateClass($config, $cacheDir, $mode);
-            $classes = array_merge($classes, $classMap);
+            $classes[$classMap[0]] = $classMap[1];
         }
 
         // Create class map file
@@ -97,7 +97,7 @@ final class TypeGenerator
 
         $namespace = $this->options->namespace;
 
-        return ["$namespace\\$className" => $path];
+        return ["$namespace\\$className", $path];
     }
 
     public function loadClasses(bool $forceReload = false): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | maybe
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

We have over 1000 classes with GraphQL generation. 
On `php symfony/console cache:warmup` the memory allocation looks awful for this part.



on main:
![3](https://github.com/user-attachments/assets/57f9fd7f-2ea1-4108-83e8-8db641927974)

this PR:
![2](https://github.com/user-attachments/assets/e304ed7b-6956-47bd-9dd3-c46e7578b6db)




