### PR TITLE
fix: avoid critical logs for argument validation failures (#1193)

### DIFF
--- a/src/EventListener/ErrorLoggerListener.php
+++ b/src/EventListener/ErrorLoggerListener.php
@@ -7,6 +7,7 @@ namespace Overblog\GraphQLBundle\EventListener;
 use GraphQL\Error\UserError;
 use Overblog\GraphQLBundle\Error\UserWarning;
 use Overblog\GraphQLBundle\Event\ErrorFormattingEvent;
+use Overblog\GraphQLBundle\Validator\Exception\ArgumentsValidationException;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use Psr\Log\NullLogger;
@@ -45,6 +46,15 @@ final class ErrorLoggerListener
         if ($exception instanceof UserWarning) {
             if ($exception->getPrevious()) {
                 $this->log($exception->getPrevious(), LogLevel::WARNING);
+            }
+
+            return;
+        }
+
+        // Validation failures are client faults, so handle them like UserError.
+        if ($exception instanceof ArgumentsValidationException) {
+            if ($exception->getPrevious()) {
+                $this->log($exception->getPrevious());
             }
 
             return;

--- a/tests/EventListener/ErrorLoggerListenerTest.php
+++ b/tests/EventListener/ErrorLoggerListenerTest.php
@@ -6,21 +6,28 @@ namespace Overblog\GraphQLBundle\Tests\EventListener;
 
 use Exception;
 use Generator;
+use GraphQL\Error\ClientAware;
 use GraphQL\Error\Error;
 use Overblog\GraphQLBundle\Error\UserError;
 use Overblog\GraphQLBundle\Error\UserWarning;
 use Overblog\GraphQLBundle\Event\ErrorFormattingEvent;
 use Overblog\GraphQLBundle\EventListener\ErrorLoggerListener;
+use Overblog\GraphQLBundle\Validator\Exception\ArgumentsValidationException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Validation;
 
+use function class_exists;
 use function sprintf;
 
 final class ErrorLoggerListenerTest extends TestCase
 {
+    private const CLIENT_SAFE_INTERNAL_MESSAGE = 'Safe internal error';
+
     private ErrorLoggerListener $listener;
 
     /**
@@ -60,6 +67,12 @@ final class ErrorLoggerListenerTest extends TestCase
     public static function onErrorFormattingDataProvider(): Generator
     {
         $exception = new Exception('Ko!');
+        $clientSafeInternalException = new class(self::CLIENT_SAFE_INTERNAL_MESSAGE) extends Exception implements ClientAware {
+            public function isClientSafe(): bool
+            {
+                return true;
+            }
+        };
 
         yield [
             new Error('Basic error'),
@@ -96,6 +109,23 @@ final class ErrorLoggerListenerTest extends TestCase
         ];
 
         yield [
+            new Error('Wrapped client-safe internal exception', null, null, [], null, $clientSafeInternalException),
+            fn (TestCase $test) => $test->once(),
+            [
+                LogLevel::CRITICAL,
+                sprintf(
+                    '[GraphQL] %s: %s[%d] (caught throwable) at %s line %s.',
+                    $clientSafeInternalException::class,
+                    self::CLIENT_SAFE_INTERNAL_MESSAGE,
+                    $clientSafeInternalException->getCode(),
+                    __FILE__,
+                    $clientSafeInternalException->getLine()
+                ),
+                ['exception' => $clientSafeInternalException],
+            ],
+        ];
+
+        yield [
             new Error('Wrapped Base UserError with previous', null, null, [], null, new UserError('User error message', 0, $exception)),
             fn (TestCase $test) => $test->once(),
             [
@@ -124,5 +154,29 @@ final class ErrorLoggerListenerTest extends TestCase
                 ['exception' => $exception],
             ],
         ];
+
+        // ArgumentsValidationException requires the optional Symfony validator
+        // component, so skip these cases when it is absent.
+        if (class_exists(Validation::class)) {
+            // Argument validation without a previous cause must NOT be logged
+            // (before the fix it was logged as CRITICAL). See #1193.
+            yield [
+                new Error('Wrapped ArgumentsValidationException without previous', null, null, [], null, new ArgumentsValidationException(new ConstraintViolationList())),
+                fn (TestCase $test) => $test->never(),
+                [fn (TestCase $test) => $test->anything()],
+            ];
+
+            // Argument validation with a previous cause is logged at ERROR,
+            // like a UserError — not CRITICAL. See #1193.
+            yield [
+                new Error('Wrapped ArgumentsValidationException with previous', null, null, [], null, new ArgumentsValidationException(new ConstraintViolationList(), $exception)),
+                fn (TestCase $test) => $test->once(),
+                [
+                    LogLevel::ERROR,
+                    sprintf('[GraphQL] Exception: Ko![0] (caught throwable) at %s line %s.', __FILE__, $exception->getLine()),
+                    ['exception' => $exception],
+                ],
+            ];
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #1193
| License       | MIT

### Problem

`ArgumentsValidationException` represents invalid client input, but
`ErrorLoggerListener` treated it like an unknown server exception and logged it at
`CRITICAL`.

### Fix

Treat `ArgumentsValidationException` like `UserError`: log its previous cause at
`ERROR` when one exists, and do not emit a `CRITICAL` entry for a routine validation
failure without a previous cause.

The condition is deliberately limited to `ArgumentsValidationException`.
Other exceptions implementing `ClientAware` retain their existing `CRITICAL` logging,
because client-safe messages do not necessarily indicate client-caused failures.

### Test verification (RED → GREEN)

The two argument-validation cases fail on the unmodified base because they reach the
`CRITICAL` fallback:

```
FAILURES!
Tests: 11, Assertions: 10, Failures: 2, Risky: 1.
```

An additional regression case failed against the earlier generic `ClientAware`
implementation because the expected `CRITICAL` log was suppressed:

```
FAILURES!
Tests: 11, Assertions: 11, Failures: 1.
Method was expected to be called 1 time, actually called 0 times.
```

With the final scoped implementation:

```
OK (11 tests, 11 assertions)
```

The full suite remains iso-baseline: the same five pre-existing
`GraphDumpSchemaCommandTest` failures occur on `master`; the final run reports
`Tests: 715, Assertions: 1722, Failures: 5, Skipped: 8`.
