### PR TITLE
fix: resolve enable_introspection env variable at runtime (#1211)

### DIFF
--- a/src/DependencyInjection/OverblogGraphQLExtension.php
+++ b/src/DependencyInjection/OverblogGraphQLExtension.php
@@ -182,15 +182,17 @@ final class OverblogGraphQLExtension extends Extension
     private function setSecurity(array $config, ContainerBuilder $container): void
     {
         $executorDefinition = $container->getDefinition(Executor::class);
-        if ($config['security']['enable_introspection']) {
-            $executorDefinition->addMethodCall('enableIntrospectionQuery');
-        } else {
-            $executorDefinition->addMethodCall('disableIntrospectionQuery');
-        }
 
         foreach ($config['security'] as $key => $value) {
             $container->setParameter(sprintf('%s.%s', $this->getAlias(), $key), $value);
         }
+
+        // Pass the parameter reference (not the compile-time value) so that an
+        // "enable_introspection" backed by an env variable is resolved at
+        // runtime instead of always evaluating truthy as a placeholder string.
+        $executorDefinition->addMethodCall('setIntrospectionQueryEnabled', [
+            sprintf('%%%s.enable_introspection%%', $this->getAlias()),
+        ]);
     }
 
     private function setErrorHandler(array $config, ContainerBuilder $container): void

--- a/src/Request/Executor.php
+++ b/src/Request/Executor.php
@@ -117,12 +117,22 @@ class Executor
 
     public function enableIntrospectionQuery(): void
     {
-        DocumentValidator::addRule(new DisableIntrospection(DisableIntrospection::DISABLED));
+        $this->setIntrospectionQueryEnabled(true);
     }
 
     public function disableIntrospectionQuery(): void
     {
-        DocumentValidator::addRule(new DisableIntrospection(DisableIntrospection::ENABLED));
+        $this->setIntrospectionQueryEnabled(false);
+    }
+
+    /**
+     * Toggles the introspection query at runtime so the value can be provided by
+     * an environment variable (resolved when the service is instantiated) rather
+     * than being evaluated at container-compile time.
+     */
+    public function setIntrospectionQueryEnabled(bool $enabled): void
+    {
+        DocumentValidator::addRule(new DisableIntrospection($enabled ? DisableIntrospection::DISABLED : DisableIntrospection::ENABLED));
     }
 
     /**

--- a/tests/Functional/App/config/enableIntrospectionEnvVar/config.yml
+++ b/tests/Functional/App/config/enableIntrospectionEnvVar/config.yml
@@ -1,0 +1,17 @@
+imports:
+    - { resource: ../config.yml }
+    - { resource: ../connection/services.yml }
+
+overblog_graphql:
+    security:
+        enable_introspection: '%env(bool:GRAPHQL_ENABLE_INTROSPECTION)%'
+    definitions:
+        class_namespace: "Overblog\\GraphQLBundle\\IntrospectionEnvVar\\__DEFINITIONS__"
+        schema:
+            query: Query
+            mutation: ~
+        mappings:
+            types:
+                -
+                    type: yaml
+                    dir: "%kernel.project_dir%/config/queryComplexity/mapping"

--- a/tests/Functional/Security/EnableIntrospectionEnvVarTest.php
+++ b/tests/Functional/Security/EnableIntrospectionEnvVarTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Overblog\GraphQLBundle\Tests\Functional\Security;
+
+use Overblog\GraphQLBundle\Tests\Functional\TestCase;
+
+use function putenv;
+
+/**
+ * When "enable_introspection" is backed by an environment variable, the value
+ * must be resolved at runtime. Before the fix it was evaluated at
+ * container-compile time as a placeholder string (always truthy), so
+ * introspection stayed enabled regardless of the env variable.
+ *
+ * @see https://github.com/overblog/GraphQLBundle/issues/1211
+ */
+final class EnableIntrospectionEnvVarTest extends TestCase
+{
+    private const ENV_VAR = 'GRAPHQL_ENABLE_INTROSPECTION';
+
+    private string $introspectionQuery = <<<'EOF'
+        query {
+          __schema {
+            types {
+              name
+              description
+            }
+          }
+        }
+        EOF;
+
+    public function testIntrospectionDisabledViaEnvVar(): void
+    {
+        $previous = getenv(self::ENV_VAR);
+        putenv(self::ENV_VAR.'=false');
+        $_ENV[self::ENV_VAR] = 'false';
+        $_SERVER[self::ENV_VAR] = 'false';
+
+        try {
+            $expected = [
+                'errors' => [
+                    [
+                        'message' => 'GraphQL introspection is not allowed, but the query contained __schema or __type',
+                        'locations' => [
+                            [
+                                'line' => 2,
+                                'column' => 3,
+                            ],
+                        ],
+                    ],
+                ],
+            ];
+
+            $this->assertResponse($this->introspectionQuery, $expected, self::ANONYMOUS_USER, 'enableIntrospectionEnvVar');
+        } finally {
+            $this->restoreEnv($previous);
+        }
+    }
+
+    public function testIntrospectionEnabledViaEnvVar(): void
+    {
+        $previous = getenv(self::ENV_VAR);
+        putenv(self::ENV_VAR.'=true');
+        $_ENV[self::ENV_VAR] = 'true';
+        $_SERVER[self::ENV_VAR] = 'true';
+
+        try {
+            $client = self::createClientAuthenticated(self::ANONYMOUS_USER, 'enableIntrospectionEnvVar');
+            $result = self::sendRequest($client, $this->introspectionQuery, true);
+
+            static::assertArrayHasKey('data', $result);
+            static::assertArrayNotHasKey('errors', $result);
+        } finally {
+            $this->restoreEnv($previous);
+        }
+    }
+
+    /**
+     * @param string|false $previous the value returned by getenv() before the test
+     */
+    private function restoreEnv($previous): void
+    {
+        if (false === $previous) {
+            putenv(self::ENV_VAR);
+            unset($_ENV[self::ENV_VAR], $_SERVER[self::ENV_VAR]);
+        } else {
+            putenv(self::ENV_VAR.'='.$previous);
+            $_ENV[self::ENV_VAR] = $previous;
+            $_SERVER[self::ENV_VAR] = $previous;
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #1211
| License       | MIT

### Problem

`security.enable_introspection` was evaluated at container-compile time:

```php
if ($config['security']['enable_introspection']) {
    $executorDefinition->addMethodCall('enableIntrospectionQuery');
} else {
    $executorDefinition->addMethodCall('disableIntrospectionQuery');
}
```

When the option is backed by an environment variable:

```yaml
overblog_graphql:
    security:
        enable_introspection: '%env(bool:GRAPHQL_ENABLE_INTROSPECTION)%'
```

at compile time `$config['security']['enable_introspection']` is still an unresolved
placeholder string (e.g. `env_..._GRAPHQL_ENABLE_INTROSPECTION_...`), which is always
truthy — so introspection stays enabled regardless of the variable.

### Fix

Pass the **parameter reference** to a new `Executor::setIntrospectionQueryEnabled(bool)`
method call. The value — including the env variable — is then resolved when the service
is instantiated at runtime, not at compile time. The existing
`enableIntrospectionQuery()` / `disableIntrospectionQuery()` methods are kept and now
delegate to it, so there is no BC break.

### Test verification (RED → GREEN)

New functional test boots a kernel whose `enable_introspection` is bound to an env
variable, sets it to `false`, and asserts introspection is blocked.

**RED** — on the unmodified branch (fix reverted, test only), the env variable is
ignored and introspection stays enabled:

```
FAILURES!
Tests: 1, Assertions: 1, Failures: 1.
```

**GREEN** — with the fix, both the env-disabled and env-enabled cases pass:

```
OK (2 tests, 3 assertions)
```

Full suite is iso-baseline (the 5 pre-existing `GraphDumpSchemaCommandTest` failures on
`master` are unrelated to this change and stay unchanged): `Tests: 713, Failures: 5`.
