### PR TITLE
fix: make profiler configurable and disable it by default in non-debug mode

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -311,6 +311,7 @@ final class Configuration implements ConfigurationInterface
 
         // @phpstan-ignore-next-line
         $node
+            ->{$this->debug ? 'canBeDisabled' : 'canBeEnabled'}()
             ->addDefaultsIfNotSet()
             ->children()
                 ->scalarNode('query_match')->defaultNull()->end()

--- a/src/DependencyInjection/OverblogGraphQLExtension.php
+++ b/src/DependencyInjection/OverblogGraphQLExtension.php
@@ -38,10 +38,10 @@ final class OverblogGraphQLExtension extends Extension
 {
     public function load(array $configs, ContainerBuilder $container): void
     {
-        $this->loadConfigFiles($container);
         $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
 
+        $this->loadConfigFiles($config, $container);
         $this->setBatchingMethod($config, $container);
         $this->setServicesAliases($config, $container);
         $this->setSchemaBuilderArguments($config, $container);
@@ -75,7 +75,7 @@ final class OverblogGraphQLExtension extends Extension
         );
     }
 
-    private function loadConfigFiles(ContainerBuilder $container): void
+    private function loadConfigFiles(array $config, ContainerBuilder $container): void
     {
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yaml');
@@ -86,7 +86,10 @@ final class OverblogGraphQLExtension extends Extension
         $loader->load('expression_language_functions.yaml');
         $loader->load('definition_config_processors.yaml');
         $loader->load('aliases.yaml');
-        $loader->load('profiler.yaml');
+
+        if ($config['profiler']['enabled']) {
+            $loader->load('profiler.yaml');
+        }
     }
 
     private function registerForAutoconfiguration(ContainerBuilder $container): void
@@ -143,6 +146,10 @@ final class OverblogGraphQLExtension extends Extension
 
     private function setProfilerParameters(array $config, ContainerBuilder $container): void
     {
+        if (!$config['profiler']['enabled']) {
+            return;
+        }
+
         $container->setParameter($this->getAlias().'.profiler.query_match', $config['profiler']['query_match']);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | maybe
| Documented?   | no
| Fixed tickets | no
| License       | MIT

**Summary**
The profiler.yaml configuration was loaded unconditionally in OverblogGraphQLExtension::loadConfigFiles(), registering GraphQLCollector and ProfilerController in all environments — including production.

While the data_collector tag is harmless when the profiler is disabled (Symfony's ProfilerPass simply skips it), the kernel.event_listener tag on graphql.post_executor is processed by RegisterListenersPass independently.

This means GraphQLCollector::onPostExecutor() fired **on every GraphQL request in production**, performing:

  - Parser::parse() — re-parsing the full GraphQL query into an AST
  - $this->cloneVar($variables) — deep-cloning all query variables via Symfony's VarCloner
  - $this->cloneVar($result) — deep-cloning the entire GraphQL response
  - AST traversal of all operation definitions and fields

All this data was accumulated into $this->batches and never consumed, since collect() is only called by Symfony when the profiler is enabled.

**Impact**
  - Eliminates unnecessary CPU overhead (query parsing + deep cloning) on every production GraphQL request
  - Reduces memory usage from cloned result objects that were never read
  - Removes an unused public controller endpoint (ProfilerController) from production
