### PR TITLE
fix: sort YAML config files by name for deterministic schema order

### DIFF
--- a/src/DependencyInjection/Compiler/ConfigParserPass.php
+++ b/src/DependencyInjection/Compiler/ConfigParserPass.php
@@ -257,7 +257,7 @@ final class ConfigParserPass implements CompilerPassInterface
         foreach ($types as $type) {
             $finder = Finder::create();
             try {
-                $finder->files()->in($path)->name(sprintf('*%s.%s', $suffix, self::SUPPORTED_TYPES_EXTENSIONS[$type]));
+                $finder->files()->in($path)->name(sprintf('*%s.%s', $suffix, self::SUPPORTED_TYPES_EXTENSIONS[$type]))->sortByName();
             } catch (InvalidArgumentException $e) {
                 continue;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| License       | MIT

`ConfigParserPass::detectFilesByTypes()` uses `Symfony\Finder` without sorting, so the discovery order of YAML/GraphQL config files follows the  underlying filesystem's readdir order.                                                                                                                   
                                                                                                                                                           
This order differs between filesystems — notably between APFS (macOS) accessed via VirtioFS in Docker Desktop, and ext4 on a Linux CI runner. The resulting schemas are functionally identical but contain fields and types declared in a different order. 

 ## Impact                                                                                                                                                
                                                                                                                                                           
Teams running a `git diff --exit-code schema.graphql` check in CI see false positives: a developer regenerates the schema locally on macOS, commits it, and CI fails on Linux with a large reorder-only diff — even though no source change was made.
                                                                                               
  ## Fix                                                                                                                                                   
                                                                                                                                                           
 Add `->sortByName()` to the Finder so file discovery is alphabetical, stable, and platform-independent.