### PR TITLE
Fix isAnonymous() always returning false on Symfony 6.x

### DIFF
--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -104,7 +104,9 @@ abstract class BaseSecurity
 
     public function isAnonymous(): bool
     {
-        return $this->isGranted('IS_AUTHENTICATED_ANONYMOUSLY');
+        // IS_AUTHENTICATED_ANONYMOUSLY was removed from AuthenticatedVoter in Symfony 6.x.
+        // PUBLIC_ACCESS (added in Symfony 5.4) is the correct replacement and always grants access.
+        return $this->isGranted(Kernel::VERSION_ID >= 60000 ? 'PUBLIC_ACCESS' : 'IS_AUTHENTICATED_ANONYMOUSLY');
     }
 
     public function isAuthenticated(): bool

--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -104,9 +104,7 @@ abstract class BaseSecurity
 
     public function isAnonymous(): bool
     {
-        // IS_AUTHENTICATED_ANONYMOUSLY was removed from AuthenticatedVoter in Symfony 6.x.
-        // PUBLIC_ACCESS (added in Symfony 5.4) is the correct replacement and always grants access.
-        return $this->isGranted(Kernel::VERSION_ID >= 60000 ? 'PUBLIC_ACCESS' : 'IS_AUTHENTICATED_ANONYMOUSLY');
+        return $this->isGranted('PUBLIC_ACCESS');
     }
 
     public function isAuthenticated(): bool

--- a/tests/ExpressionLanguage/ExpressionFunction/Security/IsAnonymousTest.php
+++ b/tests/ExpressionLanguage/ExpressionFunction/Security/IsAnonymousTest.php
@@ -17,10 +17,7 @@ final class IsAnonymousTest extends TestCase
 
     public function testEvaluator(): void
     {
-        $security = $this->getSecurityIsGrantedWithExpectation(
-            'IS_AUTHENTICATED_ANONYMOUSLY',
-            $this->any()
-        );
+        $security = $this->getSecurityIsGrantedWithExpectation('PUBLIC_ACCESS', $this->any());
         $services = $this->createGraphQLServices(['security' => $security]);
 
         $isAnonymous = $this->expressionLanguage->evaluate('isAnonymous()', [TypeGenerator::GRAPHQL_SERVICES => $services]);
@@ -29,6 +26,6 @@ final class IsAnonymousTest extends TestCase
 
     public function testIsAnonymous(): void
     {
-        $this->assertExpressionCompile('isAnonymous()', 'IS_AUTHENTICATED_ANONYMOUSLY');
+        $this->assertExpressionCompile('isAnonymous()', 'PUBLIC_ACCESS');
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1205

`BaseSecurity::isAnonymous()` calls `isGranted('IS_AUTHENTICATED_ANONYMOUSLY')`, which was removed from `AuthenticatedVoter` in Symfony 6.x (deprecated since 5.4) : https://github.com/symfony/symfony/blob/6.0/UPGRADE-6.0.md#security:~:text=Remove%20AuthenticatedVoter%3A%3AIS_AUTHENTICATED_ANONYMOUSLY%20and%20AuthenticatedVoter%3A%3AIS_ANONYMOUS%2C%20use%20AuthenticatedVoter%3A%3APUBLIC_ACCESS%20instead.

The access decision manager does not work and returns `false`. Every field annotated with `#[GQL\Access('isAnonymous()')]` gets "Access denied to this field" for all requests.

The fix uses `PUBLIC_ACCESS` on Symfony 6.x, which has the same behavior (`IS_AUTHENTICATED_ANONYMOUSLY` and `PUBLIC_ACCESS` both always grant access) and is the [official replacement](https://symfony.com/doc/6.4/security.html#checking-to-see-if-a-user-is-logged-in-is-authenticated-fully).

## Changes

- `src/Security/Security.php`: use `PUBLIC_ACCESS` on Symfony >= 6.0, keep `IS_AUTHENTICATED_ANONYMOUSLY` for 5.x

## Reproduction

A minimal reproduction repo is available at: https://github.com/mfaivre-simplis/graphqlbundle-issue-1205

```php
#[GQL\Provider]
#[GQL\Access('isAnonymous()')]
final readonly class ConnectedUserQuery
{
    #[GQL\Query(name: 'connectedUser', type: 'Boolean!')]
    #[GQL\Access('isAnonymous()')]
    public function __invoke(): bool
    {
        return true;
    }
}
```

With Symfony 6.x, querying `{ connectedUser }` always returns `"Access denied to this field"` before this fix.