### PR TITLE
fix: do not rethrow client-safe exceptions as internal (#1194)

### DIFF
--- a/src/Error/ErrorHandler.php
+++ b/src/Error/ErrorHandler.php
@@ -7,6 +7,7 @@ namespace Overblog\GraphQLBundle\Error;
 use Closure;
 use Error;
 use Exception;
+use GraphQL\Error\ClientAware;
 use GraphQL\Error\DebugFlag;
 use GraphQL\Error\Error as GraphQLError;
 use GraphQL\Error\FormattedError;
@@ -116,6 +117,15 @@ class ErrorHandler
             // user warning
             if ($rawException instanceof UserWarning) {
                 $treatedExceptions['extensions']['warnings'][] = $errorWithConvertedException;
+
+                continue;
+            }
+
+            // client-safe exception (e.g. a validation error): it is not an
+            // internal exception, so it must be formatted like a user error
+            // instead of being rethrown when rethrow_internal_exceptions is on.
+            if ($rawException instanceof ClientAware && $rawException->isClientSafe()) {
+                $treatedExceptions['errors'][] = $errorWithConvertedException;
 
                 continue;
             }

--- a/tests/Error/ErrorHandlerTest.php
+++ b/tests/Error/ErrorHandlerTest.php
@@ -16,10 +16,14 @@ use Overblog\GraphQLBundle\Error\ExceptionConverterInterface;
 use Overblog\GraphQLBundle\Error\UserError;
 use Overblog\GraphQLBundle\Error\UserErrors;
 use Overblog\GraphQLBundle\Error\UserWarning;
+use Overblog\GraphQLBundle\Validator\Exception\ArgumentsValidationException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Validation;
 
+use function class_exists;
 use function is_array;
 use function is_string;
 use function sprintf;
@@ -139,6 +143,34 @@ final class ErrorHandlerTest extends TestCase
             'errors' => [
                 [
                     'message' => 'Error with wrapped user error',
+                ],
+            ],
+        ];
+
+        $this->assertSame($expected, $executionResult->toArray());
+    }
+
+    public function testMaskErrorWithWrappedClientSafeExceptionAndThrowExceptionSetToTrue(): void
+    {
+        if (!class_exists(Validation::class)) {
+            $this->markTestSkipped('Symfony validator component is not installed');
+        }
+
+        // A client-safe exception (e.g. a validation error) is not internal, so it
+        // must be formatted like a user error, not rethrown. See #1194.
+        $executionResult = new ExecutionResult(
+            null,
+            [
+                new GraphQLError('Error with wrapped validation error', null, null, [], null, new ArgumentsValidationException(new ConstraintViolationList())),
+            ]
+        );
+
+        $this->errorHandler->handleErrors($executionResult, true);
+
+        $expected = [
+            'errors' => [
+                [
+                    'message' => 'Error with wrapped validation error',
                 ],
             ],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documented?   | no
| Fixed tickets | #1194
| License       | MIT

### Problem

With `errors_handler.rethrow_internal_exceptions` enabled, `ErrorHandler::treatExceptions()`
rethrows every exception that is not a `UserError` or a `UserWarning`:

```php
if ($rawException instanceof GraphQLUserError) { ...; continue; }
if ($rawException instanceof UserWarning)     { ...; continue; }

if ($throwRawException) {
    throw $rawException;
}
```

The option is documented as *"re-throw internal exception"*, but a client-safe exception
such as `ArgumentsValidationException` (implements `GraphQL\Error\ClientAware` and returns
`true` from `isClientSafe()`) is **not** internal. It was nonetheless rethrown and bubbled
up raw instead of being formatted into the GraphQL response.

### Fix

Before the rethrow, format any client-safe `ClientAware` exception like a user error.
Only genuinely internal (non-client-safe) exceptions are still rethrown. The default
path (`rethrow_internal_exceptions = false`) is unchanged: such exceptions already ended
up in the formatted errors.

### Test verification (RED → GREEN)

New test wraps an `ArgumentsValidationException` and calls `handleErrors($result, true)`.

**RED** — on the unmodified branch (fix reverted, test only), the exception is rethrown:

```
There was 1 error:
1) ...testMaskErrorWithWrappedClientSafeExceptionAndThrowExceptionSetToTrue
Overblog\GraphQLBundle\Validator\Exception\ArgumentsValidationException: validation
ERRORS! Tests: 16, Errors: 1.
```

**GREEN** — with the fix, it is formatted into the response:

```
OK (16 tests, 23 assertions)
```

Full suite is iso-baseline (the 5 pre-existing `GraphDumpSchemaCommandTest` failures on
`master` are unrelated and unchanged): `Tests: 713, Failures: 5`.
