### PR TITLE
fix: preserve zero fraction during response json encoding

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -431,16 +431,6 @@ parameters:
 			path: tests/Functional/Command/ValidateCommandTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
-			count: 5
-			path: tests/Functional/Controller/GraphControllerTest.php
-
-		-
-			message: "#^Parameter \\#3 \\$message of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\) expects string, string\\|false given\\.$#"
-			count: 5
-			path: tests/Functional/Controller/GraphControllerTest.php
-
-		-
 			message: "#^Method Overblog\\\\GraphQLBundle\\\\Tests\\\\Functional\\\\BaseTestCase\\:\\:createKernel\\(\\) should return Symfony\\\\Component\\\\HttpKernel\\\\KernelInterface but returns object\\.$#"
 			count: 1
 			path: tests/Functional/BaseTestCase.php

--- a/src/Controller/GraphController.php
+++ b/src/Controller/GraphController.php
@@ -64,7 +64,7 @@ final class GraphController
             }
             $payload = $this->processQuery($request, $schemaName, $batched);
             $response = new JsonResponse('', 200);
-            $response->setEncodingOptions(JsonResponse::DEFAULT_ENCODING_OPTIONS|JSON_PRESERVE_ZERO_FRACTION);
+            $response->setEncodingOptions(JsonResponse::DEFAULT_ENCODING_OPTIONS | JSON_PRESERVE_ZERO_FRACTION);
             $response->setData($payload);
         }
         $this->addCORSHeadersIfNeeded($response, $request);

--- a/src/Controller/GraphController.php
+++ b/src/Controller/GraphController.php
@@ -63,7 +63,9 @@ final class GraphController
                 return new JsonResponse('', 405);
             }
             $payload = $this->processQuery($request, $schemaName, $batched);
-            $response = new JsonResponse($payload, 200);
+            $response = new JsonResponse('', 200);
+            $response->setEncodingOptions(JsonResponse::DEFAULT_ENCODING_OPTIONS|JSON_PRESERVE_ZERO_FRACTION);
+            $response->setData($payload);
         }
         $this->addCORSHeadersIfNeeded($response, $request);
 

--- a/tests/Functional/App/config/preserveFloats/config.yml
+++ b/tests/Functional/App/config/preserveFloats/config.yml
@@ -1,0 +1,15 @@
+imports:
+    - { resource: ../config.yml }
+    - { resource: ../exception/services.yml }
+
+overblog_graphql:
+    definitions:
+        class_namespace: "Overblog\\GraphQLBundle\\PreserveFloats\\__DEFINITIONS__"
+        schema:
+            query: RootQuery
+            mutation: RootQuery
+        mappings:
+            types:
+                -
+                    type: yaml
+                    dir: "%kernel.project_dir%/config/preserveFloats/mapping"

--- a/tests/Functional/App/config/preserveFloats/mapping/RootQuery.types.yml
+++ b/tests/Functional/App/config/preserveFloats/mapping/RootQuery.types.yml
@@ -1,0 +1,7 @@
+RootQuery:
+    type: object
+    config:
+        fields:
+            float:
+                type: Float
+                resolve: '1.0'

--- a/tests/Functional/Controller/GraphControllerTest.php
+++ b/tests/Functional/Controller/GraphControllerTest.php
@@ -164,6 +164,16 @@ final class GraphControllerTest extends TestCase
         $client->request('GET', '/', ['query' => $query, 'variables' => '"firstFriends": 2}']);
     }
 
+    public function testEndpointActionPreservesFloats(): void
+    {
+        $client = static::createClient(['test_case' => 'preserveFloats']);
+        $this->disableCatchExceptions($client);
+
+        $client->request('GET', '/', ['query' => 'query { float }'], [], ['CONTENT_TYPE' => 'application/graphql;charset=utf8', 'HTTP_Origin' => 'http://example.com']);
+        $result = $client->getResponse()->getContent();
+        $this->assertSame(['data' => ['float' => 1.0]], json_decode($result, true), $result);
+    }
+
     public function testMultipleEndpointActionWithUnknownSchemaName(): void
     {
         $this->expectException(NotFoundHttpException::class);

--- a/tests/Functional/Controller/GraphControllerTest.php
+++ b/tests/Functional/Controller/GraphControllerTest.php
@@ -6,6 +6,7 @@ namespace Overblog\GraphQLBundle\Tests\Functional\Controller;
 
 use Overblog\GraphQLBundle\Tests\Functional\TestCase;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -71,8 +72,8 @@ final class GraphControllerTest extends TestCase
         $this->disableCatchExceptions($client);
 
         $client->request('GET', $uri, ['query' => $this->friendsQuery], [], ['CONTENT_TYPE' => 'application/graphql;charset=utf8', 'HTTP_Origin' => 'http://example.com']);
-        $result = $client->getResponse()->getContent();
-        $this->assertSame(['data' => $this->expectedData], json_decode($result, true), $result);
+        $result = self::decodeResponse($client->getResponse());
+        $this->assertSame(['data' => $this->expectedData], $result);
         $this->assertCORSHeadersExists($client);
     }
 
@@ -108,8 +109,9 @@ final class GraphControllerTest extends TestCase
         $client = static::createClient(['test_case' => 'connectionWithCORS']);
         $this->disableCatchExceptions($client);
         $client->request('GET', '/', ['query' => $this->friendsQuery], [], ['CONTENT_TYPE' => 'application/json']);
-        $result = $client->getResponse()->getContent();
-        $this->assertSame(['data' => $this->expectedData], json_decode($result, true), $result);
+        $result = self::decodeResponse($client->getResponse());
+
+        $this->assertSame(['data' => $this->expectedData], $result);
     }
 
     public function testEndpointWithInvalidBodyQuery(): void
@@ -170,8 +172,9 @@ final class GraphControllerTest extends TestCase
         $this->disableCatchExceptions($client);
 
         $client->request('GET', '/', ['query' => 'query { float }'], [], ['CONTENT_TYPE' => 'application/graphql;charset=utf8', 'HTTP_Origin' => 'http://example.com']);
-        $result = $client->getResponse()->getContent();
-        $this->assertSame(['data' => ['float' => 1.0]], json_decode($result, true), $result);
+        $result = self::decodeResponse($client->getResponse());
+
+        $this->assertSame(['data' => ['float' => 1.0]], $result);
     }
 
     public function testMultipleEndpointActionWithUnknownSchemaName(): void
@@ -198,8 +201,9 @@ final class GraphControllerTest extends TestCase
         $query = $this->friendsQuery."\n".$this->friendsTotalCountQuery;
 
         $client->request('POST', '/', ['query' => $query, 'operationName' => 'FriendsQuery'], [], ['CONTENT_TYPE' => 'application/x-www-form-urlencoded']);
-        $result = $client->getResponse()->getContent();
-        $this->assertSame(['data' => $this->expectedData], json_decode($result, true), $result);
+        $result = self::decodeResponse($client->getResponse());
+
+        $this->assertSame(['data' => $this->expectedData], $result);
     }
 
     /**
@@ -223,13 +227,13 @@ final class GraphControllerTest extends TestCase
 
         $content = json_encode($data) ?: null;
         $client->request('POST', $uri, [], [], ['CONTENT_TYPE' => 'application/json'], $content);
-        $result = $client->getResponse()->getContent();
+        $result = self::decodeResponse($client->getResponse());
 
         $expected = [
             ['id' => 'friends', 'payload' => ['data' => $this->expectedData]],
             ['id' => 'friendsTotalCount', 'payload' => ['data' => ['user' => ['friends' => ['totalCount' => 4]]]]],
         ];
-        $this->assertSame($expected, json_decode($result, true), $result);
+        $this->assertSame($expected, $result);
     }
 
     public function graphQLBatchEndpointUriProvider(): array
@@ -311,8 +315,8 @@ final class GraphControllerTest extends TestCase
         $client = static::createClient(['test_case' => 'connectionWithCORS']);
         $this->disableCatchExceptions($client);
         $client->request('GET', '/', ['query' => $this->friendsQuery], [], ['CONTENT_TYPE' => 'application/graphql']);
-        $result = $client->getResponse()->getContent();
-        $this->assertSame(['data' => $this->expectedData], json_decode($result, true), $result);
+        $result = self::decodeResponse($client->getResponse());
+        $this->assertSame(['data' => $this->expectedData], $result);
         $this->assertCORSHeadersNotExists($client);
     }
 
@@ -341,5 +345,15 @@ final class GraphControllerTest extends TestCase
         $this->assertSame('true', $response->headers->get('Access-Control-Allow-Credentials'));
         $this->assertSame('Content-Type, Authorization', $response->headers->get('Access-Control-Allow-Headers'));
         $this->assertSame('3600', $response->headers->get('Access-Control-Max-Age'));
+    }
+
+    private static function decodeResponse(Response $response): array
+    {
+        $result = $response->getContent();
+        self::assertIsString($result);
+        $result = json_decode($result, true);
+        self::assertNotNull($result);
+
+        return $result;
     }
 }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? |no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | 
| License       | MIT

Fix zero-fraction floats (1.0) losing their fraction during json_encode, resulting in '1'.
